### PR TITLE
use duration in the min story representer as well

### DIFF
--- a/app/representers/api/min/story_representer.rb
+++ b/app/representers/api/min/story_representer.rb
@@ -4,7 +4,7 @@ class Api::Min::StoryRepresenter < Api::BaseRepresenter
 
   property :id
   property :title
-  property :length
+  property :duration
   property :short_description
   property :published_at
   property :produced_on

--- a/test/representers/api/story_representer_test.rb
+++ b/test/representers/api/story_representer_test.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 require 'test_helper'
-require 'story' if !defined?(Story)
 
 describe Api::StoryRepresenter do
 
@@ -61,6 +60,17 @@ describe Api::StoryRepresenter do
     story.stub(:timing_and_cues, sigil) do
       json['timingAndCues'].must_equal sigil
     end
+  end
+
+  describe Api::Min::StoryRepresenter do
+    let(:representer) { Api::Min::StoryRepresenter.new(story) }
+
+    it 'serializes the length of the story as duration' do
+      story.stub(:duration, 212) do
+        json['duration'].must_equal 212
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
See #33 for more information.

Basically, any object with a "length" property is treated as array-like by angular in some internal methods.

if that "length" is 0, it short circuits and treats the object like `[]`, even if it looks like `{name:'foo', bar:'baz', length:0}`

This change also has the benefit of pulling the duration of the promos when the story is published as "promos-only" (which is a state that subauto stories can be in)
