### PR TITLE
Fix no method errors

### DIFF
--- a/app/controllers/api/account_images_controller.rb
+++ b/app/controllers/api/account_images_controller.rb
@@ -8,4 +8,12 @@ class Api::AccountImagesController < Api::BaseController
 
   represent_with Api::ImageRepresenter
 
+  def resource
+    @account_image = account.image if !super && account
+    @account_image
+  end
+
+  def account
+    @account ||= Account.find(params[:account_id]) if params[:account_id]
+  end
 end

--- a/app/controllers/api/addresses_controller.rb
+++ b/app/controllers/api/addresses_controller.rb
@@ -4,6 +4,14 @@ class Api::AddressesController < Api::BaseController
 
   api_versions :v1
 
-  filter_resources_by :user_id, :account_id
+  filter_resources_by :account_id
 
+  def resource
+    @address = account.address if !super && account
+    @address
+  end
+
+  def account
+    @account ||= Account.find(params[:account_id]) if params[:account_id]
+  end
 end

--- a/app/controllers/api/stories_controller.rb
+++ b/app/controllers/api/stories_controller.rb
@@ -33,10 +33,12 @@ class Api::StoriesController < Api::BaseController
     stories = nil
     filters = params[:filters].try(:split, ',') || []
 
-    if params[:account_id].present? && filters.include?('highlighted')
-      stories = Account.find(params[:account_id]).portfolio_stories
+    stories = if account && filters.include?('highlighted')
+      account.portfolio_stories
+    elsif account
+      account.stories
     else
-      stories = Story
+      Story
     end
 
     if filters.include?('purchased')
@@ -46,6 +48,10 @@ class Api::StoriesController < Api::BaseController
     end
 
     stories.published.visible
+  end
+
+  def account
+    @account ||= Account.find(params[:account_id]) if params[:account_id]
   end
 
   # don't add another order, handled in the resources_base

--- a/app/controllers/api/stories_controller.rb
+++ b/app/controllers/api/stories_controller.rb
@@ -34,12 +34,12 @@ class Api::StoriesController < Api::BaseController
     filters = params[:filters].try(:split, ',') || []
 
     stories = if account && filters.include?('highlighted')
-      account.portfolio_stories
-    elsif account
-      account.stories
-    else
-      Story
-    end
+                account.portfolio_stories
+              elsif account
+                account.stories
+              else
+                Story
+              end
 
     if filters.include?('purchased')
       stories = stories.purchased.order('purchase_count DESC')

--- a/app/controllers/api/user_images_controller.rb
+++ b/app/controllers/api/user_images_controller.rb
@@ -8,4 +8,12 @@ class Api::UserImagesController < Api::BaseController
 
   represent_with Api::ImageRepresenter
 
+  def resource
+    @user_image = user.image if !super && user
+    @user_image
+  end
+
+  def user
+    @user ||= User.find(params[:user_id]) if params[:user_id]
+  end
 end

--- a/app/controllers/concerns/hal_actions.rb
+++ b/app/controllers/concerns/hal_actions.rb
@@ -40,7 +40,7 @@ module HalActions
     instance_variable_get("@#{resource_name}") || self.resource = if params[:id]
       self.class.resource_class.find(params[:id].to_i)
     else
-      self.class.resource_class.new
+      self.class.resource_class.new if (request.put? || request.post?)
     end
   end
 

--- a/app/controllers/concerns/hal_actions.rb
+++ b/app/controllers/concerns/hal_actions.rb
@@ -40,7 +40,7 @@ module HalActions
     instance_variable_get("@#{resource_name}") || self.resource = if params[:id]
       self.class.resource_class.find(params[:id].to_i)
     else
-      self.class.resource_class.new if (request.put? || request.post?)
+      self.class.resource_class.new if request.put? || request.post?
     end
   end
 

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -11,4 +11,8 @@ class Address < BaseModel
       addressable.individual_account
     end
   end
+
+  def account=(a)
+    self.addressable = a
+  end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -4,4 +4,11 @@ class Address < BaseModel
 
   belongs_to :addressable, polymorphic: true
 
+  def account
+    if addressable.is_a?(Account)
+      addressable
+    elsif addressable.is_a?(User)
+      addressable.individual_account
+    end
+  end
 end

--- a/app/representers/api/address_representer.rb
+++ b/app/representers/api/address_representer.rb
@@ -12,8 +12,6 @@ class Api::AddressRepresenter < Api::BaseRepresenter
   property :country
 
   def self_url(address)
-    addressable = address.addressable
-    addressable = addressable.becomes(Account) if addressable.is_a?(Account)
-    polymorphic_path([:api, addressable, address])
+    api_account_address_path(address.account)
   end
 end

--- a/app/representers/concerns/uri_methods.rb
+++ b/app/representers/concerns/uri_methods.rb
@@ -25,8 +25,8 @@ module UriMethods
   end
 
   def joined_names(args)
-    (Array(args.map { |arg| prx_model_uri_part_to_string(arg) } ) +
-      prx_model_uri_suffix(args)).flatten.compact.join("/")
+    (Array(args.map { |arg| prx_model_uri_part_to_string(arg) }) +
+      prx_model_uri_suffix(args)).flatten.compact.join('/')
   end
 
   def prx_model_uri_suffix(args)

--- a/app/representers/concerns/uri_methods.rb
+++ b/app/representers/concerns/uri_methods.rb
@@ -25,7 +25,7 @@ module UriMethods
   end
 
   def joined_names(args)
-    ( Array(args.collect{|arg| prx_model_uri_part_to_string(arg)}) + 
+    ( Array(args.collect { |arg| prx_model_uri_part_to_string(arg) } ) +
       prx_model_uri_suffix(args) ).flatten.compact.join("/")
   end
 
@@ -49,5 +49,4 @@ module UriMethods
       end
     end
   end
-
 end

--- a/app/representers/concerns/uri_methods.rb
+++ b/app/representers/concerns/uri_methods.rb
@@ -25,8 +25,8 @@ module UriMethods
   end
 
   def joined_names(args)
-    ( Array(args.collect { |arg| prx_model_uri_part_to_string(arg) } ) +
-      prx_model_uri_suffix(args) ).flatten.compact.join("/")
+    (Array(args.map { |arg| prx_model_uri_part_to_string(arg) } ) +
+      prx_model_uri_suffix(args)).flatten.compact.join("/")
   end
 
   def prx_model_uri_suffix(args)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,6 @@ PRX::Application.routes.draw do
       end
 
       resources :users do
-        resource :address, except: [:new, :edit]
         resource :user_image, path: 'image', except: [:new, :edit]
         resources :memberships, except: [:new, :edit]
         resources :accounts, only: [:index]

--- a/test/controllers/api/stories_controller_test.rb
+++ b/test/controllers/api/stories_controller_test.rb
@@ -30,6 +30,14 @@ describe Api::StoriesController do
     assert_response :success
   end
 
+  it 'should list stories for an account' do
+    story.must_be :published
+    get(:index, { api_version: 'v1',
+                  format: 'json',
+                  account_id: story.account_id })
+    assert_response :success
+  end
+
   it 'should list highlighted stories' do
     portfolio = create(:portfolio)
     playlist_section = create(:playlist_section, playlist: portfolio)

--- a/test/controllers/api/stories_controller_test.rb
+++ b/test/controllers/api/stories_controller_test.rb
@@ -32,9 +32,9 @@ describe Api::StoriesController do
 
   it 'should list stories for an account' do
     story.must_be :published
-    get(:index, { api_version: 'v1',
-                  format: 'json',
-                  account_id: story.account_id })
+    get(:index, api_version: 'v1',
+                format: 'json',
+                account_id: story.account_id)
     assert_response :success
   end
 
@@ -43,10 +43,10 @@ describe Api::StoriesController do
     playlist_section = create(:playlist_section, playlist: portfolio)
     pick1 = create(:pick, story: story, playlist_section: playlist_section)
     pick2 = create(:pick)
-    get(:index, { api_version: 'v1',
-                  format: 'json',
-                  account_id: portfolio.account_id,
-                  filters: 'highlighted'})
+    get(:index, api_version: 'v1',
+                format: 'json',
+                account_id: portfolio.account_id,
+                filters: 'highlighted')
 
     assert_response :success
     assert_not_nil assigns[:stories]
@@ -59,10 +59,10 @@ describe Api::StoriesController do
     story2 = create(:story, account: story.account)
     story3 = create(:story_with_purchases, account: story.account)
 
-    get(:index, { api_version: 'v1',
-                  format: 'json',
-                  account_id: story.account_id,
-                  filters: 'purchased'})
+    get(:index, api_version: 'v1',
+                format: 'json',
+                account_id: story.account_id,
+                filters: 'purchased')
 
     assert_response :success
     assert_not_nil assigns[:stories]

--- a/test/controllers/concerns/hal_actions_test.rb
+++ b/test/controllers/concerns/hal_actions_test.rb
@@ -1,3 +1,5 @@
+require 'hal_actions'
+
 describe HalActions do
 
   class Foo
@@ -35,10 +37,14 @@ describe HalActions do
 
     cattr_accessor :_caches_action
 
-    attr_accessor :_respond_with
+    attr_accessor :_respond_with, :request, :params
 
     def params
       @params ||= ActionController::Parameters.new(action: 'update', id: 1)
+    end
+
+    def request
+      @request ||= OpenStruct.new('put?' => false, 'post?' => false)
     end
 
     def current_user
@@ -59,6 +65,17 @@ describe HalActions do
   let (:account) { create(:account) }
 
   describe 'instance methods' do
+
+    it 'retrieves resource' do
+      controller.resource.must_be_instance_of Foo
+    end
+
+    it 'retrieves new resource when id not found' do
+      controller.params = ActionController::Parameters.new(action: 'create')
+      controller.request = OpenStruct.new('put?' => false, 'post?' => true)
+      controller.resource.must_be_instance_of Foo
+      controller.resource.id.must_be_nil
+    end
 
     it 'determines resource id for caching' do
       controller.show_cache_path.must_equal 60

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -35,5 +35,4 @@ describe Account do
       account.portfolio_stories.wont_include pick2.story
     end
   end
-
 end

--- a/test/models/address_test.rb
+++ b/test/models/address_test.rb
@@ -7,5 +7,4 @@ describe Address do
   it 'has a table defined' do
     Address.table_name.must_equal 'addresses'
   end
-
 end

--- a/test/models/api_test.rb
+++ b/test/models/api_test.rb
@@ -7,6 +7,4 @@ describe Api do
   it 'create an api with a version' do
     api.version.must_equal '1.0'
   end
-
-
 end

--- a/test/representers/api/account_representer_test.rb
+++ b/test/representers/api/account_representer_test.rb
@@ -6,9 +6,9 @@ require 'account' if !defined?(AudioFile)
 
 describe Api::AccountRepresenter do
 
-  let(:account)     { create(:account) }
+  let(:account) { create(:account) }
   let(:representer) { Api::AccountRepresenter.new(account) }
-  let(:json)        { JSON.parse(representer.to_json) }
+  let(:json) { JSON.parse(representer.to_json) }
 
   it 'use representer to create json' do
     json['id'].must_equal account.id
@@ -28,5 +28,4 @@ describe Api::AccountRepresenter do
       json['_links']['prx:external'].must_include 'href' => 'http://example.com'
     end
   end
-
 end

--- a/test/representers/api/account_representer_test.rb
+++ b/test/representers/api/account_representer_test.rb
@@ -6,7 +6,7 @@ require 'account' if !defined?(AudioFile)
 
 describe Api::AccountRepresenter do
 
-  let(:account)     { build_stubbed(:account) }
+  let(:account)     { create(:account) }
   let(:representer) { Api::AccountRepresenter.new(account) }
   let(:json)        { JSON.parse(representer.to_json) }
 

--- a/test/representers/api/address_representer_test.rb
+++ b/test/representers/api/address_representer_test.rb
@@ -1,14 +1,13 @@
 # encoding: utf-8
 
 require 'test_helper'
-
 require 'address' if !defined?(AudioFile)
 
 describe Api::AddressRepresenter do
 
-  let(:address)     { create(:account).address }
+  let(:address) { create(:account).address }
   let(:representer) { Api::AddressRepresenter.new(address) }
-  let(:json)        { JSON.parse(representer.to_json) }
+  let(:json) { JSON.parse(representer.to_json) }
 
   it 'create representer' do
     representer.wont_be_nil
@@ -17,5 +16,4 @@ describe Api::AddressRepresenter do
   it 'use representer to create json' do
     json['id'].must_equal address.id
   end
-
 end

--- a/test/representers/api/address_representer_test.rb
+++ b/test/representers/api/address_representer_test.rb
@@ -6,7 +6,7 @@ require 'address' if !defined?(AudioFile)
 
 describe Api::AddressRepresenter do
 
-  let(:address)     { FactoryGirl.create(:address) }
+  let(:address)     { create(:account).address }
   let(:representer) { Api::AddressRepresenter.new(address) }
   let(:json)        { JSON.parse(representer.to_json) }
 

--- a/test/representers/api/story_representer_test.rb
+++ b/test/representers/api/story_representer_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 describe Api::StoryRepresenter do
 
-  let(:story)       { build_stubbed(:story_with_audio, audio_versions_count: 1, id: 212) }
+  let(:story)       { create(:story_with_audio, audio_versions_count: 1) }
   let(:representer) { Api::StoryRepresenter.new(story) }
   let(:json)        { JSON.parse(representer.to_json) }
 
@@ -29,7 +29,7 @@ describe Api::StoryRepresenter do
   describe 'serialize' do
 
     it 'can serialize an unsaved story' do
-      story_with_audio = build(:story_with_audio)
+      story_with_audio = create(:story_with_audio)
       json = Api::StoryRepresenter.new(story_with_audio).to_json
       json.wont_be_nil
     end
@@ -95,8 +95,7 @@ describe Api::StoryRepresenter do
   describe 'series info' do
     let(:schedule) { create(:schedule) }
     let(:series) { schedule.series }
-    let(:story) { build_stubbed(:story, series: series,
-                                        episode_identifier: '#2') }
+    let(:story) { create(:story, series: series, episode_identifier: '#2') }
     let(:representer) { Api::StoryRepresenter.new(story) }
     let(:json) { JSON.parse(representer.to_json) }
 
@@ -113,7 +112,7 @@ describe Api::StoryRepresenter do
     end
 
     it 'has none of this when story is not in a series' do
-      story2 = build_stubbed(:story)
+      story2 = create(:story)
       json = JSON.parse(Api::StoryRepresenter.new(story2).to_json)
       json['_links'].keys.wont_include('prx:series')
       json.keys.wont_include('episode_number')

--- a/test/representers/api/story_representer_test.rb
+++ b/test/representers/api/story_representer_test.rb
@@ -4,9 +4,9 @@ require 'test_helper'
 
 describe Api::StoryRepresenter do
 
-  let(:story)       { create(:story_with_audio, audio_versions_count: 1) }
+  let(:story) { create(:story_with_audio, audio_versions_count: 1) }
   let(:representer) { Api::StoryRepresenter.new(story) }
-  let(:json)        { JSON.parse(representer.to_json) }
+  let(:json) { JSON.parse(representer.to_json) }
 
   describe 'deserialize' do
 


### PR DESCRIPTION
Seeing errors in production where getting the images, addresses, and stories related to accounts are throwing errors.

The controllers were still assuming these were has many rather than has one resources, and trying to retrieve and link to them incorrectly.