### PR TITLE
fixes objects being added to the cache as strings

### DIFF
--- a/app/representers/concerns/caches.rb
+++ b/app/representers/concerns/caches.rb
@@ -54,7 +54,7 @@ module Caches
   end
 
   def cache_options
-    {race_condition_ttl: 10, expires_in: 1.hour, raw: true}
+    {race_condition_ttl: 10, expires_in: 1.hour}
   end
 
 end


### PR DESCRIPTION
raw cache usage loses the class of the stored object which is what we are using to indicate that the value is already compiled json. this fixes that issue.
