### PR TITLE
Trust signed token instead of `users` and `memberships` tables

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'rails', '~> 4.2.1'
 
 # JWS
 gem 'prx_auth-rails', '~> 0.0.4'
+gem 'rack-prx_auth', '~> 0.0.7'
 
 ## Model
 # Use mysql as the database for Active Record

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,7 +224,7 @@ GEM
     ipaddress (0.8.0)
     jmespath (1.0.2)
       multi_json (~> 1.0)
-    json (1.8.2)
+    json (1.8.3)
     json-jwt (0.8.1)
       activesupport
       bindata
@@ -246,7 +246,7 @@ GEM
     method_source (0.8.2)
     mime-types (2.5)
     mini_portile (0.6.2)
-    minitest (5.6.1)
+    minitest (5.7.0)
     minitest-reporters (1.0.14)
       ansi
       builder
@@ -255,7 +255,7 @@ GEM
     minitest-spec-rails (5.2.0)
       minitest (~> 5.0)
       rails (~> 4.1)
-    multi_json (1.11.0)
+    multi_json (1.11.1)
     mysql2 (0.3.18)
     nenv (0.2.0)
     net-scp (1.2.1)
@@ -281,9 +281,9 @@ GEM
       activesupport (>= 3.0.0)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
-    rack (1.6.0)
+    rack (1.6.1)
     rack-cors (0.4.0)
-    rack-prx_auth (0.0.6)
+    rack-prx_auth (0.0.7)
       json (~> 1.8, >= 1.8.1)
       json-jwt (~> 0.7, >= 0.7.0)
       rack (~> 1.5, >= 1.5.2)
@@ -426,6 +426,7 @@ DEPENDENCIES
   pundit
   quiet_assets
   rack-cors
+  rack-prx_auth (~> 0.0.7)
   rails (~> 4.2.1)
   rake
   responders (~> 2.0)

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 class Api::BaseController < ApplicationController
+  include Pundit
 
   protect_from_forgery with: :null_session
 
@@ -32,9 +33,13 @@ class Api::BaseController < ApplicationController
     head :no_content
   end
 
+  def pundit_user
+    prx_auth_token
+  end
+
   def current_user
     @current_user ||= if prx_auth_token
-      User.find_by(id: prx_auth_token.user_id)
+      User.find(prx_auth_token.user_id)
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,5 @@
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
-  include Pundit
   protect_from_forgery with: :exception
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,8 +28,4 @@ class User < BaseModel
       joins('LEFT OUTER JOIN `memberships` ON `memberships`.`account_id` = `accounts`.`id`').
       where(['accounts.id = ? OR (memberships.user_id = ? and memberships.approved is true)', individual_account.id, id])
   end
-
-  def role_for(account)
-    memberships.where(account: account).first.try(:role)
-  end
 end

--- a/app/policies/account_policy.rb
+++ b/app/policies/account_policy.rb
@@ -1,15 +1,13 @@
 class AccountPolicy < ApplicationPolicy
-  alias_method :account, :record
-
   def create?
-    user.present?
+    token.present?
   end
 
   def update?
-    user && user.approved_accounts.include?(account)
+    token && token.authorized?(resource.id)
   end
 
   def destroy?
-    user && user.role_for(account) == 'admin'
+    token && token.authorized?(resource.id, :admin)
   end
 end

--- a/app/policies/accountable_policy.rb
+++ b/app/policies/accountable_policy.rb
@@ -4,7 +4,7 @@ class AccountablePolicy < ApplicationPolicy
   end
 
   def update?
-    user && user.approved_accounts.include?(record.account)
+    token && token.authorized?(resource.account.id)
   end
 
   def destroy?

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,11 +1,4 @@
-class ApplicationPolicy
-  attr_reader :user, :record
-
-  def initialize(user, record)
-    @user = user
-    @record = record
-  end
-
+class ApplicationPolicy < Struct.new(:token, :resource)
   def create?
     false
   end

--- a/app/policies/image_policy.rb
+++ b/app/policies/image_policy.rb
@@ -1,12 +1,10 @@
 class ImagePolicy < ApplicationPolicy
-  alias_method :image, :record
-
   def create?
     update?
   end
 
   def update?
-    policy_type.new(user, image_owner).update?
+    policy_type.new(token, image_owner).update?
   end
 
   private
@@ -16,10 +14,10 @@ class ImagePolicy < ApplicationPolicy
   end
 
   def image_owner_class
-    image.class.name.split('Image')[0]
+    resource.class.name.split('Image')[0]
   end
 
   def image_owner
-    image.send(image_owner_class.downcase)
+    resource.send(image_owner_class.downcase)
   end
 end

--- a/app/policies/membership_policy.rb
+++ b/app/policies/membership_policy.rb
@@ -1,15 +1,13 @@
 class MembershipPolicy < ApplicationPolicy
-  alias_method :membership, :record
-
   def create?
-    update? || (user == membership.user && !membership.approved?)
+    update? || (token.user_id == resource.user.id && !resource.approved?)
   end
 
   def update?
-    user && user.role_for(membership.account) == 'admin'
+    token && token.authorized?(resource.account.id, :admin)
   end
 
   def destroy?
-    user == membership.user || user.role_for(membership.account) == 'admin'
+    token.user_id == resource.user.id || update?
   end
 end

--- a/app/policies/producer_policy.rb
+++ b/app/policies/producer_policy.rb
@@ -1,13 +1,11 @@
 class ProducerPolicy < ApplicationPolicy
-  alias_method :producer, :record
-
   def create?
     update?
   end
 
   def update?
-    user &&
-      (producer.user == user ||
-       AccountablePolicy.new(user, producer.story).update?)
+    token &&
+      (resource.user.id == token.user_id ||
+       AccountablePolicy.new(token, resource.story).update?)
   end
 end

--- a/app/policies/story_attribute_policy.rb
+++ b/app/policies/story_attribute_policy.rb
@@ -4,6 +4,6 @@ class StoryAttributePolicy < ApplicationPolicy
   end
 
   def update?
-    AccountablePolicy.new(user, record.story).update?
+    AccountablePolicy.new(token, resource.story).update?
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,11 +1,9 @@
 class UserPolicy < ApplicationPolicy
-  alias_method :other_user, :record
-
   def create?
     true
   end
 
   def update?
-    user == other_user
+    token.user_id == resource.id
   end
 end

--- a/test/controllers/api/audio_files_controller_test.rb
+++ b/test/controllers/api/audio_files_controller_test.rb
@@ -1,14 +1,17 @@
 require 'test_helper'
 
 describe Api::AudioFilesController do
-  let(:user) { create(:user) }
-  let(:story) { create(:story, account: user.approved_accounts.first) }
-  let(:audio_file) { create(:audio_file, story: story) }
+  let(:account) { create(:account) }
+  let(:token) { StubToken.new(account.id, ['member']) }
+  let(:story) { create(:story, account: account) }
+  let(:audio_file) { create(:audio_file, story: story, account: account) }
+
+  before(:each) do
+    class << @controller; attr_accessor :prx_auth_token; end
+    @controller.prx_auth_token = token
+  end
 
   describe '#create' do
-
-    before { @controller.current_user = user }
-
     it 'can create an audio file for an account' do
       af_hash = {
         size: 1024,

--- a/test/controllers/api/stories_controller_test.rb
+++ b/test/controllers/api/stories_controller_test.rb
@@ -9,10 +9,13 @@ describe Api::StoriesController do
 
   describe 'editing' do
 
-    let(:user) { create(:user) }
-    let(:account) { user.approved_accounts.first }
+    let(:account) { create(:account) }
+    let(:token) { StubToken.new(account.id, ['member']) }
 
-    before { @controller.current_user = user }
+    before(:each) do
+      class << @controller; attr_accessor :prx_auth_token; end
+      @controller.prx_auth_token = token
+    end
 
     it 'can create a new story' do
       story_hash = { title: 'create story', set_account_uri: "/api/v1/accounts/#{account.id}" }

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -22,17 +22,4 @@ describe User do
   it 'has a list of accounts' do
     user.accounts.must_equal [user.individual_account]
   end
-
-  describe '#role_for' do
-    let(:membership) { create(:membership, user: user) }
-    let(:account) { membership.account }
-
-    it 'returns the role for a particular account' do
-      user.role_for(account).must_equal membership.role
-    end
-
-    it 'returns nil if the user is not a part of the account' do
-      create(:user).role_for(account).must_be_nil
-    end
-  end
 end

--- a/test/policies/account_policy_test.rb
+++ b/test/policies/account_policy_test.rb
@@ -1,13 +1,14 @@
 require 'test_helper'
 
 describe AccountPolicy do
-  let(:user) { build_stubbed(:user) }
-  let(:user2) { build_stubbed(:user) }
+  let(:admin_token) { StubToken.new(account.id, ['admin']) }
+  let(:member_token) { StubToken.new(account.id, ['member']) }
+  let(:non_member_token) { StubToken.new(account.id + 2, ['admin']) }
   let(:account) { build_stubbed(:account) }
 
   describe '#create?' do
     it 'returns true if user exists' do
-      AccountPolicy.new(user, account).must_allow :create?
+      AccountPolicy.new(member_token, account).must_allow :create?
     end
 
     it 'returns false if user is not present' do
@@ -21,29 +22,21 @@ describe AccountPolicy do
     end
 
     it 'returns false if user is not an approved member' do
-      user.stub(:approved_accounts, []) do
-        AccountPolicy.new(user2, account).wont_allow :update?
-      end
+      AccountPolicy.new(non_member_token, account).wont_allow :update?
     end
 
     it 'returns true if user is a member of the account' do
-      user.stub(:approved_accounts, [account]) do
-        AccountPolicy.new(user, account).must_allow :update?
-      end
+      AccountPolicy.new(member_token, account).must_allow :update?
     end
   end
 
   describe '#destroy?' do
     it 'returns true if user is an admin' do
-      user.stub(:role_for, 'admin') do
-        AccountPolicy.new(user, account).must_allow :destroy?
-      end
+      AccountPolicy.new(admin_token, account).must_allow :destroy?
     end
 
     it 'returns false if user is not an admin' do
-      user.stub(:role_for, nil) do
-        AccountPolicy.new(user, account).wont_allow :destroy?
-      end
+      AccountPolicy.new(member_token, account).wont_allow :destroy?
     end
   end
 end

--- a/test/policies/accountable_policy_test.rb
+++ b/test/policies/accountable_policy_test.rb
@@ -1,10 +1,10 @@
 require 'test_helper'
 
 describe AccountablePolicy do
-  let(:user) { build_stubbed(:user) }
-  let(:mem) { build_stubbed(:membership, user: user) }
-  let(:account) { mem.account }
-  let(:story) { build_stubbed(:story, account: mem.account) }
+  let(:non_member_token) { StubToken.new(account.id + 1, ['no']) }
+  let(:member_token) { StubToken.new(account.id, ['member']) }
+  let(:account) { build_stubbed(:account) }
+  let(:story) { build_stubbed(:story, account: account)}
 
   describe '#update?' do
     it 'returns false if user is not present' do
@@ -12,15 +12,11 @@ describe AccountablePolicy do
     end
 
     it 'returns false if user is not a member of the account' do
-      user.stub(:approved_accounts, []) do
-        AccountablePolicy.new(user, story).wont_allow :update?
-      end
+        AccountablePolicy.new(non_member_token, story).wont_allow :update?
     end
 
     it 'returns true if is a member of the account' do
-      user.stub(:approved_accounts, [account]) do
-        AccountablePolicy.new(user, story).must_allow :update?
-      end
+      AccountablePolicy.new(member_token, story).must_allow :update?
     end
   end
 end

--- a/test/policies/application_policy_test.rb
+++ b/test/policies/application_policy_test.rb
@@ -1,18 +1,18 @@
 require 'test_helper'
 
 describe ApplicationPolicy do
-  let(:user) { 'user' }
-  let(:record) { 'record' }
+  let(:token) { 'token' }
+  let(:resource) { 'resource' }
 
   it 'prevents create' do
-    ApplicationPolicy.new(user, record).wont_allow :create?
+    ApplicationPolicy.new(token, resource).wont_allow :create?
   end
 
   it 'prevents update' do
-    ApplicationPolicy.new(user, record).wont_allow :update?
+    ApplicationPolicy.new(token, resource).wont_allow :update?
   end
 
   it 'prevents destroy' do
-    ApplicationPolicy.new(user, record).wont_allow :destroy?
+    ApplicationPolicy.new(token, resource).wont_allow :destroy?
   end
 end

--- a/test/policies/image_policy_test.rb
+++ b/test/policies/image_policy_test.rb
@@ -1,36 +1,32 @@
 require 'test_helper'
 
 describe ImagePolicy do
-  let(:user) { build_stubbed(:user) }
+  let(:account) { build_stubbed(:account) }
+  let(:member_token) { StubToken.new(account.id, ['member']) }
+  let(:non_member_token) { StubToken.new(account.id + 1, ['no']) }
 
   describe 'series images' do
-    let(:account) { build_stubbed(:account) }
     let(:series) { build_stubbed(:series, account: account) }
     let(:series_image) { build_stubbed(:series_image, series: series) }
 
     it 'returns true if user is a member of account' do
-      user.stub(:approved_accounts, [account]) do
-        ImagePolicy.new(user, series_image).must_allow :update?
-      end
+      ImagePolicy.new(member_token, series_image).must_allow :update?
     end
 
     it 'returns false if user is not a member' do
-      user.stub(:approved_accounts, []) do
-        ImagePolicy.new(user, series_image).wont_allow :update?
-      end
+      ImagePolicy.new(non_member_token, series_image).wont_allow :update?
     end
   end
 
   describe 'user images' do
-    let(:user_image) { build_stubbed(:user_image, user: user) }
-    let(:user2) { build_stubbed(:user) }
+    let(:user_image) { build_stubbed(:user_image, user: User.new(id: member_token.user_id)) }
 
     it 'returns true if users are the same' do
-      ImagePolicy.new(user, user_image).must_allow :update?
+      ImagePolicy.new(member_token, user_image).must_allow :update?
     end
 
     it 'returns false if users are different' do
-      ImagePolicy.new(user2, user_image).wont_allow :update?
+      ImagePolicy.new(non_member_token, user_image).wont_allow :update?
     end
   end
 end

--- a/test/policies/membership_policy_test.rb
+++ b/test/policies/membership_policy_test.rb
@@ -1,68 +1,66 @@
 require 'test_helper'
 
 describe MembershipPolicy do
-  let(:user1) { create(:user) }
-  let(:user2) { create(:user) }
-  let(:mem1) { create(:membership, user: user1) }
-  let(:account) { mem1.account }
-  let(:mem2) { create(:membership,
-                      account: account,
-                      user: user2,
-                      approved: false,
-                      role: 'member') }
+  let(:member_token) { StubToken.new(account.id, ['member']) }
+  let(:admin_token) { StubToken.new(account.id, ['admin']) }
+  let(:non_member_token) { StubToken.new(account.id + 1, ['no']) }
+  let(:membership) { build_stubbed(:membership, user: user, account: account, approved: false) }
+  let(:user) { build_stubbed(:user, id: non_member_token.user_id) }
+  let(:account) { build_stubbed(:account) }
 
   describe '#create?' do
     describe 'when user is admin' do
       it 'returns true' do
-        MembershipPolicy.new(user1, mem1).must_allow :create?
+        MembershipPolicy.new(admin_token, membership).must_allow :create?
       end
     end
 
     describe 'when user is not admin' do
       it 'returns false if user is not the member' do
-        MembershipPolicy.new(user2, mem1).wont_allow :create?
+        membership.user.id = member_token
+        MembershipPolicy.new(non_member_token, membership).wont_allow :create?
       end
 
       it 'returns false if membership is approved' do
-        mem2.approved = true
-        MembershipPolicy.new(user2, mem2).wont_allow :create?
+        membership.approved = true
+        MembershipPolicy.new(non_member_token, membership).wont_allow :create?
       end
 
       it 'returns true otherwise' do
-        MembershipPolicy.new(user2, mem2).must_allow :create?
+        MembershipPolicy.new(non_member_token, membership).must_allow :create?
       end
     end
   end
 
   describe '#update?' do
     it 'returns true if user is admin' do
-      MembershipPolicy.new(user1, mem2).must_allow :update?
+      MembershipPolicy.new(admin_token, membership).must_allow :update?
     end
 
     it 'returns false if user is not a member' do
-      MembershipPolicy.new(create(:user), mem1).wont_allow :update?
+      MembershipPolicy.new(non_member_token, membership).wont_allow :update?
     end
 
     it 'returns false if user is not an admin' do
-      MembershipPolicy.new(user2, mem1).wont_allow :update?
+      MembershipPolicy.new(member_token, membership).wont_allow :update?
     end
 
     it 'returns false if user is not present' do
-      MembershipPolicy.new(nil, mem1).wont_allow :update?
+      MembershipPolicy.new(nil, membership).wont_allow :update?
     end
   end
 
   describe '#destroy?' do
     it 'returns true if user is the member' do
-      MembershipPolicy.new(user1, mem1).must_allow :destroy?
+      MembershipPolicy.new(non_member_token, membership).must_allow :destroy?
     end
 
     it 'returns true if user is an admin' do
-      MembershipPolicy.new(user1, mem2).must_allow :destroy?
+      MembershipPolicy.new(admin_token, membership).must_allow :destroy?
     end
 
     it 'returns false otherwise' do
-      MembershipPolicy.new(user2, mem1).wont_allow :destroy?
+      MembershipPolicy.new(member_token, membership).wont_allow :destroy?
     end
   end
 end

--- a/test/policies/producer_policy_test.rb
+++ b/test/policies/producer_policy_test.rb
@@ -1,23 +1,25 @@
 require 'test_helper'
 
 describe ProducerPolicy do
-  let(:user) { build_stubbed(:user) }
-  let(:producer) { build_stubbed(:producer_with_user_and_story) }
-  let(:story) { producer.story }
+  let(:producer_token) { StubToken.new(story.account_id + 1, ['member']) }
+  let(:member_token) { StubToken.new(story.account_id, ['member']) }
+  let(:non_member_token) { StubToken.new(story.account_id + 1, ['no'])}
+  let(:producer) { build_stubbed(:producer_with_user_and_story, user: user, story: story) }
+  let(:story) { build_stubbed(:story, account: account) }
+  let(:account) { build_stubbed(:account) }
+  let(:user) { build_stubbed(:user, id: producer_token.user_id) }
 
   describe '#update?' do
     it 'returns true if user is the producer' do
-      ProducerPolicy.new(producer.user, producer).must_allow :update?
+      ProducerPolicy.new(producer_token, producer).must_allow :update?
     end
 
     it 'returns true if user is associated with story' do
-      user.stub(:approved_accounts, [story.account]) do
-        ProducerPolicy.new(user, producer).must_allow :update?
-      end
+      ProducerPolicy.new(member_token, producer).must_allow :update?
     end
 
     it 'returns false otherwise' do
-      ProducerPolicy.new(user, producer).wont_allow :update?
+      ProducerPolicy.new(non_member_token, producer).wont_allow :update?
     end
   end
 end

--- a/test/policies/producer_policy_test.rb
+++ b/test/policies/producer_policy_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe ProducerPolicy do
   let(:producer_token) { StubToken.new(story.account_id + 1, ['member']) }
   let(:member_token) { StubToken.new(story.account_id, ['member']) }
-  let(:non_member_token) { StubToken.new(story.account_id + 1, ['no'])}
+  let(:non_member_token) { StubToken.new(story.account_id + 1, ['no']) }
   let(:producer) { build_stubbed(:producer_with_user_and_story, user: user, story: story) }
   let(:story) { build_stubbed(:story, account: account) }
   let(:account) { build_stubbed(:account) }

--- a/test/policies/story_attribute_policy_test.rb
+++ b/test/policies/story_attribute_policy_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe StoryAttributePolicy do
   describe '#update?' do
     let(:member_token) { StubToken.new(story.account_id, ['member']) }
-    let(:non_member_token) { StubToken.new(story.account_id + 1, ['no'])}
+    let(:n_m_token) { StubToken.new(story.account_id + 1, ['no']) }
     let(:story) { build_stubbed(:story) }
     let(:musical_work) { build_stubbed(:musical_work, story: story) }
 
@@ -16,7 +16,7 @@ describe StoryAttributePolicy do
     end
 
     it 'returns false if user is not a member of story account' do
-      StoryAttributePolicy.new(non_member_token, musical_work).wont_allow :update?
+      StoryAttributePolicy.new(n_m_token, musical_work).wont_allow :update?
     end
   end
 end

--- a/test/policies/story_attribute_policy_test.rb
+++ b/test/policies/story_attribute_policy_test.rb
@@ -2,25 +2,21 @@ require 'test_helper'
 
 describe StoryAttributePolicy do
   describe '#update?' do
-    let(:user) { build_stubbed(:user) }
-    let(:user2) { build_stubbed(:user) }
+    let(:member_token) { StubToken.new(story.account_id, ['member']) }
+    let(:non_member_token) { StubToken.new(story.account_id + 1, ['no'])}
     let(:story) { build_stubbed(:story) }
     let(:musical_work) { build_stubbed(:musical_work, story: story) }
 
     it 'returns true if user is a member of story account' do
-      user.stub(:approved_accounts, [story.account]) do
-        StoryAttributePolicy.new(user, musical_work).must_allow :update?
-      end
+      StoryAttributePolicy.new(member_token, musical_work).must_allow :update?
     end
 
     it 'returns false if user is not present' do
-      StoryAttributePolicy.new(user, musical_work).wont_allow :update?
+      StoryAttributePolicy.new(nil, musical_work).wont_allow :update?
     end
 
     it 'returns false if user is not a member of story account' do
-      user.stub(:approved_accounts, []) do
-        StoryAttributePolicy.new(user2, musical_work).wont_allow :update?
-      end
+      StoryAttributePolicy.new(non_member_token, musical_work).wont_allow :update?
     end
   end
 end

--- a/test/policies/user_policy_test.rb
+++ b/test/policies/user_policy_test.rb
@@ -1,16 +1,17 @@
 require 'test_helper'
 
 describe UserPolicy do
-  let(:user1) { build_stubbed(:user) }
-  let(:user2) { build_stubbed(:user) }
+  let(:user_token) { StubToken.new(123, ['member']) }
+  let(:other_token) { StubToken.new(123, ['member']) }
+  let(:user) { build_stubbed(:user, id: user_token.user_id) }
 
   describe '#update?' do
     it 'lets users update themselves' do
-      UserPolicy.new(user1, user1).must_allow :update?
+      UserPolicy.new(user_token, user).must_allow :update?
     end
 
     it 'does not let users update each other' do
-      UserPolicy.new(user1, user2).wont_allow :update?
+      UserPolicy.new(other_token, user).wont_allow :update?
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,18 +51,18 @@ end
 Minitest::Expectations.infect_an_assertion :assert_operator, :must_allow, :reverse
 Minitest::Expectations.infect_an_assertion :refute_operator, :wont_allow, :reverse
 
-
 include Announce::Testing
 reset_announce
 
-class StubToken < Struct.new(:resource, :scopes, :user_id)
+StubToken = Struct.new(:resource, :scopes, :user_id)
+class StubToken
   @@user_id = 0
 
   def initialize(res, scopes)
     super(res.to_s, scopes, @@user_id += 1)
   end
 
-  def authorized?(r, s=nil)
+  def authorized?(r, s = nil)
     resource == r.to_s && (s.nil? || scopes.include?(s.to_s))
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,5 +51,18 @@ end
 Minitest::Expectations.infect_an_assertion :assert_operator, :must_allow, :reverse
 Minitest::Expectations.infect_an_assertion :refute_operator, :wont_allow, :reverse
 
+
 include Announce::Testing
 reset_announce
+
+class StubToken < Struct.new(:resource, :scopes, :user_id)
+  @@user_id = 0
+
+  def initialize(res, scopes)
+    super(res.to_s, scopes, @@user_id += 1)
+  end
+
+  def authorized?(r, s=nil)
+    resource == r.to_s && (s.nil? || scopes.include?(s.to_s))
+  end
+end


### PR DESCRIPTION
For the purposes of authorization, rely on the information encoded in the
signed token instead of going to the database.

This allows us to start making tokens that do not line up perfectly with what is
stored in the database (i.e. application agents, which are not members of the
accounts but are still granted permissions) and also allows us to issue tokens
that only work on a subset of the permissions a given user actually possesses.

There are a couple of holdouts here. For one, the `authorization` endpoint still
relies on the `memberships` table to show the accounts that the user associated
with the currently active token has access to. We're also being a little fast
and loose with our use of scopes – most checks are for the mere presence of the
account identifier in the token, regardless of scopes granted. Those that do
look for a specific scope are checking for the `admin` scope which is, at best,
a meta-scope which encompasses several more specific ones. Those should be
specified further.