### PR TITLE
switch to minitest-spec-rails, which seems to actually work pretty well

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ group :development do
 end
 
 group :development, :test do
-  gem 'minitest-rails'
+  gem 'minitest-spec-rails'
   gem 'minitest-reporters', require: false
   gem 'factory_girl_rails'
   gem "codeclimate-test-reporter", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,14 +126,14 @@ GEM
     mime-types (1.25.1)
     mini_portile (0.5.2)
     minitest (5.3.3)
-    minitest-rails (2.0.0)
-      minitest (>= 5.3.3, < 6.0)
-      railties (~> 4.1)
     minitest-reporters (1.0.3)
       ansi
       builder
       minitest (>= 5.0)
       ruby-progressbar
+    minitest-spec-rails (5.0.3)
+      minitest (~> 5.0)
+      rails (~> 4.1.0.rc2)
     multi_json (1.9.2)
     mysql2 (0.3.15)
     net-scp (1.1.2)
@@ -259,8 +259,8 @@ DEPENDENCIES
   guard-minitest
   highline
   kaminari
-  minitest-rails
   minitest-reporters
+  minitest-spec-rails
   mysql2
   newrelic_rpm
   oj

--- a/config/application.rb
+++ b/config/application.rb
@@ -4,6 +4,7 @@ require File.expand_path('../boot', __FILE__)
 require "active_record/railtie"
 require "action_controller/railtie"
 require "action_mailer/railtie"
+require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,19 +14,19 @@ end
 
 require File.expand_path("../../config/environment", __FILE__)
 
-require "rails/test_help"
+require 'rails/test_help'
 require 'factory_girl'
-require "minitest/rails"
-require "minitest/reporters"
+require 'minitest/reporters'
 require 'minitest/autorun'
 require 'minitest/spec'
-require "minitest/pride"
+require 'minitest/pride'
 
 # To add Capybara feature tests add `gem "minitest-rails-capybara"`
 # to the test group in the Gemfile and uncomment the following:
 # require "minitest/rails/capybara"
 
 class ActiveSupport::TestCase
+  include FactoryGirl::Syntax::Methods
 end
 
 class MiniTest::Spec


### PR DESCRIPTION
minitest-rails does a bad job. minitest-spec-rails is compatible and doesn't do a bad job

(as an example, minitest-rails required RAILS_ENV=test to work, and doesn't wipe the database after each test run)
