### PR TITLE
Audio file fields

### DIFF
--- a/app/controllers/api/audio_files_controller.rb
+++ b/app/controllers/api/audio_files_controller.rb
@@ -22,6 +22,9 @@ class Api::AudioFilesController < Api::BaseController
         af.audio_version_id ||= story.default_audio_version.id
         af.account_id ||= story.account_id
       end
+      if af.audio_version_id && !af.account_id
+        af.account_id ||= af.audio_version.story.account_id
+      end
     end
   end
 

--- a/app/representers/api/audio_file_representer.rb
+++ b/app/representers/api/audio_file_representer.rb
@@ -3,8 +3,11 @@
 class Api::AudioFileRepresenter < Api::BaseRepresenter
 
   property :id, writeable: false
+  property :position
+
   property :filename
   property :label
+  property :status, writeable: false
   property :size
   property :duration
 

--- a/test/controllers/api/audio_files_controller_test.rb
+++ b/test/controllers/api/audio_files_controller_test.rb
@@ -5,6 +5,7 @@ describe Api::AudioFilesController do
   let(:token) { StubToken.new(account.id, ['member']) }
   let(:story) { create(:story, account: account) }
   let(:audio_file) { create(:audio_file, story: story, account: account) }
+  let(:audio_version) { audio_file.audio_version }
 
   before(:each) do
     class << @controller; attr_accessor :prx_auth_token; end
@@ -32,6 +33,17 @@ describe Api::AudioFilesController do
       }
       @request.env['CONTENT_TYPE'] = 'application/json'
       post :create, af_hash.to_json, api_request_opts(story_id: story.id)
+      assert_response :success
+    end
+
+    it 'can create an audio file for an audio version' do
+      af_hash = {
+        upload: "http://thisisatest.com/guid1/test.mp3",
+        size: 1024,
+        duration: 30
+      }
+      @request.env['CONTENT_TYPE'] = 'application/json'
+      post :create, af_hash.to_json, api_request_opts(audio_version_id: audio_version.id)
       assert_response :success
     end
 

--- a/test/controllers/api/audio_files_controller_test.rb
+++ b/test/controllers/api/audio_files_controller_test.rb
@@ -38,7 +38,7 @@ describe Api::AudioFilesController do
 
     it 'can create an audio file for an audio version' do
       af_hash = {
-        upload: "http://thisisatest.com/guid1/test.mp3",
+        upload: 'http://thisisatest.com/guid1/test.mp3',
         size: 1024,
         duration: 30
       }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,7 @@ ENV['META_HOST'] = 'meta.prx.org'
 
 require 'simplecov' if !ENV['GUARD'] || ENV['GUARD_COVERAGE']
 
-ENV['action_dispatch.logger'] = Rails.logger
+ENV['action_dispatch.logger'] = Rails.logger if defined? Rails
 
 if ENV['TRAVIS']
   require 'codeclimate-test-reporter'


### PR DESCRIPTION
Updates for publish.prx.org file uploading:

- Add the writeable `position`
- Add the read-only `status`
- Infer `account_id` through the `audio_version.story.account_id`, if possible.  So when POSTing new files through the `/audio_versions/:id/audio_files`, they get that implicit account set.