### PR TITLE
Simple forever-based worker for production server

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -52,7 +52,6 @@ namespace :deploy do
     on roles(:app), in: :sequence, wait: 5 do
       within release_path do
         with rails_env: fetch(:rails_env) do
-          cmd = release_path.join('bin/application')
           log = release_path.join('log/production.worker.log')
           pid = release_path.join('tmp/pids/production.worker.pid')
           opts = "-al #{log} -c /bin/sh --pidFile #{pid} --workingDir #{release_path}"

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -47,7 +47,26 @@ namespace :deploy do
     end
   end
 
+  desc 'Start/restart worker'
+  task :worker do
+    on roles(:app), in: :sequence, wait: 5 do
+      within release_path do
+        with rails_env: fetch(:rails_env) do
+          cmd = release_path.join('bin/application')
+          log = release_path.join('log/production.worker.log')
+          pid = release_path.join('tmp/pids/production.worker.pid')
+          opts = "-al #{log} -c /bin/sh --pidFile #{pid} --workingDir #{release_path}"
+
+          # stop any running worker
+          execute :forever, :stop, "$(cat #{pid})" if test("[ -f #{pid} ]")
+          execute :forever, :start, opts, 'bin/application worker'
+        end
+      end
+    end
+  end
+
   after :publishing, :restart
+  after :restart, :worker
 
   desc "Flushes cache"
   task :flush_cache do


### PR DESCRIPTION
Added `forever` to production.  Simple cap task to start/restart the `bin/application worker` script.

Fixes #149.