### PR TITLE
Series/story v4 filtering

### DIFF
--- a/app/controllers/api/series_controller.rb
+++ b/app/controllers/api/series_controller.rb
@@ -5,4 +5,11 @@ class Api::SeriesController < Api::BaseController
   api_versions :v1
 
   filter_resources_by :account_id
+
+  filter_params :v4
+
+  def filtered(resources)
+    resources = resources.v4 if filters.v4?
+    super
+  end
 end

--- a/app/controllers/api/stories_controller.rb
+++ b/app/controllers/api/stories_controller.rb
@@ -6,7 +6,7 @@ class Api::StoriesController < Api::BaseController
 
   filter_resources_by :series_id, :account_id, :network_id
 
-  filter_params :highlighted, :purchased
+  filter_params :highlighted, :purchased, :v4
 
   announce_actions :create, :update, :delete, :publish, :unpublish
 
@@ -50,6 +50,7 @@ class Api::StoriesController < Api::BaseController
   end
 
   def filtered(resources)
+    resources = resources.v4 if filters.v4?
     if highlighted?
       resources
     else

--- a/app/controllers/concerns/api_filtering.rb
+++ b/app/controllers/concerns/api_filtering.rb
@@ -43,9 +43,10 @@ module ApiFiltering
 
   def parse_filters_param
     filters_map = {}
+    filters = self.class.allowed_filter_names || self.class.superclass.allowed_filter_names
 
     # set nils
-    self.class.allowed_filter_names.each do |name|
+    filters.each do |name|
       filters_map[name] = nil
     end
 

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -25,15 +25,6 @@ class Image < BaseModel
     end
   end
 
-  # not all the tables have these columns, story images do
-  def caption
-    self.try(:read_attribute, :caption)
-  end
-
-  def credit
-    self.try(:read_attribute, :credit)
-  end
-
   def self.policy_class
     ImagePolicy
   end

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -19,7 +19,11 @@ class Series < BaseModel
 
   has_one :image, -> { where(parent_id: nil) }, class_name: 'SeriesImage'
 
+  before_validation :set_app_version, on: :create
+
   event_attribute :subscriber_only_at
+
+  scope :v4, -> { where('`app_version` = ?', PRX::APP_VERSION) }
 
   def story_count
     @story_count ||= stories.published.network_visible.series_visible.count
@@ -103,5 +107,24 @@ class Series < BaseModel
     schedule_index = schedule_index - episodes_per_week if schedule_index >= episodes_per_week
 
     schedule_index
+  end
+
+  def destroy
+    if v4?
+      really_destroy!
+    else
+      super
+    end
+  end
+
+  def v4?
+    app_version == PRX::APP_VERSION
+  end
+
+  private
+
+  def set_app_version
+    return unless new_record?
+    self.app_version = PRX::APP_VERSION
   end
 end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 class Story < BaseModel
-  APPLICATION_VERSION = 'v4'
+
   self.table_name = 'pieces'
 
   acts_as_paranoid
@@ -9,7 +9,7 @@ class Story < BaseModel
   def self.paranoia_scope
     where(
       arel_table[paranoia_column].eq(paranoia_sentinel_value).or(
-        arel_table['app_version'].eq(APPLICATION_VERSION)
+        arel_table['app_version'].eq(PRX::APP_VERSION)
       )
     )
   end
@@ -58,6 +58,8 @@ class Story < BaseModel
   scope :unpublished, -> { where('`published_at` IS NULL') }
 
   scope :unseries, -> { where('`series_id` IS NULL') }
+
+  scope :v4, -> { where(app_version: PRX::APP_VERSION) }
 
   scope :purchased, -> {
     joins(:purchases).
@@ -168,6 +170,10 @@ class Story < BaseModel
     end
   end
 
+  def v4?
+    app_version == PRX::APP_VERSION
+  end
+
   private
 
   def longest_single_file_version
@@ -180,11 +186,7 @@ class Story < BaseModel
 
   def set_app_version
     return unless new_record?
-    self.app_version = APPLICATION_VERSION
+    self.app_version = PRX::APP_VERSION
     self.deleted_at = Time.now
-  end
-
-  def v4?
-    app_version == APPLICATION_VERSION
   end
 end

--- a/app/representers/api/min/series_representer.rb
+++ b/app/representers/api/min/series_representer.rb
@@ -5,6 +5,7 @@ class Api::Min::SeriesRepresenter < Api::BaseRepresenter
   property :id, writeable: false
   property :title
   property :short_description
+  property :app_version, writeable: false
 
   alternate_link
 

--- a/app/representers/api/series_representer.rb
+++ b/app/representers/api/series_representer.rb
@@ -8,6 +8,7 @@ class Api::SeriesRepresenter < Api::BaseRepresenter
   property :description
   property :created_at, writeable: false
   property :updated_at, writeable: false
+  property :app_version, writeable: false
 
   alternate_link
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,8 @@ require "rails/test_unit/railtie"
 Bundler.require(:default, Rails.env)
 
 module PRX
+  APP_VERSION = 'v4'
+
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,7 @@ require "rails/test_unit/railtie"
 Bundler.require(:default, Rails.env)
 
 module PRX
-  APP_VERSION = 'v4'
+  APP_VERSION = 'v4'.freeze
 
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -196,6 +196,8 @@ ActiveRecord::Schema.define(version: 6) do
     t.datetime "updated_at"
     t.string "upload_path"
     t.string "status"
+    t.string   "caption"
+    t.string   "credit"
   end
 
   add_index "account_images", ["account_id"], :name => "account_images_account_id_fk"
@@ -257,6 +259,7 @@ ActiveRecord::Schema.define(version: 6) do
     t.integer  "promos_days_early"
     t.datetime "subauto_bill_me_at"
     t.datetime "subscriber_only_at"
+    t.string   "app_version",             :default => "v3", :null => false
   end
 
   add_index "series", ["account_id"], :name => "index_series_on_account_id"
@@ -337,6 +340,8 @@ ActiveRecord::Schema.define(version: 6) do
     t.datetime "updated_at"
     t.string "upload_path"
     t.string "status"
+    t.string   "caption"
+    t.string   "credit"
   end
 
   add_index "user_images", ["user_id"], :name => "user_images_user_id_fk"

--- a/test/controllers/api/auth/series_controller_test.rb
+++ b/test/controllers/api/auth/series_controller_test.rb
@@ -1,0 +1,57 @@
+require 'test_helper'
+
+describe Api::Auth::SeriesController do
+  let(:user) { create(:user) }
+  let(:token) { StubToken.new(account.id, ['member'], user.id) }
+  let(:account) { user.individual_account }
+  let(:series) { create(:series, account: account) }
+  let(:v3_series) { create(:series_v3, account: account) }
+  let(:other_account_series) { create(:series) }
+
+  describe 'with a valid token' do
+
+    around do |test|
+      @controller.stub(:prx_auth_token, token) { test.call }
+    end
+
+    it 'indexes series under their account' do
+      series && v3_series && other_account_series
+      get(:index, api_version: 'v1', account_id: account.id)
+      assert_response :success
+      assert_not_nil assigns[:series]
+      assigns[:series].must_include series
+      assigns[:series].must_include v3_series
+      assigns[:series].wont_include other_account_series
+    end
+
+    it 'filters v4 series' do
+      series && v3_series
+      get(:index, api_version: 'v1', account_id: account.id, filters: 'v4')
+      assert_response :success
+      assert_not_nil assigns[:series]
+      assigns[:series].must_include series
+      assigns[:series].wont_include v3_series
+    end
+
+    it 'does not show unowned series' do
+      get(:show, api_version: 'v1', id: other_account_series.id)
+      assert_response :not_found
+    end
+
+  end
+
+  describe 'with no token' do
+
+    it 'will not show you anything' do
+      get(:show, api_version: 'v1', id: series.id)
+      assert_response :unauthorized
+    end
+
+    it 'will not index you anything' do
+      get(:index, api_version: 'v1', account_id: account.id)
+      assert_response :unauthorized
+    end
+
+  end
+
+end

--- a/test/controllers/api/series_controller_test.rb
+++ b/test/controllers/api/series_controller_test.rb
@@ -7,14 +7,14 @@ describe Api::SeriesController do
   let(:v3_series) { create(:series_v3, account: account) }
 
   it 'should show' do
-    get(:show, { api_version: 'v1', format: 'json', id: series.id } )
+    get(:show, api_version: 'v1', format: 'json', id: series.id)
     assert_response :success
   end
 
   it 'should list' do
     series.must_be :v4?
     v3_series.wont_be :v4?
-    get(:index, { api_version: 'v1', format: 'json' } )
+    get(:index, api_version: 'v1', format: 'json')
     assert_response :success
     assert_not_nil assigns[:series]
     assigns[:series].must_include series
@@ -24,7 +24,7 @@ describe Api::SeriesController do
   it 'should filter v4 stories' do
     series.must_be :v4?
     v3_series.wont_be :v4?
-    get(:index, { api_version: 'v1', format: 'json', filters: 'v4' } )
+    get(:index, api_version: 'v1', format: 'json', filters: 'v4')
     assert_response :success
     assert_not_nil assigns[:series]
     assigns[:series].must_include series
@@ -61,7 +61,5 @@ describe Api::SeriesController do
     end
 
   end
-
-
 
 end

--- a/test/controllers/api/series_controller_test.rb
+++ b/test/controllers/api/series_controller_test.rb
@@ -2,7 +2,9 @@ require 'test_helper'
 
 describe Api::SeriesController do
   let(:user) { create(:user) }
-  let(:series) { create(:series, account: user.individual_account) }
+  let(:account) { user.individual_account }
+  let(:series) { create(:series, account: account) }
+  let(:v3_series) { create(:series_v3, account: account) }
 
   it 'should show' do
     get(:show, { api_version: 'v1', format: 'json', id: series.id } )
@@ -10,8 +12,56 @@ describe Api::SeriesController do
   end
 
   it 'should list' do
-    series.id.wont_be_nil
+    series.must_be :v4?
+    v3_series.wont_be :v4?
     get(:index, { api_version: 'v1', format: 'json' } )
     assert_response :success
+    assert_not_nil assigns[:series]
+    assigns[:series].must_include series
+    assigns[:series].must_include v3_series
   end
+
+  it 'should filter v4 stories' do
+    series.must_be :v4?
+    v3_series.wont_be :v4?
+    get(:index, { api_version: 'v1', format: 'json', filters: 'v4' } )
+    assert_response :success
+    assert_not_nil assigns[:series]
+    assigns[:series].must_include series
+    assigns[:series].wont_include v3_series
+  end
+
+  describe 'with a valid token' do
+
+    around do |test|
+      token = StubToken.new(account.id, ['member'], user.id)
+      @request.env['CONTENT_TYPE'] = 'application/json'
+      @controller.stub(:prx_auth_token, token) { test.call }
+    end
+
+    it 'creates a series' do
+      post :create, { title: 'foobar' }.to_json, api_version: 'v1', account_id: account.id
+      assert_response :success
+      new_series = Series.find(JSON.parse(response.body)['id'])
+      new_series.title.must_equal 'foobar'
+      new_series.must_be :v4?
+      new_series.account_id.must_equal account.id
+    end
+
+    it 'updates a series' do
+      put :update, { title: 'foobar' }.to_json, api_version: 'v1', id: series.id
+      assert_response :success
+      Series.find(series.id).title.must_equal('foobar')
+    end
+
+    it 'deletes a series' do
+      delete :destroy, api_version: 'v1', id: series.id
+      response.status.must_equal 204
+      Series.where(id: series.id).must_be :empty?
+    end
+
+  end
+
+
+
 end

--- a/test/controllers/api/stories_controller_test.rb
+++ b/test/controllers/api/stories_controller_test.rb
@@ -92,10 +92,16 @@ describe Api::StoriesController do
     assert_response :success
   end
 
-  it 'should list' do
+  it 'should list published stories of any app version' do
     story.must_be :published
+    story2 = create(:story, published_at: nil)
+    story3 = create(:story_v3)
+
     get(:index, { api_version: 'v1', format: 'json' } )
     assert_response :success
+    assigns[:stories].must_include story
+    assigns[:stories].wont_include story2
+    assigns[:stories].must_include story3
   end
 
   it 'should list stories for an account' do
@@ -136,6 +142,16 @@ describe Api::StoriesController do
     assert_response :success
     assert_not_nil assigns[:stories]
     assigns[:stories].must_equal [story, story3]
+  end
+
+  it 'should list only v4 stories' do
+    story.must_be :v4?
+    story2 = create(:story_v3)
+    get(:index, api_version: 'v1', format: 'json', filters: 'v4')
+    assert_response :success
+    assert_not_nil assigns[:stories]
+    assigns[:stories].must_include story
+    assigns[:stories].wont_include story2
   end
 
   it 'should error on bad version' do

--- a/test/factories/series_factory.rb
+++ b/test/factories/series_factory.rb
@@ -14,5 +14,11 @@ FactoryGirl.define do
     after(:create) do |series, evaluator|
       FactoryGirl.create_list(:story, evaluator.stories_count, series: series)
     end
+
+    factory :series_v3 do
+      after(:create, :stub) do |series, evaluator|
+        series.update_attributes(app_version: 'v3')
+      end
+    end
   end
 end

--- a/test/factories/series_factory.rb
+++ b/test/factories/series_factory.rb
@@ -16,7 +16,7 @@ FactoryGirl.define do
     end
 
     factory :series_v3 do
-      after(:create, :stub) do |series, evaluator|
+      after(:create, :stub) do |series, _evaluator|
         series.update_attributes(app_version: 'v3')
       end
     end

--- a/test/factories/story_factory.rb
+++ b/test/factories/story_factory.rb
@@ -50,5 +50,12 @@ FactoryGirl.define do
         create(:promos, story: story)
       end
     end
+
+    factory :story_v3 do
+      after(:create, :stub) do |story, evaluator|
+        story.update_attributes(app_version: 'v3', deleted_at: nil)
+      end
+    end
+
   end
 end

--- a/test/factories/story_factory.rb
+++ b/test/factories/story_factory.rb
@@ -52,7 +52,7 @@ FactoryGirl.define do
     end
 
     factory :story_v3 do
-      after(:create, :stub) do |story, evaluator|
+      after(:create, :stub) do |story, _evaluator|
         story.update_attributes(app_version: 'v3', deleted_at: nil)
       end
     end


### PR DESCRIPTION
Ability to filter stories/series based on their `app_version`.

Part of PRX/publish.prx.org#27

Requires migration PRX/prx.org#282 (and copying that to the staging DB).