### PR TITLE
Add support for linking to external websites on accounts

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -10,6 +10,7 @@ class Account < BaseModel
 
   has_many :stories, -> { where('published_at is not null and network_only_at is null').order(published_at: :desc) }
   has_many :memberships
+  has_many :websites, as: :browsable
 
   scope :pending, -> { where status: :pending }
   scope :active, -> { where status: :open }

--- a/app/models/website.rb
+++ b/app/models/website.rb
@@ -1,0 +1,16 @@
+# encoding: utf-8
+
+class Website < BaseModel
+  belongs_to :browsable, polymorphic: true
+
+  SEARCH  = /^(?!http)./
+  REPLACE = 'http://\\0'
+
+  def url
+    super.sub(SEARCH, REPLACE)
+  end
+
+  def as_link
+    { href: url }
+  end
+end

--- a/app/representers/api/account_representer.rb
+++ b/app/representers/api/account_representer.rb
@@ -36,4 +36,7 @@ class Api::AccountRepresenter < Api::BaseRepresenter
   end
   embed :stories, as: :stories, paged: true, item_class: Story, item_decorator: Api::Min::StoryRepresenter
 
+  links :external do
+    represented.websites.map(&:as_link)
+  end
 end

--- a/app/representers/api/min/story_representer.rb
+++ b/app/representers/api/min/story_representer.rb
@@ -18,7 +18,7 @@ class Api::Min::StoryRepresenter < Api::BaseRepresenter
       profile: prx_model_uri(represented.account)
     }
   end
-  embed :account, class: Account, decorator: Api::Min::AccountRepresenter
+  embed :account, class: Account, decorator: Api::Min::AccountRepresenter, zoom: false
 
   link :image do
     api_story_image_path(represented.default_image.id) if represented.default_image
@@ -31,7 +31,7 @@ class Api::Min::StoryRepresenter < Api::BaseRepresenter
       title: represented.series.title
     } if represented.series_id
   end
-  embed :series, class: Series, decorator: Api::Min::SeriesRepresenter
+  embed :series, class: Series, decorator: Api::Min::SeriesRepresenter, zoom: false
 
   links :audio do
     represented.default_audio.collect{ |a| { href: api_audio_file_path(a), title: a.label } }

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -397,4 +397,12 @@ ActiveRecord::Schema.define(version: 1) do
     t.string   "path"
   end
 
+  create_table "websites", :force => true do |t|
+    t.integer "browsable_id"
+    t.string  "browsable_type"
+    t.string  "url"
+  end
+
+  add_index "websites", ["browsable_id", "browsable_type"], :name => "websites_browsable_fk"
+
 end

--- a/test/factories/websites_factory.rb
+++ b/test/factories/websites_factory.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :website do
+    url 'http://example.com'
+  end
+end

--- a/test/models/website_test.rb
+++ b/test/models/website_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+describe Website do
+  let (:website) { build_stubbed(:website) }
+
+  it 'automatically adds a schema to urls that lack them' do
+    website.url = "prx.org"
+    website.url.must_equal 'http://prx.org'
+  end
+
+  it 'does not impact urls that have schemas' do
+    website.url = 'http://prx.org'
+    website.url.must_equal 'http://prx.org'
+  end
+
+  describe '#as_link' do
+    it 'sets :href to #url' do
+      website.url = "http://example.com"
+      website.as_link[:href].must_equal "http://example.com"
+    end
+  end
+end

--- a/test/representers/api/account_representer_test.rb
+++ b/test/representers/api/account_representer_test.rb
@@ -6,13 +6,9 @@ require 'account' if !defined?(AudioFile)
 
 describe Api::AccountRepresenter do
 
-  let(:account)     { FactoryGirl.create(:account) }
+  let(:account)     { build_stubbed(:account) }
   let(:representer) { Api::AccountRepresenter.new(account) }
   let(:json)        { JSON.parse(representer.to_json) }
-
-  it 'create representer' do
-    representer.wont_be_nil
-  end
 
   it 'use representer to create json' do
     json['id'].must_equal account.id
@@ -22,12 +18,15 @@ describe Api::AccountRepresenter do
     json['shortName'].must_equal account.short_name
   end
 
-  describe "individual accounts" do
-
-    let(:individual_account)  { FactoryGirl.create(:individual_account) }
-    let(:ia_representer) { Api::AccountRepresenter.new(account) }
-    let(:json)        { JSON.parse(representer.to_json) }
-
+  it 'includes external urls' do
+    websites = [
+      build_stubbed(:website, url: 'http://prx.org'),
+      build_stubbed(:website, url: 'http://example.com')
+    ]
+    account.stub(:websites, websites) do
+      json['_links']['prx:external'].must_include 'href' => 'http://prx.org'
+      json['_links']['prx:external'].must_include 'href' => 'http://example.com'
+    end
   end
 
 end


### PR DESCRIPTION
`external` seemed like the appropriate rel to use from the list of existing and
proposed rels on the microformats wiki. I opted not to add it to the list of
link types that would not be prefixed, but I anticipate that we may opt to do so
in the near future, as it's already in common, unprefixed use.

http://microformats.org/wiki/rel-external
http://microformats.org/wiki/existing-rel-values#HTML5_link_type_extensions

The only other rels I could find that might make sense are `alternate` (but I
don't like this for a few reasons) or `me` which might make more sense for
specifically social links (like facebook, twitter, etc).
