### PR TITLE
Event messages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'oj_mimic_json'
 
 ## Messaging
 gem 'shoryuken'
-gem 'announce', path: '/Users/andrew/dev/projects/announce'
+gem 'announce'
 
 ## Deployment
 # configuration

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem 'oj_mimic_json'
 
 ## Messaging
 gem 'shoryuken'
+gem 'announce', path: '/Users/andrew/dev/projects/announce'
 
 ## Deployment
 # configuration

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /Users/andrew/dev/projects/announce
   specs:
-    announce (0.1.1)
+    announce (0.2.1)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,8 @@
+PATH
+  remote: /Users/andrew/dev/projects/announce
+  specs:
+    announce (0.1.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -393,6 +398,7 @@ PLATFORMS
 DEPENDENCIES
   actionpack-action_caching
   acts_as_list
+  announce!
   better_errors
   binding_of_caller
   capistrano (~> 3.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
       tzinfo (~> 1.1)
     acts_as_list (0.7.0)
       activerecord (>= 3.0)
-    announce (0.2.1)
+    announce (0.2.2)
     ansi (1.5.0)
     arel (6.0.0)
     aws-sdk-core (2.0.41)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,3 @@
-PATH
-  remote: /Users/andrew/dev/projects/announce
-  specs:
-    announce (0.2.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -46,6 +41,7 @@ GEM
       tzinfo (~> 1.1)
     acts_as_list (0.7.0)
       activerecord (>= 3.0)
+    announce (0.2.1)
     ansi (1.5.0)
     arel (6.0.0)
     aws-sdk-core (2.0.41)
@@ -398,7 +394,7 @@ PLATFORMS
 DEPENDENCIES
   actionpack-action_caching
   acts_as_list
-  announce!
+  announce
   better_errors
   binding_of_caller
   capistrano (~> 3.2)

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -8,6 +8,7 @@ class Api::BaseController < ApplicationController
 
   include ApiVersioning
   include HalActions
+  include AnnounceActions
   include Roar::Rails::ControllerAdditions
 
   # respond to hal or json, but always returns application/hal+json
@@ -17,7 +18,6 @@ class Api::BaseController < ApplicationController
   allow_params :index, [:page, :per, :zoom]
 
   cache_api_action :show
-
   cache_api_action :index
 
   caches_action :entrypoint, cache_path: ->(_c) { { _c: Api.version(api_version).cache_key } }

--- a/app/controllers/api/stories_controller.rb
+++ b/app/controllers/api/stories_controller.rb
@@ -9,8 +9,11 @@ class Api::StoriesController < Api::BaseController
   announce_actions :create, :update, :delete, :publish, :unpublish
 
   def publish
-    publish_resource.publish!
-    show
+    publish_resource.tap do |res|
+      authorize res
+      res.publish!
+      respond_with root_resource(res), show_options
+    end
   end
 
   def publish_resource
@@ -18,8 +21,11 @@ class Api::StoriesController < Api::BaseController
   end
 
   def unpublish
-    resource.unpublish!
-    show
+    unpublish_resource.tap do |res|
+      authorize res
+      res.unpublish!
+      respond_with root_resource(res), show_options
+    end
   end
 
   def unpublish_resource

--- a/app/controllers/api/stories_controller.rb
+++ b/app/controllers/api/stories_controller.rb
@@ -6,17 +6,16 @@ class Api::StoriesController < Api::BaseController
 
   filter_resources_by :series_id, :account_id
 
-  after_action :announce_story_update, only: [:create, :update], if: ->() { response.successful? }
-  after_action :announce_story_delete, only: [:destroy], if: ->() { response.successful? }
+  announce_actions :create, :update, :delete, :publish, :unpublish
 
-  def announce_story_update
-    representer = Api::Min::StoryRepresenter.new(resource)
-    announce(:story, :update, representer.to_json)
+  def publish
+    resource.publish!
+    show
   end
 
-  def announce_story_delete
-    representer = Api::Min::StoryRepresenter.new(resource)
-    announce(:story, :delete, representer.to_json)
+  def unpublish
+    resource.unpublish!
+    show
   end
 
   def random

--- a/app/controllers/api/stories_controller.rb
+++ b/app/controllers/api/stories_controller.rb
@@ -9,13 +9,21 @@ class Api::StoriesController < Api::BaseController
   announce_actions :create, :update, :delete, :publish, :unpublish
 
   def publish
-    resource.publish!
+    publish_resource.publish!
     show
+  end
+
+  def publish_resource
+    @story ||= Story.unpublished.where(id: params[:id]).first
   end
 
   def unpublish
     resource.unpublish!
     show
+  end
+
+  def unpublish_resource
+    @story ||= Story.published.where(id: params[:id]).first
   end
 
   def random

--- a/app/controllers/api/stories_controller.rb
+++ b/app/controllers/api/stories_controller.rb
@@ -6,6 +6,19 @@ class Api::StoriesController < Api::BaseController
 
   filter_resources_by :series_id, :account_id
 
+  after_action :announce_story_update, only: [:create, :update], if: ->() { response.successful? }
+  after_action :announce_story_delete, only: [:destroy], if: ->() { response.successful? }
+
+  def announce_story_update
+    representer = Api::Min::StoryRepresenter.new(resource)
+    announce(:story, :update, representer.to_json)
+  end
+
+  def announce_story_delete
+    representer = Api::Min::StoryRepresenter.new(resource)
+    announce(:story, :delete, representer.to_json)
+  end
+
   def random
     @story = Story.published.limit(1).order('RAND()').first
     show

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   include Pundit
+  include Announce::Publisher
   protect_from_forgery with: :exception
 
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,6 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   include Pundit
-  include Announce::Publisher
   protect_from_forgery with: :exception
 
 end

--- a/app/controllers/concerns/announce_actions.rb
+++ b/app/controllers/concerns/announce_actions.rb
@@ -1,0 +1,41 @@
+# encoding: utf-8
+
+require 'active_support/concern'
+require 'announce_actions/announce_filter'
+
+# expects underlying model to have filename, class, and id attributes
+module AnnounceActions
+
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+
+    attr_accessor :announced_actions
+
+    def announce_actions(*args)
+      self.announced_actions ||= []
+
+      options = args.extract_options!
+      callback_options = options.slice(:only, :except, :if, :unless)
+
+      actions = args.map(&:to_s).uniq
+      actions = [:create, :update, :destroy] if actions.empty?
+
+      actions.each do |action|
+        next if announced_actions.include?(action)
+
+        # remember this action already announcing, prevent dupes
+        self.announced_actions << action
+
+        # when it is a destroy action, default action name to 'delete'
+        filter_options = options.slice(:action, :decorator)
+        filter_options[:action] ||= 'delete' if action.to_s == 'destroy'
+        announce_filter = AnnounceActions::AnnounceFilter.new(action, filter_options)
+
+        # default callback options for only this action, and only on success
+        callback_options.reverse_merge!(only: [action], if: ->() { response.successful? } )
+        after_action announce_filter, callback_options
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/announce_actions.rb
+++ b/app/controllers/concerns/announce_actions.rb
@@ -5,18 +5,15 @@ require 'announce_actions/announce_filter'
 
 # expects underlying model to have filename, class, and id attributes
 module AnnounceActions
-
   extend ActiveSupport::Concern
 
   module ClassMethods
-
     attr_accessor :announced_actions
 
     def announce_actions(*args)
       self.announced_actions ||= []
 
       options = args.extract_options!
-      callback_options = options.slice(:only, :except, :if, :unless)
 
       actions = args.map(&:to_s).uniq
       actions = [:create, :update, :destroy] if actions.empty?
@@ -24,18 +21,28 @@ module AnnounceActions
       actions.each do |action|
         next if announced_actions.include?(action)
 
+        add_announce_filter(action, options)
+
         # remember this action already announcing, prevent dupes
         self.announced_actions << action
-
-        # when it is a destroy action, default action name to 'delete'
-        filter_options = options.slice(:action, :decorator)
-        filter_options[:action] ||= 'delete' if action.to_s == 'destroy'
-        announce_filter = AnnounceActions::AnnounceFilter.new(action, filter_options)
-
-        # default callback options for only this action, and only on success
-        callback_options.reverse_merge!(only: [action], if: ->() { response.successful? } )
-        after_action announce_filter, callback_options
       end
+    end
+
+    def add_announce_filter(action, options)
+      # when it is a destroy action, default action name to 'delete'
+      announce_filter = new_announce_filter(action, options)
+
+      # default callback options for only this action, and only on success
+      default_options = { only: [action], if: ->() { response.successful? } }
+      callback_options = options.slice(:only, :except, :if, :unless)
+
+      after_action announce_filter, default_options.merge(callback_options)
+    end
+
+    def new_announce_filter(action, options)
+      filter_options = options.slice(:action, :decorator)
+      filter_options[:action] ||= 'delete' if action.to_s == 'destroy'
+      AnnounceActions::AnnounceFilter.new(action, filter_options)
     end
   end
 end

--- a/app/controllers/concerns/announce_actions/announce_filter.rb
+++ b/app/controllers/concerns/announce_actions/announce_filter.rb
@@ -11,7 +11,7 @@ module AnnounceActions
     attr_accessor :action, :options
 
     def initialize(action, options = {})
-      @action  = action
+      @action = action
       @options = options
     end
 
@@ -32,15 +32,15 @@ module AnnounceActions
     end
 
     def announce_resource(action, controller)
-      prefix = "#{action}_" if controller.respond_to?("#{action}_resource", true)
-      controller.send("#{prefix}resource")
+      pre = "#{action}_" if controller.respond_to?("#{action}_resource", true)
+      controller.send("#{pre}resource")
     end
 
     def decorator_class(controller)
       return options[:decorator] if options[:decorator]
       resource_class = controller.controller_name.singularize.camelize
       "Api::Min::#{resource_class}Representer".safe_constantize ||
-      "Api::#{resource_class}Representer".safe_constantize
+        "Api::#{resource_class}Representer".safe_constantize
     end
   end
 end

--- a/app/controllers/concerns/announce_actions/announce_filter.rb
+++ b/app/controllers/concerns/announce_actions/announce_filter.rb
@@ -1,0 +1,46 @@
+# encoding: utf-8
+
+require 'announce'
+
+# expects underlying model to have filename, class, and id attributes
+module AnnounceActions
+
+  class AnnounceFilter
+    include Announce::Publisher
+
+    attr_accessor :action, :options
+
+    def initialize(action, options = {})
+      @action  = action
+      @options = options
+    end
+
+    def after(controller)
+      subject = controller.controller_name.singularize
+      announce(subject, resource_action, decorated_resource(controller))
+    end
+
+    def resource_action
+      (options[:action] || action).to_s
+    end
+
+    def decorated_resource(controller)
+      decorator = decorator_class(controller)
+      raise "No decorator specified: #{controller.inspect}" unless decorator
+      res = announce_resource(action, controller)
+      decorator.new(res).to_json
+    end
+
+    def announce_resource(action, controller)
+      prefix = "#{action}_" if controller.respond_to?("#{action}_resource", true)
+      controller.send("#{prefix}resource")
+    end
+
+    def decorator_class(controller)
+      return options[:decorator] if options[:decorator]
+      resource_class = controller.controller_name.singularize.camelize
+      "Api::Min::#{resource_class}Representer".safe_constantize ||
+      "Api::#{resource_class}Representer".safe_constantize
+    end
+  end
+end

--- a/app/controllers/concerns/api_versioning.rb
+++ b/app/controllers/concerns/api_versioning.rb
@@ -26,7 +26,5 @@ module ApiVersioning
       self.understood_api_versions = versions.map(&:to_s)
       before_filter :check_api_version
     end
-
   end
-
 end

--- a/app/controllers/public_assets_controller.rb
+++ b/app/controllers/public_assets_controller.rb
@@ -11,5 +11,4 @@ class PublicAssetsController < ApplicationController
       head 401
     end
   end
-
 end

--- a/app/models/base_model.rb
+++ b/app/models/base_model.rb
@@ -4,7 +4,6 @@ class BaseModel < ActiveRecord::Base
   self.abstract_class = true
 
   include RepresentedModel
-  include Announce::Publisher
 
   def id_from_url(url)
     Rails.application.routes.recognize_path(url)[:id]

--- a/app/models/base_model.rb
+++ b/app/models/base_model.rb
@@ -4,6 +4,7 @@ class BaseModel < ActiveRecord::Base
   self.abstract_class = true
 
   include RepresentedModel
+  include Announce::Publisher
 
   def id_from_url(url)
     Rails.application.routes.recognize_path(url)[:id]

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -120,7 +120,7 @@ class Story < BaseModel
   end
 
   def self.policy_class
-    AccountablePolicy
+    StoryPolicy
   end
 
   def episode_date

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -131,6 +131,23 @@ class Story < BaseModel
     series && series.subscribable?
   end
 
+  # raising exceptions here to prevent sending publish messages when not actually published
+  def publish!
+    if published_at
+      raise "Story #{id} is already published."
+    else
+      update_attributes!(published_at: Time.now)
+    end
+  end
+
+  def unpublish!
+    unless published_at
+      raise "Story #{id} is not published."
+    else
+      update_attributes!(published_at: nil)
+    end
+  end
+
   def destroy
     if v4?
       really_destroy!

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -56,8 +56,6 @@ class Story < BaseModel
     audio_versions.create(label: 'Main Audio')
   end
 
-  after_commit :send_events, if: :persisted?
-
   scope :published, -> { where('`published_at` IS NOT NULL AND `network_only_at` IS NULL') }
 
   scope :purchased, -> {
@@ -70,14 +68,6 @@ class Story < BaseModel
     where(['`series`.`subscription_approval_status` != ? OR `series`.`subscriber_only_at` IS NULL',
            Series::SUBSCRIPTION_PRX_APPROVED])
   }
-
-  def send_events
-    if previous_changes[:published_at] && previous_changes[:published_at].first.nil?
-      publish(:story, :published, { story_id: id, published_at: published_at } )
-    end
-
-    publish(:story, :updated, { story_id: id } )
-  end
 
   def points(level=point_level)
     has_custom_points? ? self.custom_points : Economy.points(level, self.length)

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -56,6 +56,8 @@ class Story < BaseModel
     audio_versions.create(label: 'Main Audio')
   end
 
+  after_commit :send_events, if: :persisted?
+
   scope :published, -> { where('`published_at` IS NOT NULL AND `network_only_at` IS NULL') }
 
   scope :purchased, -> {
@@ -68,6 +70,14 @@ class Story < BaseModel
     where(['`series`.`subscription_approval_status` != ? OR `series`.`subscriber_only_at` IS NULL',
            Series::SUBSCRIPTION_PRX_APPROVED])
   }
+
+  def send_events
+    if previous_changes[:published_at] && previous_changes[:published_at].first.nil?
+      publish(:story, :published, { story_id: id, published_at: published_at } )
+    end
+
+    publish(:story, :updated, { story_id: id } )
+  end
 
   def points(level=point_level)
     has_custom_points? ? self.custom_points : Economy.points(level, self.length)

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -58,6 +58,8 @@ class Story < BaseModel
 
   scope :published, -> { where('`published_at` IS NOT NULL AND `network_only_at` IS NULL') }
 
+  scope :unpublished, -> { where('`published_at` IS NULL') }
+
   scope :purchased, -> {
     joins(:purchases).
     select('`pieces`.*', 'COUNT(`purchases`.`id`) AS `purchase_count`').group('`pieces`.`id`')

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -131,7 +131,8 @@ class Story < BaseModel
     series && series.subscribable?
   end
 
-  # raising exceptions here to prevent sending publish messages when not actually published
+  # raising exceptions here to prevent sending publish messages
+  #  when not actually a change to be published
   def publish!
     if published_at
       raise "Story #{id} is already published."
@@ -141,7 +142,7 @@ class Story < BaseModel
   end
 
   def unpublish!
-    unless published_at
+    if !published_at
       raise "Story #{id} is not published."
     else
       update_attributes!(published_at: nil)

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -136,7 +136,7 @@ class Story < BaseModel
   # raising exceptions here to prevent sending publish messages
   #  when not actually a change to be published
   def publish!
-    if published_at
+    if published?
       raise "Story #{id} is already published."
     else
       update_attributes!(published_at: Time.now)
@@ -144,7 +144,7 @@ class Story < BaseModel
   end
 
   def unpublish!
-    if !published_at
+    if !published?
       raise "Story #{id} is not published."
     else
       update_attributes!(published_at: nil)

--- a/app/policies/account_policy.rb
+++ b/app/policies/account_policy.rb
@@ -1,10 +1,5 @@
 class AccountPolicy < ApplicationPolicy
-  attr_reader :user, :account
-
-  def initialize(user, account)
-    @user = user
-    @account = account
-  end
+  alias_method :account, :record
 
   def create?
     user.present?

--- a/app/policies/accountable_policy.rb
+++ b/app/policies/accountable_policy.rb
@@ -1,11 +1,4 @@
-class AccountablePolicy
-  attr_reader :user, :record
-
-  def initialize(user, record)
-    @user = user
-    @record = record
-  end
-
+class AccountablePolicy < ApplicationPolicy
   def create?
     update?
   end

--- a/app/policies/image_policy.rb
+++ b/app/policies/image_policy.rb
@@ -1,10 +1,5 @@
-class ImagePolicy
-  attr_reader :user, :image
-
-  def initialize(user, image)
-    @user = user
-    @image = image
-  end
+class ImagePolicy < ApplicationPolicy
+  alias_method :image, :record
 
   def create?
     update?

--- a/app/policies/membership_policy.rb
+++ b/app/policies/membership_policy.rb
@@ -1,10 +1,5 @@
 class MembershipPolicy < ApplicationPolicy
-  attr_reader :user, :membership
-
-  def initialize(user, membership)
-    @user = user
-    @membership = membership
-  end
+  alias_method :membership, :record
 
   def create?
     update? || (user == membership.user && !membership.approved?)

--- a/app/policies/producer_policy.rb
+++ b/app/policies/producer_policy.rb
@@ -1,10 +1,5 @@
 class ProducerPolicy < ApplicationPolicy
-  attr_reader :user, :producer
-
-  def initialize(user, producer)
-    @user = user
-    @producer = producer
-  end
+  alias_method :producer, :record
 
   def create?
     update?

--- a/app/policies/story_attribute_policy.rb
+++ b/app/policies/story_attribute_policy.rb
@@ -1,11 +1,4 @@
-class StoryAttributePolicy
-  attr_reader :user, :record
-
-  def initialize(user, record)
-    @user = user
-    @record = record
-  end
-
+class StoryAttributePolicy < ApplicationPolicy
   def create?
     update?
   end

--- a/app/policies/story_policy.rb
+++ b/app/policies/story_policy.rb
@@ -1,0 +1,9 @@
+class StoryPolicy < AccountablePolicy
+  def publish?
+    update?
+  end
+
+  def unpublish?
+    update?
+  end
+end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,10 +1,5 @@
 class UserPolicy < ApplicationPolicy
-  attr_reader :user, :other_user
-
-  def initialize(user, other_user)
-    @user = user
-    @other_user = other_user
-  end
+  alias_method :other_user, :record
 
   def create?
     true

--- a/app/representers/api/account_representer.rb
+++ b/app/representers/api/account_representer.rb
@@ -2,7 +2,7 @@
 
 class Api::AccountRepresenter < Api::BaseRepresenter
 
-  property :id
+  property :id, writeable: false
   property :type
   property :name
   property :path

--- a/app/representers/api/address_representer.rb
+++ b/app/representers/api/address_representer.rb
@@ -2,7 +2,7 @@
 
 class Api::AddressRepresenter < Api::BaseRepresenter
 
-  property :id
+  property :id, writeable: false
   property :street_1
   property :street_2
   property :street_3

--- a/app/representers/api/audio_file_representer.rb
+++ b/app/representers/api/audio_file_representer.rb
@@ -2,7 +2,7 @@
 
 class Api::AudioFileRepresenter < Api::BaseRepresenter
 
-  property :id
+  property :id, writeable: false
   property :filename
   property :label
   property :size

--- a/app/representers/api/audio_version_representer.rb
+++ b/app/representers/api/audio_version_representer.rb
@@ -2,7 +2,7 @@
 
 class Api::AudioVersionRepresenter < Api::BaseRepresenter
 
-  property :id
+  property :id, writeable: false
   property :label
   property :timing_and_cues
   property :explicit

--- a/app/representers/api/authorization_representer.rb
+++ b/app/representers/api/authorization_representer.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 class Api::AuthorizationRepresenter < Api::BaseRepresenter
-  property :id
+  property :id, writeable: false
   property :name
 
   link :default_account do

--- a/app/representers/api/base_representer.rb
+++ b/app/representers/api/base_representer.rb
@@ -32,5 +32,4 @@ class Api::BaseRepresenter < Roar::Decorator
     klass = rep.try(:item_class) || rep.class.try(:base_class)
     (klass && (klass != rep.class)) ? rep.becomes(klass) : rep
   end
-
 end

--- a/app/representers/api/image_representer.rb
+++ b/app/representers/api/image_representer.rb
@@ -2,7 +2,7 @@
 
 class Api::ImageRepresenter < Api::BaseRepresenter
 
-  property :id
+  property :id, writeable: false
   property :filename
   property :size
   property :caption

--- a/app/representers/api/membership_representer.rb
+++ b/app/representers/api/membership_representer.rb
@@ -2,7 +2,7 @@
 
 class Api::MembershipRepresenter < Api::BaseRepresenter
 
-  property :id
+  property :id, writeable: false
   property :role
   property :approved
   property :request

--- a/app/representers/api/min/account_representer.rb
+++ b/app/representers/api/min/account_representer.rb
@@ -2,7 +2,7 @@
 
 class Api::Min::AccountRepresenter < Api::BaseRepresenter
 
-  property :id
+  property :id, writeable: false
   property :type
   property :name
   property :path

--- a/app/representers/api/min/series_representer.rb
+++ b/app/representers/api/min/series_representer.rb
@@ -2,7 +2,7 @@
 
 class Api::Min::SeriesRepresenter < Api::BaseRepresenter
 
-  property :id
+  property :id, writeable: false
   property :title
   property :short_description
 

--- a/app/representers/api/min/story_representer.rb
+++ b/app/representers/api/min/story_representer.rb
@@ -2,12 +2,12 @@
 
 class Api::Min::StoryRepresenter < Api::BaseRepresenter
 
-  property :id
+  property :id, writeable: false
   property :title
   property :short_description
   property :episode_number
   property :episode_identifier
-  property :published_at
+  property :published_at, writeable: false
   property :produced_on
 
   property :duration, writeable: false

--- a/app/representers/api/min/user_representer.rb
+++ b/app/representers/api/min/user_representer.rb
@@ -2,7 +2,7 @@
 
 class Api::Min::UserRepresenter < Api::BaseRepresenter
 
-  property :id
+  property :id, writeable: false
   property :first_name
   property :last_name
   property :login

--- a/app/representers/api/musical_work_representer.rb
+++ b/app/representers/api/musical_work_representer.rb
@@ -2,7 +2,7 @@
 
 class Api::MusicalWorkRepresenter < Api::BaseRepresenter
 
-  property :id
+  property :id, writeable: false
   property :position
   property :title
   property :artist

--- a/app/representers/api/pick_representer.rb
+++ b/app/representers/api/pick_representer.rb
@@ -2,7 +2,7 @@
 
 class Api::PickRepresenter < Api::BaseRepresenter
 
-  property :id
+  property :id, writeable: false
   property :comment
   property :editors_title
 

--- a/app/representers/api/producer_representer.rb
+++ b/app/representers/api/producer_representer.rb
@@ -2,7 +2,7 @@
 
 class Api::ProducerRepresenter < Api::BaseRepresenter
 
-  property :id
+  property :id, writeable: false
   property :user_id
   property :name
 

--- a/app/representers/api/series_representer.rb
+++ b/app/representers/api/series_representer.rb
@@ -2,7 +2,7 @@
 
 class Api::SeriesRepresenter < Api::BaseRepresenter
 
-  property :id
+  property :id, writeable: false
   property :title
   property :short_description
   property :description

--- a/app/representers/api/story_representer.rb
+++ b/app/representers/api/story_representer.rb
@@ -2,12 +2,12 @@
 
 class Api::StoryRepresenter < Api::BaseRepresenter
 
-  property :id
+  property :id, writeable: false
   property :title
   property :short_description
   property :episode_number
   property :episode_identifier
-  property :published_at
+  property :published_at, writeable: false
   property :produced_on
 
   property :duration, writeable: false

--- a/app/representers/api/story_representer.rb
+++ b/app/representers/api/story_representer.rb
@@ -23,6 +23,18 @@ class Api::StoryRepresenter < Api::BaseRepresenter
 
   property :license, class: License, decorator: Api::LicenseRepresenter
 
+  link rel: :publish, writeable: false do
+    {
+      href: publish_api_story_path(represented)
+    } if !represented.published?
+  end
+
+  link rel: :unpublish, writeable: false do
+    {
+      href: unpublish_api_story_path(represented)
+    } if represented.published?
+  end
+
   link rel: :account, writeable: true do
     {
       href: api_account_path(represented.account),

--- a/app/representers/api/user_representer.rb
+++ b/app/representers/api/user_representer.rb
@@ -2,7 +2,7 @@
 
 class Api::UserRepresenter < Api::BaseRepresenter
 
-  property :id
+  property :id, writeable: false
   property :first_name
   property :last_name
   property :login

--- a/app/representers/concerns/caches.rb
+++ b/app/representers/concerns/caches.rb
@@ -43,5 +43,4 @@ module Caches
   def cache_options
     {compress: true, race_condition_ttl: 10, expires_in: 1.hour}
   end
-
 end

--- a/app/representers/concerns/curies.rb
+++ b/app/representers/concerns/curies.rb
@@ -48,7 +48,5 @@ module Curies
       options[:as] = curify(options[:as] || name) if options[:embedded]
       super(name, options)
     end
-
   end
-
 end

--- a/app/representers/concerns/embeds.rb
+++ b/app/representers/concerns/embeds.rb
@@ -45,7 +45,6 @@ module Embeds
       # then do not zoom when this name is not in the request
       zoom_param.nil? ? zoom_def : zoom_param.include?(name)
     end
-
   end
 
   # Possible values for zoom option in the embed representer definition
@@ -86,7 +85,5 @@ module Embeds
 
       collection(name, options)
     end
-
   end
-
 end

--- a/app/representers/concerns/format_keys.rb
+++ b/app/representers/concerns/format_keys.rb
@@ -26,7 +26,5 @@ module FormatKeys
       options[:as] = options[:embedded] ? n.dasherize : n.camelize(:lower)
       super(name, options)
     end
-
   end
-
 end

--- a/config/announce.yml
+++ b/config/announce.yml
@@ -3,5 +3,7 @@ app_name: cms
 
 publish:
   story:
-    - published
-    - updated
+    - update
+    - delete
+    - publish
+    - unpublish

--- a/config/announce.yml
+++ b/config/announce.yml
@@ -3,6 +3,7 @@ app_name: cms
 
 publish:
   story:
+    - create
     - update
     - delete
     - publish

--- a/config/announce.yml
+++ b/config/announce.yml
@@ -1,0 +1,7 @@
+# Configuration file that defines the settings for pub/sub of events
+app_name: cms
+
+publish:
+  story:
+    - published
+    - updated

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,6 +50,8 @@ module PRX
     end
 
     config.active_job.queue_adapter = :shoryuken
+    config.active_job.queue_name_prefix = Rails.env
+    config.active_job.queue_name_delimiter = '_'
 
     config.active_record.raise_in_transactional_callbacks = true
   end

--- a/config/initializers/announce.rb
+++ b/config/initializers/announce.rb
@@ -1,0 +1,1 @@
+Announce::configure

--- a/config/initializers/shoryuken.rb
+++ b/config/initializers/shoryuken.rb
@@ -1,0 +1,12 @@
+require 'shoryuken'
+require 'shoryuken/extensions/active_job_adapter'
+
+Shoryuken.default_worker_options =  {
+  'queue'                   => 'default',
+  'auto_delete'             => true,
+  'auto_visibility_timeout' => true,
+  'batch'                   => false,
+  'body_parser'             => :json
+}
+
+Shoryuken::EnvironmentLoader.load(config_file: (Rails.root + 'config' + 'shoryuken.yml'))

--- a/config/initializers/shoryuken.rb
+++ b/config/initializers/shoryuken.rb
@@ -1,3 +1,4 @@
 require 'shoryuken'
 
-Shoryuken::EnvironmentLoader.load(config_file: (Rails.root + 'config' + 'shoryuken.yml'))
+config_file = File.join(Rails.root, 'config', 'shoryuken.yml')
+Shoryuken::EnvironmentLoader.load(config_file: config_file)

--- a/config/initializers/shoryuken.rb
+++ b/config/initializers/shoryuken.rb
@@ -1,12 +1,3 @@
 require 'shoryuken'
-require 'shoryuken/extensions/active_job_adapter'
-
-Shoryuken.default_worker_options =  {
-  'queue'                   => 'default',
-  'auto_delete'             => true,
-  'auto_visibility_timeout' => true,
-  'batch'                   => false,
-  'body_parser'             => :json
-}
 
 Shoryuken::EnvironmentLoader.load(config_file: (Rails.root + 'config' + 'shoryuken.yml'))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,13 +17,15 @@ PRX::Application.routes.draw do
       end
 
       resources :stories, except: [:new, :edit] do
+        get 'random', on: :collection
+        put 'publish', on: :member
+        put 'unpublish', on: :member
         resources :promos, except: [:new, :edit]
         resources :audio_files, except: [:new, :edit]
         resources :audio_versions, except: [:new, :edit]
         resources :story_images, path: 'images', except: [:new, :edit]
         resources :musical_works, except: [:new, :edit]
         resources :producers, except: [:new, :edit]
-        get 'random', on: :collection
       end
 
       resources :series, except: [:new, :edit] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,8 +18,8 @@ PRX::Application.routes.draw do
 
       resources :stories, except: [:new, :edit] do
         get 'random', on: :collection
-        put 'publish', on: :member
-        put 'unpublish', on: :member
+        post 'publish', on: :member
+        post 'unpublish', on: :member
         resources :promos, except: [:new, :edit]
         resources :audio_files, except: [:new, :edit]
         resources :audio_versions, except: [:new, :edit]

--- a/config/shoryuken.yml
+++ b/config/shoryuken.yml
@@ -1,0 +1,9 @@
+aws:
+  access_key_id:     <%= ENV['AWS_ACCESS_KEY_ID'] %>
+  secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+  region:            <%= ENV['AWS_REGION'] %>
+  account_id:        <%= ENV['AWS_ACCOUNT_ID'] %>
+concurrency: 25  # The number of allocated threads to process messages. Default 25
+delay:       30        # The delay in seconds to pause a queue when it's empty. Default 0
+queues:
+  - default

--- a/config/shoryuken.yml
+++ b/config/shoryuken.yml
@@ -5,5 +5,3 @@ aws:
   account_id:        <%= ENV['AWS_ACCOUNT_ID'] %>
 concurrency: 25  # The number of allocated threads to process messages. Default 25
 delay:       30        # The delay in seconds to pause a queue when it's empty. Default 0
-queues:
-  - default

--- a/test/controllers/api/stories_controller_test.rb
+++ b/test/controllers/api/stories_controller_test.rb
@@ -54,6 +54,22 @@ describe Api::StoriesController do
       Story.find(story.id).title.must_equal('this')
     end
 
+    it 'can publish a story' do
+      story = create(:story, title: 'not this', account: account, published_at: nil)
+      @request.env['CONTENT_TYPE'] = 'application/json'
+      put :publish, api_version: 'v1', format: 'json', id: story.id
+      assert_response :success
+      Story.find(story.id).published_at.wont_be_nil
+    end
+
+    it 'can unpublish a story' do
+      story = create(:story, title: 'not this', account: account, published_at: Time.now)
+      @request.env['CONTENT_TYPE'] = 'application/json'
+      put :unpublish, api_version: 'v1', format: 'json', id: story.id
+      assert_response :success
+      Story.find(story.id).published_at.must_be_nil
+    end
+
     it 'can delete a story' do
       story = create(:story, account: account)
       delete :destroy, api_version: 'v1', format: 'json', id: story.id

--- a/test/controllers/api/stories_controller_test.rb
+++ b/test/controllers/api/stories_controller_test.rb
@@ -56,10 +56,9 @@ describe Api::StoriesController do
 
     it 'can publish a story' do
       story = create(:story,
-        title: 'not this',
-        account: account,
-        published_at: nil
-      )
+                     title: 'not this',
+                     account: account,
+                     published_at: nil)
       @request.env['CONTENT_TYPE'] = 'application/json'
       post :publish, api_version: 'v1', format: 'json', id: story.id
       assert_response :success
@@ -68,10 +67,9 @@ describe Api::StoriesController do
 
     it 'can unpublish a story' do
       story = create(:story,
-        title: 'not this',
-        account: account,
-        published_at: Time.now
-      )
+                     title: 'not this',
+                     account: account,
+                     published_at: Time.now)
       @request.env['CONTENT_TYPE'] = 'application/json'
       post :unpublish, api_version: 'v1', format: 'json', id: story.id
       assert_response :success

--- a/test/controllers/api/stories_controller_test.rb
+++ b/test/controllers/api/stories_controller_test.rb
@@ -57,7 +57,7 @@ describe Api::StoriesController do
     it 'can publish a story' do
       story = create(:story, title: 'not this', account: account, published_at: nil)
       @request.env['CONTENT_TYPE'] = 'application/json'
-      put :publish, api_version: 'v1', format: 'json', id: story.id
+      post :publish, api_version: 'v1', format: 'json', id: story.id
       assert_response :success
       Story.find(story.id).published_at.wont_be_nil
     end
@@ -65,7 +65,7 @@ describe Api::StoriesController do
     it 'can unpublish a story' do
       story = create(:story, title: 'not this', account: account, published_at: Time.now)
       @request.env['CONTENT_TYPE'] = 'application/json'
-      put :unpublish, api_version: 'v1', format: 'json', id: story.id
+      post :unpublish, api_version: 'v1', format: 'json', id: story.id
       assert_response :success
       Story.find(story.id).published_at.must_be_nil
     end

--- a/test/controllers/api/stories_controller_test.rb
+++ b/test/controllers/api/stories_controller_test.rb
@@ -55,7 +55,11 @@ describe Api::StoriesController do
     end
 
     it 'can publish a story' do
-      story = create(:story, title: 'not this', account: account, published_at: nil)
+      story = create(:story,
+        title: 'not this',
+        account: account,
+        published_at: nil
+      )
       @request.env['CONTENT_TYPE'] = 'application/json'
       post :publish, api_version: 'v1', format: 'json', id: story.id
       assert_response :success
@@ -63,7 +67,11 @@ describe Api::StoriesController do
     end
 
     it 'can unpublish a story' do
-      story = create(:story, title: 'not this', account: account, published_at: Time.now)
+      story = create(:story,
+        title: 'not this',
+        account: account,
+        published_at: Time.now
+      )
       @request.env['CONTENT_TYPE'] = 'application/json'
       post :unpublish, api_version: 'v1', format: 'json', id: story.id
       assert_response :success

--- a/test/controllers/concerns/announce_actions/announce_filter_test.rb
+++ b/test/controllers/concerns/announce_actions/announce_filter_test.rb
@@ -11,7 +11,6 @@ describe AnnounceActions::AnnounceFilter do
   let(:filter) { AnnounceActions::AnnounceFilter.new('create', {}) }
 
   before do
-
     controller_class.class_eval do
       include AnnounceActions
       announce_actions

--- a/test/controllers/concerns/announce_actions/announce_filter_test.rb
+++ b/test/controllers/concerns/announce_actions/announce_filter_test.rb
@@ -1,0 +1,49 @@
+# encoding: utf-8
+
+require 'announce_actions'
+
+describe AnnounceActions::AnnounceFilter do
+
+  let(:controller_class) { Api::TestObjectsController }
+
+  let(:controller) { controller_class.new }
+
+  let(:filter) { AnnounceActions::AnnounceFilter.new('create', {}) }
+
+  before do
+
+    controller_class.class_eval do
+      include AnnounceActions
+      announce_actions
+    end
+
+    clear_messages
+  end
+
+  it 'is created with an action and a options' do
+    filter.action.must_equal('create')
+    filter.options.must_equal({})
+  end
+
+  it 'defaults to the min decorator when possible' do
+    dc = filter.decorator_class(controller)
+    dc.must_equal Api::Min::TestObjectRepresenter
+  end
+
+  it 'can use an optional decorator' do
+    filter.options[:decorator] = Api::TestObjectRepresenter
+    dc = filter.decorator_class(controller)
+    dc.must_equal Api::TestObjectRepresenter
+  end
+
+  it 'can use an optional action name' do
+    filter.resource_action.must_equal('create')
+    filter.options[:action] = 'foo'
+    filter.resource_action.must_equal('foo')
+  end
+
+  it 'tries the action specific resource method' do
+    def controller.foo_resource; 'foo'; end
+    filter.announce_resource('foo', controller).must_equal 'foo'
+  end
+end

--- a/test/controllers/concerns/announce_actions_test.rb
+++ b/test/controllers/concerns/announce_actions_test.rb
@@ -24,8 +24,9 @@ describe Api::TestObjectsController do
   end
 
   it 'defaults to create, update, and destroy' do
+    default_actions = [:create, :destroy, :update]
     controller_class.announce_actions
-    controller_class.announced_actions.sort.must_equal [:create, :destroy, :update]
+    controller_class.announced_actions.sort.must_equal default_actions
   end
 
   describe 'test callbacks' do
@@ -40,7 +41,7 @@ describe Api::TestObjectsController do
 
       response.must_be :success?
       last_message['subject'].to_s.must_equal 'test_object'
-      last_message['action'].to_s.must_equal  'create'
+      last_message['action'].to_s.must_equal 'create'
     end
 
     it 'renames destroy action to delete' do
@@ -50,7 +51,7 @@ describe Api::TestObjectsController do
 
       response.must_be :success?
       last_message['subject'].to_s.must_equal 'test_object'
-      last_message['action'].to_s.must_equal  'delete'
+      last_message['action'].to_s.must_equal 'delete'
     end
   end
 end

--- a/test/controllers/concerns/announce_actions_test.rb
+++ b/test/controllers/concerns/announce_actions_test.rb
@@ -1,0 +1,56 @@
+# encoding: utf-8
+
+require 'announce_actions'
+
+describe Api::TestObjectsController do
+
+  let (:controller_class) { Api::TestObjectsController }
+
+  before do
+    controller_class.class_eval { include AnnounceActions }
+    controller_class.announced_actions = []
+    clear_messages
+  end
+
+  it 'can declare announced actions' do
+    controller_class.announce_actions(:destroy)
+    controller_class.announced_actions.size.must_equal 1
+  end
+
+  it 'prevents dupe announcements' do
+    controller_class.announce_actions(:destroy)
+    controller_class.announce_actions(:destroy, :update)
+    controller_class.announced_actions.size.must_equal 2
+  end
+
+  it 'defaults to create, update, and destroy' do
+    controller_class.announce_actions
+    controller_class.announced_actions.sort.must_equal [:create, :destroy, :update]
+  end
+
+  describe 'test callbacks' do
+
+    before { define_routes }
+    after { Rails.application.reload_routes! }
+
+    it 'will call announce' do
+      controller_class.announce_actions(:create)
+
+      post :create, { title: 'foo' }.to_json
+
+      response.must_be :success?
+      last_message['subject'].to_s.must_equal 'test_object'
+      last_message['action'].to_s.must_equal  'create'
+    end
+
+    it 'renames destroy action to delete' do
+      controller_class.announce_actions(:destroy)
+
+      delete :destroy, id: 1
+
+      response.must_be :success?
+      last_message['subject'].to_s.must_equal 'test_object'
+      last_message['action'].to_s.must_equal  'delete'
+    end
+  end
+end

--- a/test/controllers/concerns/api_versioning_test.rb
+++ b/test/controllers/concerns/api_versioning_test.rb
@@ -1,7 +1,9 @@
+# encoding: utf-8
+
 describe ApiVersioning do
 
   class ApiVersioningTestController < ActionController::Base
-    include ApiVersioning    
+    include ApiVersioning
   end
 
   let (:controller) { ApiVersioningTestController.new }
@@ -10,5 +12,4 @@ describe ApiVersioning do
     ApiVersioningTestController.api_versions(:v0)
     ApiVersioningTestController.understood_api_versions.must_equal ['v0']
   end
-
 end

--- a/test/controllers/concerns/hal_actions_test.rb
+++ b/test/controllers/concerns/hal_actions_test.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'hal_actions'
 
 describe HalActions do

--- a/test/controllers/public_assets_controller_test.rb
+++ b/test/controllers/public_assets_controller_test.rb
@@ -29,5 +29,4 @@ describe PublicAssetsController do
 
     assert_response :redirect
   end
-
 end

--- a/test/models/story_test.rb
+++ b/test/models/story_test.rb
@@ -5,6 +5,37 @@ describe Story do
   let(:story) { build_stubbed(:story_with_audio, audio_versions_count: 10) }
   let(:promos_only) { build_stubbed(:story_promos_only) }
 
+  describe 'publishing' do
+
+    let(:story) { create(:story) }
+
+    it 'publishes a story' do
+      story.published_at = nil
+      story.publish!
+      story.published_at.wont_be_nil
+    end
+
+    it 'wont publish when already published' do
+      lambda do
+        story.publish!
+        story.publish!
+      end.must_raise(RuntimeError)
+    end
+
+    it 'unpublishes a story' do
+      story.published_at = Time.now
+      story.unpublish!
+      story.published_at.must_be_nil
+    end
+
+    it 'wont unpublish an unpublished story' do
+      lambda do
+        story.unpublish!
+        story.unpublish!
+      end.must_raise(RuntimeError)
+    end
+  end
+
   describe 'basics' do
 
     it 'has a table defined' do

--- a/test/representers/api/paged_collection_representer_test.rb
+++ b/test/representers/api/paged_collection_representer_test.rb
@@ -51,7 +51,8 @@ describe Api::PagedCollectionRepresenter do
     it 'gets a route url helper method with parent' do
       representer.represented.options[:parent] = TestParent.new(1, true)
       representer.represented.options[:item_class] = TestObject
-      representer.href_url_helper({page: 1}).must_equal "/api/test_parent/1/test_objects?page=1"
+      page_one_path = '/api/test_parent/1/test_objects?page=1'
+      representer.href_url_helper(page: 1).must_equal page_one_path
     end
   end
 end

--- a/test/representers/api/paged_collection_representer_test.rb
+++ b/test/representers/api/paged_collection_representer_test.rb
@@ -32,15 +32,6 @@ describe Api::PagedCollectionRepresenter do
     representer.href_url_helper({page: 1}).must_equal "/api/v1/stories?page=1"
   end
 
-  # TODO Find out why this is broken
-  it 'gets a route url helper method with parent' do
-    define_routes
-    representer.represented.options[:parent] = TestParent.new(1, true)
-    representer.represented.options[:item_class] = TestObject
-    representer.href_url_helper({page: 1}).must_equal "/api/test_parent/1/test_objects?page=1"
-    Rails.application.reload_routes!
-  end
-
   it 'uses a lambda for a url method' do
     representer.represented.options[:url] = ->(options){ options.keys.sort.join('/') }
     representer.href_url_helper({foo: 1, bar: 2, camp: 3}).must_equal "bar/camp/foo"
@@ -52,4 +43,15 @@ describe Api::PagedCollectionRepresenter do
     representer.href_url_helper({foo: 1, bar: 2, camp: 3}).must_equal "this is a test"
   end
 
+  describe 'test with routing' do
+
+    before { define_routes }
+    after { Rails.application.reload_routes! }
+
+    it 'gets a route url helper method with parent' do
+      representer.represented.options[:parent] = TestParent.new(1, true)
+      representer.represented.options[:item_class] = TestObject
+      representer.href_url_helper({page: 1}).must_equal "/api/test_parent/1/test_objects?page=1"
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,6 +20,8 @@ require 'minitest/reporters'
 require 'minitest/autorun'
 require 'minitest/spec'
 require 'minitest/pride'
+require 'announce/testing'
+
 
 # To add Capybara feature tests add `gem "minitest-rails-capybara"`
 # to the test group in the Gemfile and uncomment the following:
@@ -27,6 +29,7 @@ require 'minitest/pride'
 
 class ActiveSupport::TestCase
   include FactoryGirl::Syntax::Methods
+  include Announce::Testing
 
   def api_request_opts(opts={})
     { format: 'json', api_version: 'v1' }.merge(opts)
@@ -35,6 +38,7 @@ end
 
 class MiniTest::Spec
   include FactoryGirl::Syntax::Methods
+  include Announce::Testing
 
   def extract_filename(uri)
     URI.parse(uri).path.split('?')[0].split('/').last
@@ -44,4 +48,5 @@ end
 Minitest::Expectations.infect_an_assertion :assert_operator, :must_allow, :reverse
 Minitest::Expectations.infect_an_assertion :refute_operator, :wont_allow, :reverse
 
-Announce.options[:adapter] = :test
+include Announce::Testing
+reset_announce

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -43,3 +43,5 @@ end
 
 Minitest::Expectations.infect_an_assertion :assert_operator, :must_allow, :reverse
 Minitest::Expectations.infect_an_assertion :refute_operator, :wont_allow, :reverse
+
+Announce.options[:adapter] = :test

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,7 +22,6 @@ require 'minitest/spec'
 require 'minitest/pride'
 require 'announce/testing'
 
-
 # To add Capybara feature tests add `gem "minitest-rails-capybara"`
 # to the test group in the Gemfile and uncomment the following:
 # require "minitest/rails/capybara"

--- a/test/test_models.rb
+++ b/test/test_models.rb
@@ -30,7 +30,29 @@ class Api::TestObjectRepresenter < Api::BaseRepresenter
     title = rep.respond_to?('[]') ? rep[:title] : rep.try(:title)
     "/api/tests/#{title}"
   end
+end
 
+class Api::Min::TestObjectRepresenter < Api::BaseRepresenter
+
+  property :title
+
+  def api_tests_path(rep)
+    title = rep.respond_to?('[]') ? rep[:title] : rep.try(:title)
+    "/api/tests/#{title}"
+  end
+end
+
+class Api::TestObjectsController < ActionController::Base
+
+  def index;   head :no_content; end
+  def show;    head :no_content; end
+  def create;  head :no_content; end
+  def update;  head :no_content; end
+  def destroy; head :no_content; end
+
+  def resource
+    @resource ||= TestObject.new('title', true)
+  end
 end
 
 def define_routes

--- a/test/test_models.rb
+++ b/test/test_models.rb
@@ -5,7 +5,6 @@ TestObject = Struct.new(:title, :is_root_resource) do
   def to_model; self; end
 end
 
-
 TestParent = Struct.new(:id, :is_root_resource) do
   extend ActiveModel::Naming
 
@@ -23,7 +22,6 @@ TestParent = Struct.new(:id, :is_root_resource) do
 end
 
 class Api::TestObjectRepresenter < Api::BaseRepresenter
-
   property :title
 
   def api_tests_path(rep)
@@ -33,7 +31,6 @@ class Api::TestObjectRepresenter < Api::BaseRepresenter
 end
 
 class Api::Min::TestObjectRepresenter < Api::BaseRepresenter
-
   property :title
 
   def api_tests_path(rep)
@@ -43,11 +40,14 @@ class Api::Min::TestObjectRepresenter < Api::BaseRepresenter
 end
 
 class Api::TestObjectsController < ActionController::Base
+  def index; head :no_content; end
 
-  def index;   head :no_content; end
-  def show;    head :no_content; end
-  def create;  head :no_content; end
-  def update;  head :no_content; end
+  def show; head :no_content; end
+
+  def create; head :no_content; end
+
+  def update; head :no_content; end
+
   def destroy; head :no_content; end
 
   def resource
@@ -63,8 +63,6 @@ def define_routes
       resources :test_parent do
         get 'test_objects', to: 'test_objects#index'
       end
-
     end
   end
 end
-


### PR DESCRIPTION
For communicating between services, for example, on publishing a new story.
Relies on the new `announce` gem for setting up SNS topics, SQS queues, and subscriptions, and for sending messages.  Integrates with ActiveJob and `shoryuken` for processing messages.