### PR TITLE
include breaks in story representation

### DIFF
--- a/app/models/audio_version.rb
+++ b/app/models/audio_version.rb
@@ -2,6 +2,13 @@
 
 class AudioVersion < BaseModel
 
+  BREAK_TYPES = {
+    :news_hole_break? => 'News Hole',
+    :floating_break? => 'Floating',
+    :bottom_of_hour_break? => 'Bottom of the Hour',
+    :twenty_forty_break? => '20 and 40 min'
+  }
+
   belongs_to :story, class_name: 'Story', foreign_key: 'piece_id', with_deleted: true
   has_many :audio_files, -> { order :position }, dependent: :destroy
 
@@ -36,6 +43,14 @@ class AudioVersion < BaseModel
       as_default_audio.first.length
     else
       length
+    end
+  end
+
+  def breaks
+    @_breaks ||= [].tap do |array|
+      BREAK_TYPES.each do |method, text|
+        array.push text if send method
+      end
     end
   end
 

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -76,4 +76,8 @@ class Story < BaseModel
     default_audio_version.try(:content_advisory)
   end
 
+  def breaks
+    default_audio_version.try(:breaks)
+  end
+
 end

--- a/app/representers/api/story_representer.rb
+++ b/app/representers/api/story_representer.rb
@@ -14,6 +14,7 @@ class Api::StoryRepresenter < Api::BaseRepresenter
   property :broadcast_history
   property :timing_and_cues
   property :content_advisory
+  property :breaks
 
   # default zoom
   link :account do

--- a/test/models/audio_version_test.rb
+++ b/test/models/audio_version_test.rb
@@ -34,4 +34,28 @@ describe AudioVersion do
       audio_version.default_audio_duration.must_equal 571
     end
   end
+
+  describe '#breaks' do
+    BREAK_TYPES = {
+      :news_hole_break? => 'News Hole',
+      :floating_break? => 'Floating',
+      :bottom_of_hour_break? => 'Bottom of the Hour',
+      :twenty_forty_break? => '20 and 40 min'
+    }
+
+    BREAK_TYPES.each do |method, text|
+      it "includes '#{text}' when ##{method}" do
+        audio_version.stub(method, true) do
+          audio_version.breaks.must_include text
+        end
+      end
+
+      it "does not include '#{text}' when ##{method} is false" do
+        audio_version.stub(method, false) do
+          audio_version.breaks.wont_include text
+        end
+      end
+    end
+
+  end
 end

--- a/test/models/story_test.rb
+++ b/test/models/story_test.rb
@@ -45,6 +45,12 @@ describe Story do
     end
   end
 
+  it 'has breaks from the default audio version' do
+    story.default_audio_version.stub(:breaks, ['floating']) do
+      story.breaks.must_equal ['floating']
+    end
+  end
+
   describe '#default_image' do
 
     it 'returns the first image when one is present' do

--- a/test/representers/api/story_representer_test.rb
+++ b/test/representers/api/story_representer_test.rb
@@ -62,6 +62,12 @@ describe Api::StoryRepresenter do
     end
   end
 
+  it 'includes breaks' do
+    story.stub(:breaks, ['floating']) do
+      json['breaks'].must_equal ['floating']
+    end
+  end
+
   describe Api::Min::StoryRepresenter do
     let(:representer) { Api::Min::StoryRepresenter.new(story) }
 


### PR DESCRIPTION
There are some issues with the way this is done, but I wanted to mirror what we have on v3.

My biggest concern is that there's an impedance mismatch between read and write (write happens with a list of boolean attributes, read happens with an array that doesn't even really map directly to the names of those attributes). Again, just trying to avoid rethinking everything while moving to v4 from v3, otherwise I think it would make more sense to just stick to the list of booleans.

Thoughts?
