### PR TITLE
Use broadcast MP3 thumbs for audio files

### DIFF
--- a/app/representers/api/audio_file_representer.rb
+++ b/app/representers/api/audio_file_representer.rb
@@ -7,10 +7,10 @@ class Api::AudioFileRepresenter < Api::BaseRepresenter
   property :label
   property :size
   property :length, as: :duration
-  
+
   link :enclosure do
     {
-      href: represented.public_url(version: :download, extension: 'mp3'),
+      href: represented.public_url(version: :broadcast, extension: 'mp3'),
       type: 'audio/mpeg'
     }
   end


### PR DESCRIPTION
Pending the completion of processing the back catalog for download
versions, use the "broadcast" mp3.
