### PR TITLE
Async image processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ capybara-*.html
 /tmp/*
 /db/*.sqlite3
 /public/system/*
+/public/uploads/
 /coverage/
 /spec/tmp/*
 **.orig

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ADD Gemfile.lock ./
 
 RUN apk --update add --virtual build-dependencies build-base ruby-dev openssl-dev \
     zlib-dev libxml2-dev libxslt-dev libffi-dev && \
-    apk add imagemagick less && \
+    apk add less && \
     gem install -N bundler && \
     cd $APP_HOME ; \
     bundle config --global build.nokogiri  "--use-system-libraries" && \

--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,6 @@ group :development do
   gem 'quiet_assets'
   gem 'better_errors'
   gem 'binding_of_caller'
-  gem 'growl'
   gem 'guard', '~> 2.10.0'
   gem 'guard-minitest'
   gem 'guard-bundler'

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'mini_magick'
 
 ## Controller
 gem 'responders', '~> 2.0'
-gem 'hal_api-rails', '0.2.7'
+gem 'hal_api-rails', '0.2.8'
 
 # auth
 gem 'rack-cors', require: 'rack/cors'

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ gem 'event_attribute'
 gem 'carrierwave'
 gem 'fog'
 gem 'unf'
-gem 'mini_magick'
 
 ## Controller
 gem 'responders', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,7 +219,7 @@ GEM
     guard-minitest (2.4.4)
       guard-compat (~> 1.2)
       minitest (>= 3.0)
-    hal_api-rails (0.2.7)
+    hal_api-rails (0.2.8)
       actionpack (>= 3.0.0)
       activemodel (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -425,7 +425,7 @@ DEPENDENCIES
   guard (~> 2.10.0)
   guard-bundler
   guard-minitest
-  hal_api-rails (= 0.2.7)
+  hal_api-rails (= 0.2.8)
   highline
   kaminari
   mini_magick

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,7 +254,6 @@ GEM
       mime-types (>= 1.16, < 4)
     method_source (0.8.2)
     mime-types (2.99.1)
-    mini_magick (4.5.1)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
     minitest-around (0.3.2)
@@ -426,7 +425,6 @@ DEPENDENCIES
   hal_api-rails (= 0.2.8)
   highline
   kaminari
-  mini_magick
   minitest-around
   minitest-reporters
   minitest-spec-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,7 +203,6 @@ GEM
     formatador (0.2.5)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
-    growl (1.0.3)
     guard (2.10.5)
       formatador (>= 0.2.4)
       listen (~> 2.7)
@@ -421,7 +420,6 @@ DEPENDENCIES
   event_attribute
   factory_girl_rails
   fog
-  growl
   guard (~> 2.10.0)
   guard-bundler
   guard-minitest

--- a/Guardfile
+++ b/Guardfile
@@ -1,8 +1,6 @@
 # A sample Guardfile
 # More info at https://github.com/guard/guard#readme
 
-notification :growl
-
 guard :minitest, spring: true, env: {GUARD: 'true'}, all_env: :GUARD_COVERAGE, all_after_pass: false do
   watch(%r{^test/(.*)\/?test_(.*)\.rb})
   watch(%r{^lib/(.*/)?([^/]+)\.rb})                      { |m| "test/#{m[1]}test_#{m[2]}.rb" }

--- a/app/controllers/api/audio_files_controller.rb
+++ b/app/controllers/api/audio_files_controller.rb
@@ -6,6 +6,8 @@ class Api::AudioFilesController < Api::BaseController
 
   filter_resources_by :audio_version_id, :account_id
 
+  announce_actions decorator: Api::Msg::AudioFileRepresenter, subject: :audio
+
   def original
     authorize show_resource
     redirect_to show_resource.asset_url(original_params)

--- a/app/controllers/api/story_images_controller.rb
+++ b/app/controllers/api/story_images_controller.rb
@@ -6,5 +6,7 @@ class Api::StoryImagesController < Api::BaseController
 
   filter_resources_by :story_id
 
+  announce_actions decorator: Api::ImageRepresenter, subject: :image
+
   represent_with Api::ImageRepresenter
 end

--- a/app/controllers/api/story_images_controller.rb
+++ b/app/controllers/api/story_images_controller.rb
@@ -6,7 +6,7 @@ class Api::StoryImagesController < Api::BaseController
 
   filter_resources_by :story_id
 
-  announce_actions decorator: Api::ImageRepresenter, subject: :image
+  announce_actions decorator: Api::Msg::ImageRepresenter, subject: :image
 
   represent_with Api::ImageRepresenter
 end

--- a/app/controllers/concerns/announce_actions.rb
+++ b/app/controllers/concerns/announce_actions.rb
@@ -40,7 +40,7 @@ module AnnounceActions
     end
 
     def new_announce_filter(action, options)
-      filter_options = options.slice(:action, :decorator)
+      filter_options = options.slice(:action, :decorator, :subject)
       filter_options[:action] ||= 'delete' if action.to_s == 'destroy'
       AnnounceActions::AnnounceFilter.new(action, filter_options)
     end

--- a/app/controllers/concerns/announce_actions/announce_filter.rb
+++ b/app/controllers/concerns/announce_actions/announce_filter.rb
@@ -42,7 +42,6 @@ module AnnounceActions
     def decorator_class(controller)
       return options[:decorator] if options[:decorator]
       resource_class = controller.controller_name.singularize.camelize
-      "Api::Msg::#{resource_class}Representer".safe_constantize ||
       "Api::Min::#{resource_class}Representer".safe_constantize ||
         "Api::#{resource_class}Representer".safe_constantize
     end

--- a/app/controllers/concerns/announce_actions/announce_filter.rb
+++ b/app/controllers/concerns/announce_actions/announce_filter.rb
@@ -42,6 +42,7 @@ module AnnounceActions
     def decorator_class(controller)
       return options[:decorator] if options[:decorator]
       resource_class = controller.controller_name.singularize.camelize
+      "Api::Msg::#{resource_class}Representer".safe_constantize ||
       "Api::Min::#{resource_class}Representer".safe_constantize ||
         "Api::#{resource_class}Representer".safe_constantize
     end

--- a/app/controllers/concerns/announce_actions/announce_filter.rb
+++ b/app/controllers/concerns/announce_actions/announce_filter.rb
@@ -16,8 +16,11 @@ module AnnounceActions
     end
 
     def after(controller)
-      subject = controller.controller_name.singularize
+      subject = (options[:subject] || controller.controller_name).to_s.singularize
       announce(subject, resource_action, decorated_resource(controller))
+    rescue Aws::SNS::Errors::NotFound => e
+      Rails.logger.error("Non-existent SNS topic: #{Rails.env.downcase}_announce_#{subject}_#{action}")
+      raise e
     end
 
     def resource_action

--- a/app/models/audio_file.rb
+++ b/app/models/audio_file.rb
@@ -26,6 +26,7 @@ class AudioFile < BaseModel
   alias_attribute :duration, :length
 
   mount_uploader :file, AudioFileUploader, mount_on: :filename
+  skip_callback :commit, :after, :remove_file! # don't remove s3 file
   fixerable_upload :upload, :file
 
   before_validation do

--- a/app/models/audio_file.rb
+++ b/app/models/audio_file.rb
@@ -6,13 +6,20 @@ class AudioFile < BaseModel
   include Fixerable
 
   UPLOADED         = 'uploaded'
+  NOTFOUND         = 'not found'
   VALIDATING       = 'validating'
   VALID            = 'valid'
   INVALID          = 'invalid'
+  FAILED           = 'failed'
   COMPLETE         = 'complete'
   TRANSFORMING     = 'creating mp3s'
   TRANSFORM_FAILED = 'creating mp3s failed'
   TRANSFORMED      = 'mp3s created'
+
+  SINGLE_CHANNEL = 'Single Channel'
+  DUAL_CHANNEL   = 'Dual Channel'
+  STEREO         = 'Stereo'
+  JOINT_STEREO   = 'JStereo'
 
   belongs_to :account
 

--- a/app/models/audio_file.rb
+++ b/app/models/audio_file.rb
@@ -5,21 +5,21 @@ class AudioFile < BaseModel
   include PublicAsset
   include Fixerable
 
-  UPLOADED         = 'uploaded'
-  NOTFOUND         = 'not found'
-  VALIDATING       = 'validating'
-  VALID            = 'valid'
-  INVALID          = 'invalid'
-  FAILED           = 'failed'
-  COMPLETE         = 'complete'
-  TRANSFORMING     = 'creating mp3s'
-  TRANSFORM_FAILED = 'creating mp3s failed'
-  TRANSFORMED      = 'mp3s created'
+  UPLOADED         = 'uploaded'.freeze
+  NOTFOUND         = 'not found'.freeze
+  VALIDATING       = 'validating'.freeze
+  VALID            = 'valid'.freeze
+  INVALID          = 'invalid'.freeze
+  FAILED           = 'failed'.freeze
+  COMPLETE         = 'complete'.freeze
+  TRANSFORMING     = 'creating mp3s'.freeze
+  TRANSFORM_FAILED = 'creating mp3s failed'.freeze
+  TRANSFORMED      = 'mp3s created'.freeze
 
-  SINGLE_CHANNEL = 'Single Channel'
-  DUAL_CHANNEL   = 'Dual Channel'
-  STEREO         = 'Stereo'
-  JOINT_STEREO   = 'JStereo'
+  SINGLE_CHANNEL = 'Single Channel'.freeze
+  DUAL_CHANNEL   = 'Dual Channel'.freeze
+  STEREO         = 'Stereo'.freeze
+  JOINT_STEREO   = 'JStereo'.freeze
 
   belongs_to :account
 

--- a/app/models/concerns/fixerable.rb
+++ b/app/models/concerns/fixerable.rb
@@ -9,6 +9,19 @@ module Fixerable
     def fixerable_upload(temp_field, final_field)
       @fixerable_temp_field = temp_field
       @fixerable_final_field = final_field
+
+      # alias filename field until upload has completed
+      mask_field = final_field
+      if try(:uploader_options) && uploader_options[final_field] && uploader_options[final_field][:mount_on]
+        mask_field = uploader_options[final_field][:mount_on]
+      end
+      define_method mask_field do
+        if fixerable_final?
+          read_attribute(mask_field)
+        else
+          public_asset_filename
+        end
+      end
     end
 
     def fixtemp
@@ -102,6 +115,10 @@ module Fixerable
       f.fog_authenticated_url_expiration = options[:expiration].to_i
     end
     f.url
+  end
+
+  def fixerable_final_path
+    fixfinal.store_dir
   end
 
   # temporary location

--- a/app/models/concerns/fixerable.rb
+++ b/app/models/concerns/fixerable.rb
@@ -80,8 +80,11 @@ module Fixerable
 
   # override public asset filename
   def public_asset_filename
-    f = fixfinal.path || URI.parse(fixtemp || '').path
-    File.basename(f) if f
+    if fixerable_final?
+      File.basename(fixfinal.path)
+    else
+      File.basename(URI.parse(fixtemp || '').path)
+    end
   end
 
   # has upload been copied to final destination?

--- a/app/models/concerns/fixerable.rb
+++ b/app/models/concerns/fixerable.rb
@@ -12,11 +12,11 @@ module Fixerable
     end
 
     def fixtemp
-      @fixerable_temp_field
+      @fixerable_temp_field || superclass.try(:fixtemp)
     end
 
     def fixfinal
-      @fixerable_final_field
+      @fixerable_final_field || superclass.try(:fixfinal)
     end
 
     def fixerable_storage

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -8,7 +8,9 @@ class Image < BaseModel
   include Fixerable
 
   UPLOADED = 'uploaded'.freeze
+  NOTFOUND = 'not found'.freeze
   INVALID  = 'invalid'.freeze
+  FAILED   = 'failed'.freeze
   COMPLETE = 'complete'.freeze
 
   alias_attribute :upload, :upload_path

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -7,9 +7,9 @@ class Image < BaseModel
   include PublicAsset
   include Fixerable
 
-  UPLOADED = 'uploaded'
-  INVALID  = 'invalid'
-  COMPLETE = 'complete'
+  UPLOADED = 'uploaded'.freeze
+  INVALID  = 'invalid'.freeze
+  COMPLETE = 'complete'.freeze
 
   alias_attribute :upload, :upload_path
 

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -16,6 +16,7 @@ class Image < BaseModel
   alias_attribute :upload, :upload_path
 
   mount_uploader :file, ImageUploader, mount_on: :filename
+  skip_callback :commit, :after, :remove_file! # don't remove s3 file
   fixerable_upload :upload, :file
 
   before_validation do

--- a/app/representers/api/audio_file_representer.rb
+++ b/app/representers/api/audio_file_representer.rb
@@ -5,7 +5,7 @@ class Api::AudioFileRepresenter < Api::BaseRepresenter
   property :id, writeable: false
   property :position
 
-  property :filename
+  property :filename, writeable: false
   property :label
   property :status, writeable: false
   property :size

--- a/app/representers/api/image_representer.rb
+++ b/app/representers/api/image_representer.rb
@@ -17,7 +17,7 @@ class Api::ImageRepresenter < Api::BaseRepresenter
   end
 
   property :id, writeable: false
-  property :filename
+  property :filename, writeable: false
   property :size
   property :caption
   property :credit

--- a/app/representers/api/image_representer.rb
+++ b/app/representers/api/image_representer.rb
@@ -17,18 +17,24 @@ class Api::ImageRepresenter < Api::BaseRepresenter
   end
 
   property :id, writeable: false
-  property :filename, writeable: false
+  property :filename
   property :size
   property :caption
   property :credit
 
-  # provide either an accessible url or the file itself for upload
+  # provide an accessible url to the image media file for upload
   property :upload, readable: false
-  property :file, readable: false
 
   link :enclosure do
     {
       href: represented.public_url(version: 'medium'),
+      type: represented.content_type || 'image'
+    } if represented.id
+  end
+
+  link :original do
+    {
+      href: represented.public_url(version: 'original'),
       type: represented.content_type || 'image'
     } if represented.id
   end

--- a/app/representers/api/image_representer.rb
+++ b/app/representers/api/image_representer.rb
@@ -21,6 +21,7 @@ class Api::ImageRepresenter < Api::BaseRepresenter
   property :size
   property :caption
   property :credit
+  property :status, writeable: false
 
   # provide an accessible url to the image media file for upload
   property :upload, readable: false

--- a/app/representers/api/msg/audio_file_representer.rb
+++ b/app/representers/api/msg/audio_file_representer.rb
@@ -6,7 +6,7 @@
 class Api::Msg::AudioFileRepresenter < Api::BaseRepresenter
 
   property :id, writeable: false
-  property :filename
+  property :filename, writeable: false
   property :size
   property :status, writeable: false
 

--- a/app/representers/api/msg/audio_file_representer.rb
+++ b/app/representers/api/msg/audio_file_representer.rb
@@ -1,0 +1,19 @@
+# encoding: utf-8
+
+#
+# Representer for Announce messaging
+#
+class Api::Msg::AudioFileRepresenter < Api::BaseRepresenter
+
+  property :id, writeable: false
+  property :filename
+  property :size
+  property :status, writeable: false
+
+  # the newly uploaded file
+  property :upload_path
+
+  # destination for the uploaded file
+  property :fixerable_final_path, as: :destination_path
+
+end

--- a/app/representers/api/msg/image_representer.rb
+++ b/app/representers/api/msg/image_representer.rb
@@ -12,6 +12,12 @@ class Api::Msg::ImageRepresenter < Api::BaseRepresenter
   property :credit
   property :status, writeable: false
 
+  # parent id (useful to identify soft-deleted images in s3)
+  property :piece_id, writeable: false, if: -> (*) { is_a?(StoryImage) }
+  property :series_id, writeable: false, if: -> (*) { is_a?(SeriesImage) }
+  property :account_id, writeable: false, if: -> (*) { is_a?(AccountImage) }
+  property :user_id, writeable: false, if: -> (*) { is_a?(UserImage) }
+
   # the newly uploaded file
   property :upload_path
 

--- a/app/representers/api/msg/image_representer.rb
+++ b/app/representers/api/msg/image_representer.rb
@@ -1,0 +1,21 @@
+# encoding: utf-8
+
+#
+# Representer for Announce messaging
+#
+class Api::Msg::ImageRepresenter < Api::BaseRepresenter
+
+  property :id, writeable: false
+  property :filename
+  property :size
+  property :caption
+  property :credit
+  property :status, writeable: false
+
+  # the newly uploaded file
+  property :upload_path
+
+  # destination for the uploaded file
+  property :fixerable_final_path, as: :destination_path
+
+end

--- a/app/representers/api/msg/image_representer.rb
+++ b/app/representers/api/msg/image_representer.rb
@@ -6,7 +6,7 @@
 class Api::Msg::ImageRepresenter < Api::BaseRepresenter
 
   property :id, writeable: false
-  property :filename
+  property :filename, writeable: false
   property :size
   property :caption
   property :credit

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,9 +1,6 @@
 # encoding: utf-8
-# require 'carrierwave/processing/mini_magick'
 
 class ImageUploader < CarrierWave::Uploader::Base
-
-  include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
   storage :fog

--- a/app/workers/audio_callback_worker.rb
+++ b/app/workers/audio_callback_worker.rb
@@ -24,13 +24,11 @@ class AudioCallbackWorker
     # TODO: not quite sure how to get this from ffprobe
     # job['channels'] = ffmpeg.channels
     # job['layout'] = ffmpeg.channel_layout
-    if job['channels'] == 2
-      audio.channel_mode = AudioFile::STEREO
-    elsif job['channels'] == 1
-      audio.channel_mode = AudioFile::SINGLE_CHANNEL
-    else
-      audio.channel_mode = nil
-    end
+    audio.channel_mode = if job['channels'] == 2
+                           AudioFile::STEREO
+                         elsif job['channels'] == 1
+                           AudioFile::SINGLE_CHANNEL
+                         end
 
     if !job['downloaded']
       audio.status = AudioFile::NOTFOUND

--- a/app/workers/audio_callback_worker.rb
+++ b/app/workers/audio_callback_worker.rb
@@ -1,0 +1,52 @@
+class AudioCallbackWorker
+  include Shoryuken::Worker
+
+  class UnknownAudioTypeError < StandardError; end
+
+  shoryuken_options queue: "#{ENV['RAILS_ENV']}_cms_audio_callback"
+
+  def perform(_sqs_msg, job)
+    audio = AudioFile.find(job['id'])
+    audio.filename = job['name']
+    audio.length = job['duration']
+    audio.size = job['size']
+    audio.bit_rate = (job['bitrate'] || 0) / 1000
+    audio.frequency = (job['frequency'] || 0) / 1000.0
+
+    # decode content type and mpeg layer from basic "format" string
+    mime_types = MIME::Types.type_for(job['format']).map(&:to_s)
+    prefer_type = mime_types.find { |t| t.starts_with?('audio') }
+    audio.content_type = prefer_type || mime_types.first || job['format']
+
+    # get layer from mp2/3/4 format string
+    audio.layer = (job['format'] || '').match(/mp(\d)/).try(:[], 1).to_i
+
+    # TODO: not quite sure how to get this from ffprobe
+    # job['channels'] = ffmpeg.channels
+    # job['layout'] = ffmpeg.channel_layout
+    if job['channels'] == 2
+      audio.channel_mode = AudioFile::STEREO
+    elsif job['channels'] == 1
+      audio.channel_mode = AudioFile::SINGLE_CHANNEL
+    else
+      audio.channel_mode = nil
+    end
+
+    if !job['downloaded']
+      audio.status = AudioFile::NOTFOUND
+    elsif !job['valid']
+      audio.status = AudioFile::INVALID
+    elsif !job['processed']
+      audio.status = AudioFile::FAILED
+    else
+      audio.upload_path = nil
+      audio.status = AudioFile::COMPLETE
+    end
+
+    Shoryuken.logger.info("Updating #{job['type']}[#{audio.id}]: status => #{audio.status}")
+    audio.save!
+  rescue ActiveRecord::RecordNotFound
+    Shoryuken.logger.error("Record #{job['type']}[#{job['id']}] not found")
+  end
+
+end

--- a/app/workers/image_callback_worker.rb
+++ b/app/workers/image_callback_worker.rb
@@ -1,0 +1,47 @@
+class ImageCallbackWorker
+  include Shoryuken::Worker
+
+  shoryuken_options queue: "#{ENV['RAILS_ENV']}_cms_image_callback"
+
+  def perform(sqs_msg, job)
+    image = case job['type']
+            when 'account_images'
+              AccountImage.find(job['id'])
+            when 'piece_images'
+              StoryImage.find(job['id'])
+            when 'series_images'
+              SeriesImage.find(job['id'])
+            when 'user_images'
+              UserImage.find(job['id'])
+            else
+              Shoryuken.logger.error("Unknown image type for message: #{job}")
+              return
+            end
+
+    image.filename = job['name']
+    image.size = job['size']
+    image.width = job['width']
+    image.height = job['height']
+    image.aspect_ratio = image.width / image.height.to_f if image.width && image.height
+
+    mime_type = MIME::Types.type_for(job['format']).first.try(:content_type)
+    image.content_type = mime_type || job['format']
+
+    if !job['downloaded']
+      image.status = Image::NOTFOUND
+    elsif !job['valid']
+      image.status = Image::INVALID
+    elsif !job['resized']
+      image.status = Image::FAILED
+    else
+      image.upload_path = nil
+      image.status = Image::COMPLETE
+    end
+
+    Shoryuken.logger.info("Updating #{job['type']}[#{image.id}]: status => #{image.status}")
+    image.save!
+  rescue ActiveRecord::RecordNotFound
+    Shoryuken.logger.error("Record #{job['type']}[#{job['id']}] not found")
+  end
+
+end

--- a/bin/application
+++ b/bin/application
@@ -27,7 +27,7 @@ ApplicationRun () {
     CMD="bundle exec puma -C config/puma.rb"
   elif [ "$PROCESS" = "worker" ] ; then
     ApplicationUpdate
-    CMD="bundle exec shoryuken --verbose --rails --config config/shoryuken.yml"
+    CMD="bundle exec shoryuken --rails --config config/shoryuken.yml"
   elif [ "$PROCESS" = "testsetup" ] ; then
     CMD="bundle exec rake db:create RAILS_ENV=test"
   elif [ "$PROCESS" = "test" ] ; then

--- a/bin/application
+++ b/bin/application
@@ -3,23 +3,31 @@
 PROCESS=
 CMD_ARGS=
 
-CmsUsage () {
-  echo "usage: application [ help | web | migrate | test | -- ]"
+ApplicationUsage () {
+  echo "usage: application [ help | web | worker | testsetup | test | guard | setup | sqs | -- ]"
 }
 
-CmsParseOpts () {
+ApplicationParseOpts () {
   PROCESS=$1
   shift
   CMD_ARGS=$*
 }
 
-CmsRun () {
+ApplicationUpdate () {
+  bundle exec rake -vt sqs:create announce:configure_broker db:create
+}
+
+ApplicationRun () {
   CMD=
   if [ "$PROCESS" = "help" ] ; then
-    CmsUsage
+    ApplicationUsage
     exit
   elif [ "$PROCESS" = "web" ] ; then
+    ApplicationUpdate
     CMD="bundle exec puma -C config/puma.rb"
+  elif [ "$PROCESS" = "worker" ] ; then
+    ApplicationUpdate
+    CMD="bundle exec shoryuken --verbose --rails --config config/shoryuken.yml"
   elif [ "$PROCESS" = "testsetup" ] ; then
     CMD="bundle exec rake db:create RAILS_ENV=test"
   elif [ "$PROCESS" = "test" ] ; then
@@ -28,16 +36,18 @@ CmsRun () {
     CMD="bundle exec guard"
   elif [ "$PROCESS" = "setup" ] ; then
     CMD="bundle exec rake -vt db:setup"
+  elif [ "$PROCESS" = "sqs" ] ; then
+    CMD="bundle exec rake -vt sqs:create announce:configure_broker"
   elif [ "$PROCESS" = "--" ] ; then
     CMD=
   else
     echo "ERROR: $PROCESS is not a valid command."
-    CmsUsage
+    ApplicationUsage
     exit
   fi
 
   $CMD $CMD_ARGS
 }
 
-CmsParseOpts $*
-CmsRun
+ApplicationParseOpts $*
+ApplicationRun

--- a/config/announce.yml
+++ b/config/announce.yml
@@ -8,3 +8,7 @@ publish:
     - delete
     - publish
     - unpublish
+  image:
+    - create
+    - update
+    - delete

--- a/config/announce.yml
+++ b/config/announce.yml
@@ -12,3 +12,7 @@ publish:
     - create
     - update
     - delete
+  audio:
+    - create
+    - update
+    - delete

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,7 @@ module PRX
     config.i18n.default_locale = :en
 
     config.autoload_paths += %W( #{config.root}/app/representers/concerns )
+    config.autoload_paths += %W( #{config.root}/app/workers )
 
     # Disable the asset pipeline.
     config.assets.enabled = false

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -27,6 +27,9 @@ PRX::Application.configure do
   # Raise an error on page load if there are pending migrations
   config.active_record.migration_error = :page_load
 
+  # Better logging for docker-compose
+  config.logger = Logger.new(STDOUT)
+
   PrxAuth::Rails.middleware = false
   config.middleware.insert_before 'ActionDispatch::ParamsParser', 'Rack::PrxAuth', cert_location: 'http://id.prx.dev/api/v1/certs', issuer: 'id.prx.dev'
 end

--- a/config/initializers/shoryuken.rb
+++ b/config/initializers/shoryuken.rb
@@ -1,4 +1,27 @@
 require 'shoryuken'
 
-config_file = File.join(Rails.root, 'config', 'shoryuken.yml')
-Shoryuken::EnvironmentLoader.load(config_file: config_file)
+Shoryuken.default_worker_options =  {
+  'auto_delete'             => true,
+  'auto_visibility_timeout' => false,
+  'batch'                   => false,
+  'body_parser'             => :json
+}
+
+Shoryuken.configure_server do |config|
+  Rails.logger = Shoryuken::Logging.logger
+  ActiveJob::Base.logger = Shoryuken::Logging.logger
+  ActiveRecord::Base.logger = Shoryuken::Logging.logger
+end
+
+begin
+  Shoryuken.configure_client do |config|
+    unless Rails.env.test?
+      config_file = File.join(Rails.root, 'config', 'shoryuken.yml')
+      Shoryuken::EnvironmentLoader.load(config_file: config_file)
+      Shoryuken::Client.account_id = Shoryuken.options[:aws][:account_id] || ENV['AWS_ACCOUNT_ID']
+    end
+  end
+rescue StandardError => err
+  Rails.logger.error("*** Shoryuken client failed to initialize. ***")
+  Rails.logger.error(err)
+end

--- a/config/initializers/shoryuken.rb
+++ b/config/initializers/shoryuken.rb
@@ -1,20 +1,20 @@
 require 'shoryuken'
 
-Shoryuken.default_worker_options =  {
+Shoryuken.default_worker_options = {
   'auto_delete'             => true,
   'auto_visibility_timeout' => false,
   'batch'                   => false,
   'body_parser'             => :json
 }
 
-Shoryuken.configure_server do |config|
+Shoryuken.configure_server do |_config|
   Rails.logger = Shoryuken::Logging.logger
   ActiveJob::Base.logger = Shoryuken::Logging.logger
   ActiveRecord::Base.logger = Shoryuken::Logging.logger
 end
 
 begin
-  Shoryuken.configure_client do |config|
+  Shoryuken.configure_client do |_config|
     unless Rails.env.test?
       config_file = File.join(Rails.root, 'config', 'shoryuken.yml')
       Shoryuken::EnvironmentLoader.load(config_file: config_file)
@@ -22,6 +22,6 @@ begin
     end
   end
 rescue StandardError => err
-  Rails.logger.error("*** Shoryuken client failed to initialize. ***")
+  Rails.logger.error('*** Shoryuken client failed to initialize. ***')
   Rails.logger.error(err)
 end

--- a/config/shoryuken.yml
+++ b/config/shoryuken.yml
@@ -9,3 +9,4 @@ concurrency:         25 # The number of allocated threads to process messages. D
 delay:               15 # The delay in seconds to pause a queue when it's empty. Default 0
 queues:
   - [<%= env %>_cms_image_callback, 2]
+  - [<%= env %>_cms_audio_callback, 2]

--- a/config/shoryuken.yml
+++ b/config/shoryuken.yml
@@ -1,7 +1,11 @@
+<% env = ENV['RAILS_ENV'] || 'development' %>
+---
 aws:
   access_key_id:     <%= ENV['AWS_ACCESS_KEY_ID'] %>
   secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
   region:            <%= ENV['AWS_REGION'] %>
   account_id:        <%= ENV['AWS_ACCOUNT_ID'] %>
-concurrency: 25  # The number of allocated threads to process messages. Default 25
-delay:       30        # The delay in seconds to pause a queue when it's empty. Default 0
+concurrency:         25 # The number of allocated threads to process messages. Default 25
+delay:               15 # The delay in seconds to pause a queue when it's empty. Default 0
+queues:
+  - [<%= env %>_cms_image_callback, 2]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 5) do
+ActiveRecord::Schema.define(version: 6) do
 
   create_table "pieces", :force => true do |t|
     t.integer  "position"
@@ -185,6 +185,8 @@ ActiveRecord::Schema.define(version: 5) do
     t.integer "account_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string "upload_path"
+    t.string "status"
   end
 
   add_index "account_images", ["account_id"], :name => "account_images_account_id_fk"
@@ -204,6 +206,8 @@ ActiveRecord::Schema.define(version: 5) do
     t.integer  "position"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string "upload_path"
+    t.string "status"
   end
 
   add_index "piece_images", ["piece_id"], :name => "piece_images_piece_id_fk"
@@ -262,6 +266,8 @@ ActiveRecord::Schema.define(version: 5) do
     t.string   "credit"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string "upload_path"
+    t.string "status"
   end
 
   add_index "series_images", ["series_id"], :name => "series_images_series_id_fk"
@@ -320,6 +326,8 @@ ActiveRecord::Schema.define(version: 5) do
     t.integer "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string "upload_path"
+    t.string "status"
   end
 
   add_index "user_images", ["user_id"], :name => "user_images_user_id_fk"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,8 @@ cms:
   environment:
     VIRTUAL_HOST: cms.prx.docker
     DB_PORT_3306_TCP_ADDR: db
-  tty: true
-  stdin_open: true
+  # tty: true
+  # stdin_open: true
 db:
   image: mysql
   env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,15 @@ cms:
     DB_PORT_3306_TCP_ADDR: db
   # tty: true
   # stdin_open: true
+worker:
+  image: cmsprxorg_cms
+  volumes:
+    - .:/app
+  env_file:
+    - .env
+  links:
+    - db
+  command: worker
 db:
   image: mysql
   env_file:

--- a/lib/tasks/sqs.rake
+++ b/lib/tasks/sqs.rake
@@ -16,7 +16,7 @@ namespace :sqs do
     }
 
     # create the queues and DLQs
-    ['image_callback'].each do |queue|
+    ['image_callback', 'audio_callback'].each do |queue|
       base_name = "#{env}_cms_#{queue}"
       dlq_arn = create_dlq(base_name, default_options)
       create_queue(base_name, dlq_arn, default_options)

--- a/lib/tasks/sqs.rake
+++ b/lib/tasks/sqs.rake
@@ -1,0 +1,42 @@
+require 'aws-sdk-core'
+
+namespace :sqs do
+
+  desc 'Create required SQS queues'
+  task :create, [:env] do |t, args|
+
+    env = args[:env] || Rails.env
+
+    default_options = {
+      'DelaySeconds' => "0",
+      'MaximumMessageSize' => "#{(256 * 1024)}",
+      'VisibilityTimeout' => "60",
+      'ReceiveMessageWaitTimeSeconds' => "0",
+      'MessageRetentionPeriod' => "#{1.week.seconds.to_i}"
+    }
+
+    # create the queues and DLQs
+    ['image_callback'].each do |queue|
+      base_name = "#{env}_cms_#{queue}"
+      dlq_arn = create_dlq(base_name, default_options)
+      create_queue(base_name, dlq_arn, default_options)
+    end
+  end
+
+  def create_queue(queue, dlq_arn, options={})
+    sqs = Aws::SQS::Client.new
+    options = options.merge('RedrivePolicy' => %Q{{"maxReceiveCount":"10", "deadLetterTargetArn":"#{dlq_arn}"}"})
+    q = sqs.create_queue(queue_name: queue, attributes: options)
+    puts "created queue: #{q.inspect}"
+    q
+  end
+
+  def create_dlq(queue, options)
+    sqs = Aws::SQS::Client.new
+    dlq_name = "#{queue}_failures"
+    dlq = sqs.create_queue(queue_name: dlq_name, attributes: options)
+    puts "created DLQ: #{dlq.inspect}"
+    attrs = sqs.get_queue_attributes(queue_url: dlq.queue_url, attribute_names: ['QueueArn']) rescue nil
+    attrs.attributes['QueueArn']
+  end
+end

--- a/test/factories/story_image_factory.rb
+++ b/test/factories/story_image_factory.rb
@@ -3,7 +3,13 @@ FactoryGirl.define do
 
     story
 
-    after(:create) { |si| si.update_file!('test.png') }
+    status 'complete'
 
+    after(:create) { |si| si.update_file!('test.png') unless si.status == 'uploaded' }
+
+    factory :story_image_uploaded do
+      status 'uploaded'
+      upload 'http://image.test.com/path/test.jpg'
+    end
   end
 end

--- a/test/models/story_image_test.rb
+++ b/test/models/story_image_test.rb
@@ -33,4 +33,14 @@ describe StoryImage do
     story_image.public_asset_filename.must_equal 'fromupload.jpg'
   end
 
+  it 'returns the upload filename until status is complete' do
+    story_image_uploaded.update!(caption: 'print')
+    story_image.filename.must_equal 'test.png'
+    story_image_uploaded.filename.must_equal 'test.jpg'
+    story_image_uploaded.update!(filename: 'real.jpg')
+    story_image_uploaded.filename.must_equal 'test.jpg'
+    story_image_uploaded.update!(status: 'complete')
+    story_image_uploaded.filename.must_equal 'real.jpg'
+  end
+
 end

--- a/test/models/story_image_test.rb
+++ b/test/models/story_image_test.rb
@@ -4,6 +4,8 @@ describe StoryImage do
 
   let(:story_image) { FactoryGirl.create(:story_image) }
 
+  let(:story_image_uploaded) { FactoryGirl.create(:story_image_uploaded) }
+
   it 'has a table defined' do
     StoryImage.table_name.must_equal 'piece_images'
   end
@@ -14,6 +16,21 @@ describe StoryImage do
 
   it 'has an public_asset_filename' do
     story_image.public_asset_filename.must_equal story_image.filename
+  end
+
+  it 'can have a url from the upload' do
+    story_image_uploaded.public_asset_filename.must_equal 'test.jpg'
+  end
+
+  it 'considers nil statuses to be complete uploads' do
+    story_image.fixerable_final?.must_equal true
+    story_image.public_asset_filename.must_equal story_image.filename
+    story_image.update!(status: nil)
+    story_image.fixerable_final?.must_equal true
+    story_image.public_asset_filename.must_equal story_image.filename
+    story_image.update!(status: 'invalid', upload_path: 'http://foo.bar/fromupload.jpg')
+    story_image.fixerable_final?.must_equal false
+    story_image.public_asset_filename.must_equal 'fromupload.jpg'
   end
 
 end

--- a/test/representers/api/image_representer_test.rb
+++ b/test/representers/api/image_representer_test.rb
@@ -23,6 +23,10 @@ describe Api::ImageRepresenter do
     end
   end
 
+  it 'gets the original representation of an image' do
+    json['_links']['original']['href'].must_match 'original/test.png'
+  end
+
   it 'has an image profile' do
     json['_links']['profile']['href'].must_equal 'http://meta.prx.org/model/image/story'
   end

--- a/test/representers/api/msg/audio_file_representer_test.rb
+++ b/test/representers/api/msg/audio_file_representer_test.rb
@@ -1,0 +1,52 @@
+require 'test_helper'
+
+describe Api::Msg::AudioFileRepresenter do
+
+  let(:representer) { Api::Msg::AudioFileRepresenter.new(audio) }
+  let(:json)        { JSON.parse(representer.to_json) }
+
+  describe 'with a completed upload' do
+
+    let(:audio) { FactoryGirl.create(:audio_file) }
+
+    it 'includes basic data' do
+      json['id'].must_equal audio.id
+      json['filename'].must_equal 'test.mp2'
+      json['size'].must_be_nil
+      json['status'].must_equal audio.status
+    end
+
+    it 'has no uploaded path' do
+      json['uploadPath'].must_be_nil
+    end
+
+    it 'has a destination path' do
+      json['destinationPath'].must_equal "public/audio_files/#{audio.id}"
+    end
+
+  end
+
+  describe 'with an in-progress upload' do
+
+    let(:audio) { FactoryGirl.create(:audio_file_uploaded) }
+
+    it 'includes basic data' do
+      json['id'].must_equal audio.id
+      json['filename'].must_equal 'test.mp3'
+      json['size'].must_be_nil
+      json['caption'].must_be_nil
+      json['credit'].must_be_nil
+      json['status'].must_equal audio.status
+    end
+
+    it 'has the uploaded path' do
+      json['uploadPath'].must_equal audio.upload_path
+    end
+
+    it 'has a destination path' do
+      json['destinationPath'].must_equal "public/audio_files/#{audio.id}"
+    end
+
+  end
+
+end

--- a/test/representers/api/msg/image_representer_test.rb
+++ b/test/representers/api/msg/image_representer_test.rb
@@ -26,6 +26,22 @@ describe Api::Msg::ImageRepresenter do
       json['destinationPath'].must_equal "public/piece_images/#{image.id}"
     end
 
+    it 'knows the id of the parent story' do
+      json['pieceId'].must_equal image.piece_id
+      json['userId'].must_be_nil
+    end
+
+  end
+
+  describe 'with a user image' do
+
+    let(:image) { FactoryGirl.create(:user_image) }
+
+    it 'knows the id of the parent user' do
+      json['userId'].must_equal image.user_id
+      json['pieceId'].must_be_nil
+    end
+
   end
 
   describe 'with an in-progress upload' do

--- a/test/representers/api/msg/image_representer_test.rb
+++ b/test/representers/api/msg/image_representer_test.rb
@@ -1,0 +1,54 @@
+require 'test_helper'
+
+describe Api::Msg::ImageRepresenter do
+
+  let(:representer) { Api::Msg::ImageRepresenter.new(image) }
+  let(:json)        { JSON.parse(representer.to_json) }
+
+  describe 'with a completed upload' do
+
+    let(:image) { FactoryGirl.create(:story_image) }
+
+    it 'includes basic data' do
+      json['id'].must_equal image.id
+      json['filename'].must_equal 'test.png'
+      json['size'].must_be_nil
+      json['caption'].must_be_nil
+      json['credit'].must_be_nil
+      json['status'].must_equal image.status
+    end
+
+    it 'has no uploaded path' do
+      json['uploadPath'].must_be_nil
+    end
+
+    it 'has a destination path' do
+      json['destinationPath'].must_equal "public/piece_images/#{image.id}"
+    end
+
+  end
+
+  describe 'with an in-progress upload' do
+
+    let(:image) { FactoryGirl.create(:story_image_uploaded) }
+
+    it 'includes basic data' do
+      json['id'].must_equal image.id
+      json['filename'].must_equal 'test.jpg'
+      json['size'].must_be_nil
+      json['caption'].must_be_nil
+      json['credit'].must_be_nil
+      json['status'].must_equal image.status
+    end
+
+    it 'has the uploaded path' do
+      json['uploadPath'].must_equal image.upload_path
+    end
+
+    it 'has a destination path' do
+      json['destinationPath'].must_equal "public/piece_images/#{image.id}"
+    end
+
+  end
+
+end

--- a/test/workers/audio_callback_worker_test.rb
+++ b/test/workers/audio_callback_worker_test.rb
@@ -1,0 +1,98 @@
+require 'test_helper'
+
+describe AudioCallbackWorker do
+
+  let(:worker) { AudioCallbackWorker.new }
+  let(:audio) { FactoryGirl.create(:audio_file_uploaded) }
+
+  before(:each) { Shoryuken::Logging.logger.level = Logger::FATAL }
+  after(:each) { Shoryuken::Logging.logger.level = Logger::INFO }
+
+  # {
+  #   "id":987654,
+  #   "path":"public/audio_files/987654",
+  #   "name":"test_file.mp3",
+  #   "duration":1045,
+  #   "size":16705871,
+  #   "format":"mp3",
+  #   "bitrate":128000,
+  #   "frequency":44100,
+  #   "channels":2,
+  #   "layout":"stereo",
+  #   "downloaded":true,
+  #   "valid":true,
+  #   "processed":true
+  # }
+
+  def perform(attrs = {})
+    defaults = {
+      id: audio.id,
+      downloaded: true,
+      valid: true,
+      processed: true
+    }
+    worker.perform(nil, defaults.merge(attrs).with_indifferent_access)
+    audio.reload
+  end
+
+  it 'updates audio file attributes' do
+    perform(name: 'foo.bar', duration: 12, size: 1234, format: 'mp2', bitrate: 128000,
+            frequency: 44100, channels: 2, layout: 'stereo')
+    audio.filename.must_equal 'foo.bar'
+    audio.length.must_equal 12
+    audio.size.must_equal 1234
+    audio.content_type.must_equal 'audio/mpeg'
+    audio.layer.must_equal 2
+    audio.bit_rate.must_equal 128
+    audio.frequency.must_equal 44.1
+    audio.channel_mode.must_equal(AudioFile::STEREO)
+  end
+
+  it 'sets the status to point at the final audio file' do
+    perform(name: 'foo.bar')
+    audio.filename.must_equal 'foo.bar'
+    audio.upload_path.must_be_nil
+    audio.status.must_equal AudioFile::COMPLETE
+    audio.fixerable_final?.must_equal true
+  end
+
+  it 'decodes audio mime-types' do
+    perform(format: 'mp2')
+    audio.content_type.must_equal 'audio/mpeg'
+    perform(format: 'mp3')
+    audio.content_type.must_equal 'audio/mpeg'
+    perform(format: 'wav')
+    audio.content_type.must_equal 'audio/x-wav'
+  end
+
+  it 'rescues from unknown audio types' do
+    perform(format: 'foobar')
+    audio.content_type.must_equal 'foobar'
+    perform(format: 'audio/basic')
+    audio.content_type.must_equal 'audio/basic'
+  end
+
+  it 'rescues from non-existent audio ids' do
+    perform(id: 99999, size: 12)
+    audio.size.must_be_nil
+  end
+
+  it 'sets download errors' do
+    perform(downloaded: false)
+    audio.status.must_equal AudioFile::NOTFOUND
+    audio.fixerable_final?.must_equal false
+  end
+
+  it 'sets validation errors' do
+    perform(valid: false)
+    audio.status.must_equal AudioFile::INVALID
+    audio.fixerable_final?.must_equal false
+  end
+
+  it 'sets processing errors' do
+    perform(processed: false)
+    audio.status.must_equal AudioFile::FAILED
+    audio.fixerable_final?.must_equal false
+  end
+
+end

--- a/test/workers/image_callback_worker_test.rb
+++ b/test/workers/image_callback_worker_test.rb
@@ -1,0 +1,75 @@
+require 'test_helper'
+
+describe ImageCallbackWorker do
+
+  let(:worker) { ImageCallbackWorker.new }
+  let(:image) { FactoryGirl.create(:story_image_uploaded) }
+
+  before(:each) { Shoryuken::Logging.logger.level = Logger::FATAL }
+  after(:each) { Shoryuken::Logging.logger.level = Logger::INFO }
+
+  def perform(attrs = {})
+    defaults = {
+      id: image.id,
+      type: image.class.table_name,
+      downloaded: true,
+      valid: true,
+      resized: true
+    }
+    worker.perform(nil, defaults.merge(attrs).with_indifferent_access)
+    image.reload
+  end
+
+  it 'updates image attributes' do
+    perform(name: 'foo.bar', size: 12, width: 200, height: 160)
+    image.filename.must_equal 'foo.bar'
+    image.size.must_equal 12
+    image.width.must_equal 200
+    image.height.must_equal 160
+    image.aspect_ratio.must_equal 1.25
+  end
+
+  it 'sets the status to point at the final image' do
+    perform(name: 'foo.bar')
+    image.filename.must_equal 'foo.bar'
+    image.upload_path.must_be_nil
+    image.status.must_equal Image::COMPLETE
+    image.fixerable_final?.must_equal true
+  end
+
+  it 'decodes image mime-types' do
+    perform(format: 'gif')
+    image.content_type.must_equal 'image/gif'
+  end
+
+  it 'rescues from unknown image types' do
+    perform(format: 'foobar')
+    image.content_type.must_equal 'foobar'
+    perform(format: 'image/jpg')
+    image.content_type.must_equal 'image/jpg'
+  end
+
+  it 'rescues from non-existent image ids' do
+    perform(id: 99999, size: 12)
+    image.size.must_be_nil
+  end
+
+  it 'sets download errors' do
+    perform(downloaded: false)
+    image.status.must_equal Image::NOTFOUND
+    image.fixerable_final?.must_equal false
+  end
+
+  it 'sets validation errors' do
+    perform(valid: false)
+    image.status.must_equal Image::INVALID
+    image.fixerable_final?.must_equal false
+  end
+
+  it 'sets resize errors' do
+    perform(resized: false)
+    image.status.must_equal Image::FAILED
+    image.fixerable_final?.must_equal false
+  end
+
+end


### PR DESCRIPTION
- Use `upload_path` and `status` to create pending uploads
- Announce image changes to lambda worker via sns
  - Creates and updates will cause the worker to resize the image, and move to the destination bucket/path.
  - Deletes will hard-delete the mysql record, but the worker will NOT delete the file, instead putting a `deleted.json` file representation of the last state of the record.
- Get callbacks from workers via shoryuken
  - Updates image name/status/size/etc based on the imagemagick identify output