### PR TITLE
add custom `#consume!` to honor request content_type

### DIFF
--- a/app/controllers/concerns/hal_actions.rb
+++ b/app/controllers/concerns/hal_actions.rb
@@ -16,14 +16,14 @@ module HalActions
   end
 
   def create
-    self.resource = consume!(resource)
+    consume_with_content_type! resource
     authorize resource
     resource.save!
     respond_with show_resource, show_options
   end
 
   def update
-    self.resource = consume!(resource)
+    consume_with_content_type! resource
     authorize resource
     resource.save!
     respond_with show_resource, show_options
@@ -138,6 +138,21 @@ module HalActions
     o[:_keys] = o.keys
     o
   end
+
+  private
+  # TODO: Remove this method when we upgrade roar-rails
+  # Background: https://github.com/apotonick/roar-rails/blob/a109b40/lib/roar/rails/controller_additions.rb#L27
+  def consume_with_content_type!(model, options={})
+    type = request.content_type
+    format = Mime::Type.lookup(type).try(:symbol) or raise UnsupportedMediaType.new("Cannot consume unregistered media type '#{type.inspect}'")
+
+    parse_method = compute_parsing_method(format)
+    representer = prepare_model_for(format, model, options)
+
+    representer.send(parse_method, incoming_string, options)
+    model
+  end
+
 
   module ClassMethods
 

--- a/app/controllers/concerns/hal_actions.rb
+++ b/app/controllers/concerns/hal_actions.rb
@@ -140,11 +140,16 @@ module HalActions
   end
 
   private
+
   # TODO: Remove this method when we upgrade roar-rails
   # Background: https://github.com/apotonick/roar-rails/blob/a109b40/lib/roar/rails/controller_additions.rb#L27
-  def consume_with_content_type!(model, options={})
+  def consume_with_content_type!(model, options = {})
     type = request.content_type
-    format = Mime::Type.lookup(type).try(:symbol) or raise UnsupportedMediaType.new("Cannot consume unregistered media type '#{type.inspect}'")
+    format = Mime::Type.lookup(type).try(:symbol)
+
+    if format.blank?
+      raise UnsupportedMediaType.new("Cannot consume unregistered media type '#{type.inspect}'")
+    end
 
     parse_method = compute_parsing_method(format)
     representer = prepare_model_for(format, model, options)
@@ -152,7 +157,6 @@ module HalActions
     representer.send(parse_method, incoming_string, options)
     model
   end
-
 
   module ClassMethods
 


### PR DESCRIPTION
Honor Content-Type for PUT and POST requests made to the API, which results in
actually writing to the represented models instead of failing silently.

https://github.com/apotonick/roar-rails/blob/a109b40/lib/roar/rails/controller_additions.rb#L27

This has been fixed in apotonick/roar-rails@e92bd1cb, so can be removed once the
gem is upgraded.