### PR TITLE
Update newrelic.yml for server side config

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -102,74 +102,6 @@ common: &default_settings
   audit_log:
     enabled: false
 
-  # Tells transaction tracer and error collector (when enabled)
-  # whether or not to capture HTTP params.  When true, frameworks can
-  # exclude HTTP parameters from being captured.
-  # Rails: the RoR filter_parameter_logging excludes parameters
-  # Java: create a config setting called "ignored_params" and set it to
-  #     a comma separated list of HTTP parameter names.
-  #     ex: ignored_params: credit_card, ssn, password
-  capture_params: false
-
-  # Transaction tracer captures deep information about slow
-  # transactions and sends this to the New Relic service once a
-  # minute. Included in the transaction is the exact call sequence of
-  # the transactions including any SQL statements issued.
-  transaction_tracer:
-
-    # Transaction tracer is enabled by default. Set this to false to
-    # turn it off. This feature is only available at the Professional
-    # and above product levels.
-    enabled: true
-
-    # Threshold in seconds for when to collect a transaction
-    # trace. When the response time of a controller action exceeds
-    # this threshold, a transaction trace will be recorded and sent to
-    # New Relic. Valid values are any float value, or (default) "apdex_f",
-    # which will use the threshold for an dissatisfying Apdex
-    # controller action - four times the Apdex T value.
-    transaction_threshold: apdex_f
-
-    # When transaction tracer is on, SQL statements can optionally be
-    # recorded. The recorder has three modes, "off" which sends no
-    # SQL, "raw" which sends the SQL statement in its original form,
-    # and "obfuscated", which strips out numeric and string literals.
-    record_sql: obfuscated
-
-    # Threshold in seconds for when to collect stack trace for a SQL
-    # call. In other words, when SQL statements exceed this threshold,
-    # then capture and send to New Relic the current stack trace. This is
-    # helpful for pinpointing where long SQL calls originate from.
-    stack_trace_threshold: 0.500
-
-    # Determines whether the agent will capture query plans for slow
-    # SQL queries.  Only supported in mysql and postgres.  Should be
-    # set to false when using other adapters.
-    # explain_enabled: true
-
-    # Threshold for query execution time below which query plans will
-    # not be captured.  Relevant only when `explain_enabled` is true.
-    # explain_threshold: 0.5
-
-  # Error collector captures information about uncaught exceptions and
-  # sends them to New Relic for viewing
-  error_collector:
-
-    # Error collector is enabled by default. Set this to false to turn
-    # it off. This feature is only available at the Professional and above
-    # product levels.
-    enabled: true
-
-    # Rails Only - tells error collector whether or not to capture a
-    # source snippet around the place of the error when errors are View
-    # related.
-    capture_source: true
-
-    # To stop specific errors from reporting to New Relic, set this property
-    # to comma-separated values.  Default is to ignore routing errors,
-    # which are how 404's get triggered.
-    ignore_errors: "ActionController::RoutingError,Sinatra::NotFound"
-
   # If you're interested in capturing memcache keys as though they
   # were SQL uncomment this flag. Note that this does increase
   # overhead slightly on every memcached call, and can have security
@@ -224,4 +156,4 @@ production:
 staging:
   <<: *default_settings
   monitor_mode: true
-  # app_name: My Application (Staging)
+  app_name: cms.prx.org (Staging)


### PR DESCRIPTION
NewRelic is switching over to server-side config for some application settings; they no longer need to be in the app config file.