### PR TITLE
Fix cross origin requests

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -45,7 +45,7 @@ module PRX
 
       allow do
         origins '*'
-        resource '/api/*', methods: [:get]
+        resource '/api/*', methods: [:get], headers: :any
       end
     end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,7 +39,7 @@ module PRX
 
     config.middleware.insert_after Rails::Rack::Logger, Rack::Cors do
       allow do
-        origins /.*\.prx\.(?:org|dev)$/
+        origins /.*\.prx\.(?:org|dev|tech)$/
         resource '/api/*', methods: [:get, :put, :post, :options], headers: :any
       end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,7 +45,7 @@ module PRX
 
       allow do
         origins '*'
-        resource '/api/*', methods: [:get], headers: :any
+        resource '/api/*', methods: [:get]
       end
     end
 


### PR DESCRIPTION
Adding `headers: :any` to allow non-whitelisted domains to do the preflight `Access-Control-Request-Method: GET`.

Also whitelisted the `prx.tech` domain.