### PR TITLE
Content Negotiation Tweaks

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -4,6 +4,8 @@ class Api::BaseController < ApplicationController
 
   protect_from_forgery with: :null_session
 
+  before_action :set_accepts
+
   include ApiVersioning
   include HalActions
   include Roar::Rails::ControllerAdditions
@@ -24,6 +26,12 @@ class Api::BaseController < ApplicationController
 
   def entrypoint
     respond_with Api.version(api_version)
+  end
+
+  private
+
+  def set_accepts
+    request.format = :json if request.format == Mime::HTML
   end
 
 end

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -3,4 +3,4 @@
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
 # Mime::Type.register_alias "text/html", :iphone
-Mime::Type.register 'application/json+hal', :hal
+Mime::Type.register 'application/hal+json', :hal

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 PRX::Application.routes.draw do
 
   namespace :api do
-    scope ':api_version', format: 'hal', api_version: 'v1' do
+    scope ':api_version', api_version: 'v1' do
 
       root to: 'base#entrypoint'
 
@@ -17,7 +17,7 @@ PRX::Application.routes.draw do
       resources :user_images
 
       resources :audio_versions do
-        get 'audio_files',    to: 'audio_files#index'        
+        get 'audio_files',    to: 'audio_files#index'
       end
 
       resources :stories do


### PR DESCRIPTION
`params[:format]` overrides content-negotiation in rails, so having `format:` in our routes always overrode the value.

To add back browsability (i.e. can click around the API via a browser) we take the requests that rails overrides as HTML only (i.e. direct browser traffic) and serve it as JSON.

Requests made with an accept header of application/hal+json will receive that in their content-type.
