### PR TITLE
Include created/updated timestamps

### DIFF
--- a/app/representers/api/min/story_representer.rb
+++ b/app/representers/api/min/story_representer.rb
@@ -7,6 +7,8 @@ class Api::Min::StoryRepresenter < Api::BaseRepresenter
   property :short_description
   property :episode_number
   property :episode_identifier
+  property :created_at, writeable: false
+  property :updated_at, writeable: false
   property :published_at, writeable: false
   property :produced_on
 

--- a/app/representers/api/story_representer.rb
+++ b/app/representers/api/story_representer.rb
@@ -7,6 +7,8 @@ class Api::StoryRepresenter < Api::BaseRepresenter
   property :short_description
   property :episode_number
   property :episode_identifier
+  property :created_at, writeable: false
+  property :updated_at, writeable: false
   property :published_at, writeable: false
   property :produced_on
 

--- a/test/representers/api/story_representer_test.rb
+++ b/test/representers/api/story_representer_test.rb
@@ -90,6 +90,20 @@ describe Api::StoryRepresenter do
         json['tags'].must_equal tags
       end
     end
+
+    it 'includes the created date' do
+      date = DateTime.parse('1999-12-31 23:59:59')
+      story.stub(:created_at, date) do
+        DateTime.parse(json['createdAt']).must_equal(date)
+      end
+    end
+
+    it 'includes the updated date' do
+      date = DateTime.parse('1970-01-01 00:01:00')
+      story.stub(:updated_at, date) do
+        DateTime.parse(json['updatedAt']).must_equal(date)
+      end
+    end
   end
 
   describe 'series info' do


### PR DESCRIPTION
Need to know the `updatedAt` date of un-published stories, for the publish.prx.org app.  Also included `createdAt`, for good measure.