### PR TITLE
Alias duration for musical works in model

### DIFF
--- a/app/models/musical_work.rb
+++ b/app/models/musical_work.rb
@@ -6,6 +6,8 @@ class MusicalWork < BaseModel
 
   acts_as_list scope: :piece_id
 
+  alias_attribute :duration, :excerpt_length
+
   def self.policy_class
     StoryAttributePolicy
   end

--- a/app/representers/api/musical_work_representer.rb
+++ b/app/representers/api/musical_work_representer.rb
@@ -9,7 +9,7 @@ class Api::MusicalWorkRepresenter < Api::BaseRepresenter
   property :label
   property :album
   property :year
-  property :excerpt_length, as: :duration
+  property :duration
 
   def self_url(musical_work)
     polymorphic_path([:api, musical_work.story, musical_work])

--- a/test/representers/api/musical_work_representer_test.rb
+++ b/test/representers/api/musical_work_representer_test.rb
@@ -23,7 +23,7 @@ describe Api::MusicalWorkRepresenter do
   end
 
   it 'serializes the length of the story as duration' do
-    musical_work.stub(:excerpt_length, 123) do
+    musical_work.stub(:duration, 123) do
       json['duration'].must_equal 123
     end
   end

--- a/test/representers/api/musical_work_representer_test.rb
+++ b/test/representers/api/musical_work_representer_test.rb
@@ -22,7 +22,7 @@ describe Api::MusicalWorkRepresenter do
     json['_links']['self']['href'].must_equal self_href
   end
 
-  it 'serializes the length of the story as duration' do
+  it 'serializes the length of the musical work as duration' do
     musical_work.stub(:duration, 123) do
       json['duration'].must_equal 123
     end


### PR DESCRIPTION
Moves the mapping for `excerpt_length` to `duration` to the model,
rather than the representer