### PR TITLE
Remove `length` property in favor of `duration`.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ group :development do
 
   gem 'growl', require: false
   gem 'guard'
-  gem 'guard-minitest', github: 'chrisrhoden/guard-minitest', branch: 'feat/env_settings'
+  gem 'guard-minitest'
   gem 'guard-bundler'
   gem 'spring'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: git://github.com/chrisrhoden/guard-minitest.git
-  revision: 54862bae548969a8538ddcc8bb547015c510a819
-  branch: feat/env_settings
-  specs:
-    guard-minitest (2.2.0)
-      guard (~> 2.0)
-      minitest (>= 3.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -102,7 +93,7 @@ GEM
       nokogiri (>= 1.5.11)
     formatador (0.2.4)
     growl (1.0.3)
-    guard (2.6.0)
+    guard (2.6.1)
       formatador (>= 0.2.4)
       listen (~> 2.7)
       lumberjack (~> 1.0)
@@ -111,6 +102,9 @@ GEM
     guard-bundler (2.0.0)
       bundler (~> 1.0)
       guard (~> 2.2)
+    guard-minitest (2.3.0)
+      guard (~> 2.0)
+      minitest (>= 3.0)
     highline (1.6.21)
     hike (1.2.3)
     hooks (0.3.3)
@@ -119,7 +113,7 @@ GEM
     kaminari (0.15.1)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
-    listen (2.7.1)
+    listen (2.7.4)
       celluloid (>= 0.15.2)
       celluloid-io (>= 0.15.0)
       rb-fsevent (>= 0.9.3)
@@ -183,7 +177,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (10.3.1)
     rb-fsevent (0.9.4)
-    rb-inotify (0.9.3)
+    rb-inotify (0.9.4)
       ffi (>= 0.5.0)
     rdoc (4.1.1)
       json (~> 1.4)
@@ -262,7 +256,7 @@ DEPENDENCIES
   growl
   guard
   guard-bundler
-  guard-minitest!
+  guard-minitest
   highline
   kaminari
   minitest-rails

--- a/Guardfile
+++ b/Guardfile
@@ -3,7 +3,7 @@
 
 notification :growl
 
-guard :minitest, spring: 'rake test', env: {GUARD: 'true'}, all_env: :GUARD_COVERAGE, all_after_pass: true do
+guard :minitest, spring: true, env: {GUARD: 'true'}, all_env: :GUARD_COVERAGE, all_after_pass: true do
   watch(%r{^test/(.*)\/?test_(.*)\.rb})
   watch(%r{^lib/(.*/)?([^/]+)\.rb})                      { |m| "test/#{m[1]}test_#{m[2]}.rb" }
   watch(%r{^test/test_helper\.rb})                       { 'test' }

--- a/app/representers/api/story_representer.rb
+++ b/app/representers/api/story_representer.rb
@@ -4,7 +4,7 @@ class Api::StoryRepresenter < Api::BaseRepresenter
 
   property :id
   property :title
-  property :length
+  property :length, as: :duration
   property :short_description
   property :description
   property :published_at

--- a/config/application.rb
+++ b/config/application.rb
@@ -4,8 +4,6 @@ require File.expand_path('../boot', __FILE__)
 require "active_record/railtie"
 require "action_controller/railtie"
 require "action_mailer/railtie"
-# require "sprockets/railtie"
-require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/test/representers/api/story_representer_test.rb
+++ b/test/representers/api/story_representer_test.rb
@@ -17,4 +17,13 @@ describe Api::StoryRepresenter do
     json['id'].must_equal story.id
   end
 
+  it 'does not serialize a length property' do
+    json.keys.wont_include('length')
+  end
+
+  it 'serializes the length of the story as duration' do
+    story.length = 666
+    json['duration'].must_equal 666
+  end
+
 end


### PR DESCRIPTION
In JSON, consider `length` a reserved word which can only be used to
refer to the number of iterable keys in an array-like object.

https://github.com/angular/angular.js/blob/master/src/Angular.js#L185
The current behavior causes stories with a zero duration to have no
properties copied from the JSON response because Angular detects them
as array-like and having no properties.

Also bumps to a newer version of guard-minitest.
