### PR TITLE
Don't automagically create story versions

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -52,10 +52,6 @@ class Story < BaseModel
   # indicates the piece is not publically available, only to the network
   event_attribute :network_only_at
 
-  after_create do
-    audio_versions.create(label: 'Main Audio')
-  end
-
   scope :published, -> { where('`published_at` IS NOT NULL AND `network_only_at` IS NULL') }
 
   scope :unpublished, -> { where('`published_at` IS NULL') }

--- a/test/controllers/api/audio_files_controller_test.rb
+++ b/test/controllers/api/audio_files_controller_test.rb
@@ -4,6 +4,7 @@ describe Api::AudioFilesController do
   let(:account) { create(:account) }
   let(:token) { StubToken.new(account.id, ['member']) }
   let(:story) { create(:story, account: account) }
+  let(:story_with_version) { create(:story_with_audio, account: account) }
   let(:audio_file) { create(:audio_file, story: story, account: account) }
   let(:audio_version) { audio_file.audio_version }
 
@@ -32,7 +33,7 @@ describe Api::AudioFilesController do
         duration: 30
       }
       @request.env['CONTENT_TYPE'] = 'application/json'
-      post :create, af_hash.to_json, api_request_opts(story_id: story.id)
+      post :create, af_hash.to_json, api_request_opts(story_id: story_with_version.id)
       assert_response :success
     end
 


### PR DESCRIPTION
It's easier for publish to manage its own audio-versions, rather then get one automatically added along with the new story.