### PR TITLE
Audio version and file templates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,7 +62,7 @@ CyclomaticComplexity:
 Delegate:
   Enabled: false
 
-DeprecatedHashMethods:
+Style/PreferredHashMethods:
   Enabled: false
 
 Documentation:
@@ -270,4 +270,7 @@ UnderscorePrefixedVariableName:
   Enabled: false
 
 Void:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
   Enabled: false

--- a/app/controllers/api/audio_file_templates_controller.rb
+++ b/app/controllers/api/audio_file_templates_controller.rb
@@ -1,0 +1,7 @@
+# encoding: utf-8
+
+class Api::AudioFileTemplatesController < Api::BaseController
+  api_versions :v1
+
+  filter_resources_by :audio_file_template_id
+end

--- a/app/controllers/api/audio_version_templates_controller.rb
+++ b/app/controllers/api/audio_version_templates_controller.rb
@@ -1,0 +1,7 @@
+# encoding: utf-8
+
+class Api::AudioVersionTemplatesController < Api::BaseController
+  api_versions :v1
+
+  filter_resources_by :series_id
+end

--- a/app/models/audio_file_template.rb
+++ b/app/models/audio_file_template.rb
@@ -2,6 +2,7 @@
 
 class AudioFileTemplate < BaseModel
   belongs_to :audio_version_template
+
   acts_as_list scope: :audio_version_template
 
   before_validation :set_defaults, on: :create

--- a/app/models/audio_file_template.rb
+++ b/app/models/audio_file_template.rb
@@ -4,11 +4,19 @@ class AudioFileTemplate < BaseModel
   belongs_to :audio_version_template
   acts_as_list scope: :audio_version_template
 
+  before_validation :set_defaults, on: :create
+
   validates :length_minimum,
-    presence: true,
-    numericality: { less_than_or_equal_to: :length_maximum }
+            presence: true,
+            numericality: { less_than_or_equal_to: :length_maximum }
 
   validates :length_maximum,
-    presence: true,
-    numericality: { greater_than_or_equal_to: :length_minimum }
+            presence: true,
+            numericality: { greater_than_or_equal_to: :length_minimum }
+
+  def set_defaults
+    self.label ||= 'segment'
+    self.length_minimum ||= 0
+    self.length_maximum ||= 0
+  end
 end

--- a/app/models/audio_file_template.rb
+++ b/app/models/audio_file_template.rb
@@ -1,0 +1,5 @@
+# encoding: utf-8
+
+class AudioFileTemplate < BaseModel
+  belongs_to :audio_version_template
+end

--- a/app/models/audio_file_template.rb
+++ b/app/models/audio_file_template.rb
@@ -2,4 +2,13 @@
 
 class AudioFileTemplate < BaseModel
   belongs_to :audio_version_template
+  acts_as_list scope: :audio_version_template
+
+  validates :length_minimum,
+    presence: true,
+    numericality: { less_than_or_equal_to: :length_maximum }
+
+  validates :length_maximum,
+    presence: true,
+    numericality: { greater_than_or_equal_to: :length_minimum }
 end

--- a/app/models/audio_version.rb
+++ b/app/models/audio_version.rb
@@ -5,10 +5,7 @@ class AudioVersion < BaseModel
              class_name: 'Story',
              foreign_key: 'piece_id', touch: true
 
-  belongs_to :template, -> { with_deleted },
-             class_name: 'AudioVersionTemplate',
-             foreign_key: 'audio_version_template_id'
-
+  belongs_to :audio_version_template, -> { with_deleted }
   has_many :audio_files, -> { order :position }, dependent: :destroy
 
   acts_as_paranoid

--- a/app/models/audio_version.rb
+++ b/app/models/audio_version.rb
@@ -1,8 +1,14 @@
 # encoding: utf-8
 
 class AudioVersion < BaseModel
+  belongs_to :story, -> { with_deleted },
+             class_name: 'Story',
+             foreign_key: 'piece_id', touch: true
 
-  belongs_to :story, -> { with_deleted }, class_name: 'Story', foreign_key: 'piece_id', touch: true
+  belongs_to :template, -> { with_deleted },
+             class_name: 'AudioVersionTemplate',
+             foreign_key: 'audio_version_template_id'
+
   has_many :audio_files, -> { order :position }, dependent: :destroy
 
   acts_as_paranoid
@@ -10,17 +16,6 @@ class AudioVersion < BaseModel
   def length(reload=false)
     @_length = nil if reload
     @_length ||= audio_files.inject(0) { |sum, f| sum + f.length.to_i }
-
-    # @_length ||= if !new_record?
-    #   len = AudioVersion.connection.select_one("SELECT SUM(length) as l
-    #   FROM audio_files
-    #   WHERE audio_version_id = #{self.id}
-    #   AND   status != '#{AudioFile::INVALID_AUDIO}'
-    #   AND   deleted_at is null")
-    #   len['l'].to_i
-    # else
-    #   self.audio_files.inject(0){|sum, f| sum + f.length}
-    # end
   end
 
   alias_method :duration, :length

--- a/app/models/audio_version_template.rb
+++ b/app/models/audio_version_template.rb
@@ -2,5 +2,30 @@
 
 class AudioVersionTemplate < BaseModel
   belongs_to :series
-  has_many :audio_file_templates
+  has_many :audio_file_templates, -> { order :position }, dependent: :destroy
+
+  after_save :sync_audio_file_templates
+
+  validates :label, presence: true
+
+  validates :length_minimum,
+    presence: true,
+    numericality: { less_than_or_equal_to: :length_maximum }
+
+  validates :length_maximum,
+    presence: true,
+    numericality: { greater_than_or_equal_to: :length_minimum }
+
+  validates :segment_count,
+    presence: true,
+    numericality: { only_integer: true, greater_than: 0 }
+
+  def sync_audio_file_templates
+    diff = segment_count - audio_file_templates.count
+    if diff > 0
+      diff.times { audio_file_templates.create(label: 'segment') }
+    elsif diff < 0
+      self.audio_file_templates = audio_file_templates[0, segment_count]
+    end
+  end
 end

--- a/app/models/audio_version_template.rb
+++ b/app/models/audio_version_template.rb
@@ -9,21 +9,21 @@ class AudioVersionTemplate < BaseModel
   validates :label, presence: true
 
   validates :length_minimum,
-    presence: true,
-    numericality: { less_than_or_equal_to: :length_maximum }
+            presence: true,
+            numericality: { less_than_or_equal_to: :length_maximum }
 
   validates :length_maximum,
-    presence: true,
-    numericality: { greater_than_or_equal_to: :length_minimum }
+            presence: true,
+            numericality: { greater_than_or_equal_to: :length_minimum }
 
   validates :segment_count,
-    presence: true,
-    numericality: { only_integer: true, greater_than: 0 }
+            presence: true,
+            numericality: { only_integer: true, greater_than: 0 }
 
   def sync_audio_file_templates
     diff = segment_count - audio_file_templates.count
     if diff > 0
-      diff.times { audio_file_templates.create(label: 'segment') }
+      diff.times { audio_file_templates.create! }
     elsif diff < 0
       self.audio_file_templates = audio_file_templates[0, segment_count]
     end

--- a/app/models/audio_version_template.rb
+++ b/app/models/audio_version_template.rb
@@ -1,0 +1,6 @@
+# encoding: utf-8
+
+class AudioVersionTemplate < BaseModel
+  belongs_to :series
+  has_many :audio_file_templates
+end

--- a/app/models/audio_version_template.rb
+++ b/app/models/audio_version_template.rb
@@ -2,6 +2,7 @@
 
 class AudioVersionTemplate < BaseModel
   belongs_to :series
+
   has_many :audio_file_templates, -> { order :position }, dependent: :destroy
 
   after_save :sync_audio_file_templates
@@ -27,5 +28,9 @@ class AudioVersionTemplate < BaseModel
     elsif diff < 0
       self.audio_file_templates = audio_file_templates[0, segment_count]
     end
+  end
+
+  def self.policy_class
+    SeriesAttributePolicy
   end
 end

--- a/app/policies/audio_file_template_policy.rb
+++ b/app/policies/audio_file_template_policy.rb
@@ -1,0 +1,9 @@
+class AudioFileTemplatePolicy < ApplicationPolicy
+  def create?
+    update?
+  end
+
+  def update?
+    SeriesAttributePolicy.new(token, resource.audio_version_template).update?
+  end
+end

--- a/app/policies/series_attribute_policy.rb
+++ b/app/policies/series_attribute_policy.rb
@@ -1,0 +1,9 @@
+class SeriesAttributePolicy < ApplicationPolicy
+  def create?
+    update?
+  end
+
+  def update?
+    AccountablePolicy.new(token, resource.series).update?
+  end
+end

--- a/app/representers/api/audio_file_template_representer.rb
+++ b/app/representers/api/audio_file_template_representer.rb
@@ -1,0 +1,15 @@
+# encoding: utf-8
+
+class Api::AudioFileTemplateRepresenter < Api::BaseRepresenter
+  property :id, writeable: false
+  property :position
+  property :label
+  property :length_minimum
+  property :length_maximum
+
+  def self_url(represented)
+    polymorphic_path([:api, represented.audio_version_template, represented])
+  end
+
+  set_link_property(rel: :audio_version_template, writeable: true)
+end

--- a/app/representers/api/audio_version_representer.rb
+++ b/app/representers/api/audio_version_representer.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Api::AudioVersionRepresenter < Api::BaseRepresenter
-
   property :id, writeable: false
   property :label
   property :timing_and_cues
@@ -17,4 +16,13 @@ class Api::AudioVersionRepresenter < Api::BaseRepresenter
     } if represented.id
   end
   embeds :audio_files, as: :audio, class: AudioFile, decorator: Api::AudioFileRepresenter
+
+  link :audio_version_template do
+    {
+      href: api_audio_version_template_path(represented.audio_version_template)
+    } if represented.audio_version_template_id
+  end
+  embed :audio_version_template,
+        class: AudioVersionTemplate,
+        decorator: Api::AudioVersionTemplateRepresenter
 end

--- a/app/representers/api/audio_version_template_representer.rb
+++ b/app/representers/api/audio_version_template_representer.rb
@@ -1,0 +1,20 @@
+# encoding: utf-8
+
+class Api::AudioVersionTemplateRepresenter < Api::BaseRepresenter
+  property :id, writeable: false
+  property :label
+  property :promos
+  property :segment_count
+  property :length_minimum
+  property :length_maximum
+
+  set_link_property(rel: :series, writeable: true)
+
+  link :audio_file_templates do
+    {
+      href: api_audio_version_template_audio_file_templates_path(represented),
+      count: represented.audio_file_templates.count
+    } if represented.id
+  end
+  embeds :audio_file_templates, class: AudioFileTemplate, decorator: Api::AudioFileTemplateRepresenter
+end

--- a/app/representers/api/audio_version_template_representer.rb
+++ b/app/representers/api/audio_version_template_representer.rb
@@ -16,5 +16,7 @@ class Api::AudioVersionTemplateRepresenter < Api::BaseRepresenter
       count: represented.audio_file_templates.count
     } if represented.id
   end
-  embeds :audio_file_templates, class: AudioFileTemplate, decorator: Api::AudioFileTemplateRepresenter
+  embeds :audio_file_templates,
+         class: AudioFileTemplate,
+         decorator: Api::AudioFileTemplateRepresenter
 end

--- a/bin/application
+++ b/bin/application
@@ -29,9 +29,9 @@ ApplicationRun () {
     ApplicationUpdate
     CMD="bundle exec shoryuken --rails --config config/shoryuken.yml"
   elif [ "$PROCESS" = "testsetup" ] ; then
-    CMD="bundle exec rake db:create RAILS_ENV=test"
+    CMD="bundle exec rake db:create db:setup RAILS_ENV=test"
   elif [ "$PROCESS" = "test" ] ; then
-    CMD="bundle exec rake db:create test:run RAILS_ENV=test"
+    CMD="bundle exec rake test:run RAILS_ENV=test"
   elif [ "$PROCESS" = "guard" ] ; then
     CMD="bundle exec guard"
   elif [ "$PROCESS" = "setup" ] ; then

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,11 +34,11 @@ PRX::Application.routes.draw do
       resources :series, except: [:new, :edit] do
         resources :series_images, path: 'images', except: [:new, :edit]
         resources :stories, only: [:index, :create]
-        resources :audio_version_templates
+        resources :audio_version_templates, except: [:new, :edit]
       end
 
-      resources :audio_version_templates do
-        resources :audio_file_templates
+      resources :audio_version_templates, except: [:new, :edit] do
+        resources :audio_file_templates, except: [:new, :edit]
       end
 
       resources :accounts, except: [:new, :edit, :destroy] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,11 @@ PRX::Application.routes.draw do
       resources :series, except: [:new, :edit] do
         resources :series_images, path: 'images', except: [:new, :edit]
         resources :stories, only: [:index, :create]
+        resources :audio_version_templates
+      end
+
+      resources :audio_version_templates do
+        resources :audio_file_templates
       end
 
       resources :accounts, except: [:new, :edit, :destroy] do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -100,6 +100,16 @@ ActiveRecord::Schema.define(version: 6) do
   add_index "audio_files", ["position"], :name => "position_idx"
   add_index "audio_files", ["status"], :name => "status_idx"
 
+  create_table "audio_file_templates", :force => true do |t|
+    t.integer  "audio_version_template_id"
+    t.integer  "position"
+    t.string   "label"
+    t.integer  "length_minimum"
+    t.integer  "length_maximum"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
   create_table "audio_versions", :force => true do |t|
     t.integer  "piece_id"
     t.string   "label"
@@ -119,6 +129,15 @@ ActiveRecord::Schema.define(version: 6) do
   end
 
   add_index "audio_versions", ["piece_id"], :name => "audio_versions_piece_id_fk"
+
+  create_table "audio_version_templates", :force => true do |t|
+    t.integer "series_id"
+    t.string  "label"
+    t.boolean "promos"
+    t.integer "length_minimum"
+    t.integer "segment_count"
+    t.integer "length_maximum"
+  end
 
   create_table "accounts", :force => true do |t|
     t.string   "type"

--- a/test/controllers/api/audio_file_templates_controller_test.rb
+++ b/test/controllers/api/audio_file_templates_controller_test.rb
@@ -5,13 +5,13 @@ describe Api::AudioFileTemplatesController do
   let(:template) { create(:audio_file_template, audio_version_template: version_template) }
 
   it 'should show' do
-    get(:show, { api_version: 'v1', format: 'json', audio_version_template_id: version_template.id, id: template.id } )
+    get(:show, api_request_opts(audio_version_template_id: version_template.id, id: template.id))
     assert_response :success
   end
 
   it 'should list by audio version template' do
     template.id.wont_be_nil
-    get(:index, { api_version: 'v1', format: 'json', audio_version_template_id: version_template.id } )
+    get(:index, api_request_opts(audio_version_template_id: version_template.id))
     assert_response :success
   end
 end

--- a/test/controllers/api/audio_file_templates_controller_test.rb
+++ b/test/controllers/api/audio_file_templates_controller_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+describe Api::AudioFileTemplatesController do
+  let(:version_template) { create(:audio_version_template) }
+  let(:template) { create(:audio_file_template, audio_version_template: version_template) }
+
+  it 'should show' do
+    get(:show, { api_version: 'v1', format: 'json', audio_version_template_id: version_template.id, id: template.id } )
+    assert_response :success
+  end
+
+  it 'should list by audio version template' do
+    template.id.wont_be_nil
+    get(:index, { api_version: 'v1', format: 'json', audio_version_template_id: version_template.id } )
+    assert_response :success
+  end
+end

--- a/test/controllers/api/audio_files_controller_test.rb
+++ b/test/controllers/api/audio_files_controller_test.rb
@@ -4,7 +4,7 @@ describe Api::AudioFilesController do
   let(:account) { create(:account) }
   let(:token) { StubToken.new(account.id, ['member']) }
   let(:story) { create(:story, account: account) }
-  let(:story_with_version) { create(:story_with_audio, account: account) }
+  let(:story_with_version) { create(:story, account: account) }
   let(:audio_file) { create(:audio_file, story: story, account: account) }
   let(:audio_version) { audio_file.audio_version }
 

--- a/test/controllers/api/audio_version_templates_controller_test.rb
+++ b/test/controllers/api/audio_version_templates_controller_test.rb
@@ -12,7 +12,7 @@ describe Api::AudioVersionTemplatesController do
 
   it 'should list' do
     template.id.wont_be_nil
-    get(:index, api_request_opts(series_id: series.id))
+    get(:index, api_request_opts)
     assert_response :success
   end
 

--- a/test/controllers/api/audio_version_templates_controller_test.rb
+++ b/test/controllers/api/audio_version_templates_controller_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+describe Api::AudioVersionTemplatesController do
+  let(:user) { create(:user) }
+  let(:series) { create(:series, account: user.individual_account) }
+  let(:template) { create(:audio_version_template, series: series) }
+
+  it 'should show' do
+    get(:show, { api_version: 'v1', format: 'json', id: template.id } )
+    assert_response :success
+  end
+
+  it 'should list' do
+    template.id.wont_be_nil
+    get(:index, { api_version: 'v1', format: 'json' } )
+    assert_response :success
+  end
+
+  it 'should list by series' do
+    template.id.wont_be_nil
+    get(:index, { api_version: 'v1', format: 'json', series_id: series.id } )
+    assert_response :success
+  end
+end

--- a/test/controllers/api/audio_version_templates_controller_test.rb
+++ b/test/controllers/api/audio_version_templates_controller_test.rb
@@ -6,19 +6,19 @@ describe Api::AudioVersionTemplatesController do
   let(:template) { create(:audio_version_template, series: series) }
 
   it 'should show' do
-    get(:show, { api_version: 'v1', format: 'json', id: template.id } )
+    get(:show, api_request_opts(id: template.id))
     assert_response :success
   end
 
   it 'should list' do
     template.id.wont_be_nil
-    get(:index, { api_version: 'v1', format: 'json' } )
+    get(:index, api_request_opts(series_id: series.id))
     assert_response :success
   end
 
   it 'should list by series' do
     template.id.wont_be_nil
-    get(:index, { api_version: 'v1', format: 'json', series_id: series.id } )
+    get(:index, api_request_opts(series_id: series.id))
     assert_response :success
   end
 end

--- a/test/controllers/api/auth/stories_controller_test.rb
+++ b/test/controllers/api/auth/stories_controller_test.rb
@@ -6,7 +6,7 @@ describe Api::Auth::StoriesController do
   let (:token) { StubToken.new(account.id, ['member'], user.id) }
   let (:account) { user.individual_account }
   let (:unpublished_story) { account.all_stories.first }
-  let (:random_story) { create(:story, published_at: nil) }
+  let (:random_story) { create(:story, unpublished: true) }
   let (:network) { create(:network, account: user.individual_account) }
   let (:network_story) { create(:story, network_id: network.id, network_only_at: Time.now) }
   let (:v3_story) { create(:story_v3, account: account) }
@@ -73,7 +73,7 @@ describe Api::Auth::StoriesController do
     end
 
     it 'deletes an unpublished story' do
-      story = create(:story, account: account, published_at: nil)
+      story = create(:story, account: account, unpublished: true)
       delete :destroy, api_version: 'v1', id: story.id
       response.status.must_equal 204
       Story.where(id: story.id).must_be :empty?

--- a/test/controllers/api/auth/stories_controller_test.rb
+++ b/test/controllers/api/auth/stories_controller_test.rb
@@ -6,7 +6,7 @@ describe Api::Auth::StoriesController do
   let (:token) { StubToken.new(account.id, ['member'], user.id) }
   let (:account) { user.individual_account }
   let (:unpublished_story) { account.all_stories.first }
-  let (:random_story) { create(:story, unpublished: true) }
+  let (:random_story) { create(:story, published_at: nil) }
   let (:network) { create(:network, account: user.individual_account) }
   let (:network_story) { create(:story, network_id: network.id, network_only_at: Time.now) }
   let (:v3_story) { create(:story_v3, account: account) }
@@ -73,7 +73,7 @@ describe Api::Auth::StoriesController do
     end
 
     it 'deletes an unpublished story' do
-      story = create(:story, account: account, unpublished: true)
+      story = create(:story, account: account, published_at: nil)
       delete :destroy, api_version: 'v1', id: story.id
       response.status.must_equal 204
       Story.where(id: story.id).must_be :empty?

--- a/test/controllers/api/stories_controller_test.rb
+++ b/test/controllers/api/stories_controller_test.rb
@@ -61,7 +61,7 @@ describe Api::StoriesController do
       story = create(:story,
                      title: 'not this',
                      account: account,
-                     unpublished: true)
+                     published_at: nil)
       @request.env['CONTENT_TYPE'] = 'application/json'
       post :publish, api_version: 'v1', format: 'json', id: story.id
       assert_response :success
@@ -93,7 +93,7 @@ describe Api::StoriesController do
 
   it 'should list published stories of any app version' do
     story.must_be :published
-    story2 = create(:story, unpublished: true)
+    story2 = create(:story, published_at: nil)
     story3 = create(:story_v3)
 
     get(:index, { api_version: 'v1', format: 'json' } )

--- a/test/controllers/api/stories_controller_test.rb
+++ b/test/controllers/api/stories_controller_test.rb
@@ -61,7 +61,7 @@ describe Api::StoriesController do
       story = create(:story,
                      title: 'not this',
                      account: account,
-                     published_at: nil)
+                     unpublished: true)
       @request.env['CONTENT_TYPE'] = 'application/json'
       post :publish, api_version: 'v1', format: 'json', id: story.id
       assert_response :success
@@ -71,8 +71,7 @@ describe Api::StoriesController do
     it 'can unpublish a story' do
       story = create(:story,
                      title: 'not this',
-                     account: account,
-                     published_at: Time.now)
+                     account: account)
       @request.env['CONTENT_TYPE'] = 'application/json'
       post :unpublish, api_version: 'v1', format: 'json', id: story.id
       assert_response :success
@@ -94,7 +93,7 @@ describe Api::StoriesController do
 
   it 'should list published stories of any app version' do
     story.must_be :published
-    story2 = create(:story, published_at: nil)
+    story2 = create(:story, unpublished: true)
     story3 = create(:story_v3)
 
     get(:index, { api_version: 'v1', format: 'json' } )

--- a/test/factories/audio_file_template_factory.rb
+++ b/test/factories/audio_file_template_factory.rb
@@ -1,7 +1,6 @@
 FactoryGirl.define do
   factory :audio_file_template do
     audio_version_template
-    label 'segment'
     length_minimum 1
     length_maximum 10
   end

--- a/test/factories/audio_file_template_factory.rb
+++ b/test/factories/audio_file_template_factory.rb
@@ -1,7 +1,8 @@
 FactoryGirl.define do
   factory :audio_file_template do
-
     audio_version_template
-
+    label 'segment'
+    length_minimum 1
+    length_maximum 10
   end
 end

--- a/test/factories/audio_file_template_factory.rb
+++ b/test/factories/audio_file_template_factory.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :audio_file_template do
+
+    audio_version_template
+
+  end
+end

--- a/test/factories/audio_version_factory.rb
+++ b/test/factories/audio_version_factory.rb
@@ -8,7 +8,7 @@ FactoryGirl.define do
     promos false
 
     transient do
-      audio_files_count 0
+      audio_files_count 1
     end
 
     after(:create) do |audio_version, evaluator|

--- a/test/factories/audio_version_factory.rb
+++ b/test/factories/audio_version_factory.rb
@@ -20,5 +20,9 @@ FactoryGirl.define do
     factory :promos do
       promos true
     end
+
+    factory :audio_version_with_template do
+      audio_version_template
+    end
   end
 end

--- a/test/factories/audio_version_template_factory.rb
+++ b/test/factories/audio_version_template_factory.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :audio_version_template do
+
+    series
+
+  end
+end

--- a/test/factories/audio_version_template_factory.rb
+++ b/test/factories/audio_version_template_factory.rb
@@ -1,7 +1,9 @@
 FactoryGirl.define do
   factory :audio_version_template do
-
     series
-
+    label 'test'
+    segment_count 1
+    length_minimum 10
+    length_maximum 100
   end
 end

--- a/test/factories/audio_version_template_factory.rb
+++ b/test/factories/audio_version_template_factory.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :audio_version_template do
     series
     label 'test'
-    segment_count 1
+    segment_count 4
     length_minimum 10
     length_maximum 100
   end

--- a/test/factories/story_factory.rb
+++ b/test/factories/story_factory.rb
@@ -13,23 +13,16 @@ FactoryGirl.define do
     produced_on 2.weeks.ago
     related_website 'http://prx.org'
     broadcast_history 'Broadcast history'
+    published_at 1.week.ago
 
     transient do
       audio_versions_count 1
       images_count 1
-      unpublished false
     end
 
-    after(:create) do |story, evaluator|
+    after(:create, :stub) do |story, evaluator|
       create_list(:audio_version, evaluator.audio_versions_count, story: story)
       create_list(:story_image, evaluator.images_count, story: story)
-      story.update_attribute(:published_at, 1.week.ago) unless evaluator.unpublished
-    end
-
-    after(:stub) do |story, evaluator|
-      create_list(:audio_version, evaluator.audio_versions_count, story: story)
-      create_list(:story_image, evaluator.images_count, story: story)
-      story.published_at = 1.week.ago unless evaluator.unpublished
     end
 
     factory :story_with_license do

--- a/test/factories/story_factory.rb
+++ b/test/factories/story_factory.rb
@@ -10,10 +10,27 @@ FactoryGirl.define do
     point_level 1
     short_description 'Short description'
     description 'Long description'
-    published_at 1.week.ago
     produced_on 2.weeks.ago
     related_website 'http://prx.org'
     broadcast_history 'Broadcast history'
+
+    transient do
+      audio_versions_count 1
+      images_count 1
+      unpublished false
+    end
+
+    after(:create) do |story, evaluator|
+      create_list(:audio_version, evaluator.audio_versions_count, story: story)
+      create_list(:story_image, evaluator.images_count, story: story)
+      story.update_attribute(:published_at, 1.week.ago) unless evaluator.unpublished
+    end
+
+    after(:stub) do |story, evaluator|
+      create_list(:audio_version, evaluator.audio_versions_count, story: story)
+      create_list(:story_image, evaluator.images_count, story: story)
+      story.published_at = 1.week.ago unless evaluator.unpublished
+    end
 
     factory :story_with_license do
       license
@@ -26,19 +43,6 @@ FactoryGirl.define do
 
       after(:create, :stub) do |story, evaluator|
         create_list(:purchase, evaluator.purchases_count, purchased: story)
-      end
-    end
-
-    factory :story_with_audio do
-
-      transient do
-        audio_versions_count 1
-        images_count 1
-      end
-
-      after(:create, :stub) do |story, evaluator|
-        create_list(:audio_version, evaluator.audio_versions_count, story: story)
-        create_list(:story_image, evaluator.images_count, story: story)
       end
     end
 

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -4,7 +4,7 @@ describe Account do
 
   let(:account) { create(:account) }
   let(:unpublished_story) do
-    create(:story, account: account, unpublished: true)
+    create(:story, account: account, published_at: nil)
   end
 
   it 'has a table defined' do

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -4,7 +4,7 @@ describe Account do
 
   let(:account) { create(:account) }
   let(:unpublished_story) do
-    create(:story, account: account, published_at: nil)
+    create(:story, account: account, unpublished: true)
   end
 
   it 'has a table defined' do

--- a/test/models/audio_file_template_test.rb
+++ b/test/models/audio_file_template_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+describe AudioFileTemplate do
+
+  let(:audio_file_template) { create(:audio_file_template) }
+
+  it 'has a table defined' do
+    AudioFileTemplate.table_name.must_equal 'audio_file_templates'
+  end
+
+  it 'has a version template' do
+    audio_file_template.audio_version_template.wont_be_nil
+  end
+end

--- a/test/models/audio_version_template_test.rb
+++ b/test/models/audio_version_template_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+describe AudioVersionTemplate do
+
+  let(:audio_version_template) { create(:audio_version_template) }
+
+  it 'has a table defined' do
+    AudioVersionTemplate.table_name.must_equal 'audio_version_templates'
+  end
+
+  it 'has a series' do
+    audio_version_template.series.wont_be_nil
+  end
+end

--- a/test/models/audio_version_template_test.rb
+++ b/test/models/audio_version_template_test.rb
@@ -11,4 +11,24 @@ describe AudioVersionTemplate do
   it 'has a series' do
     audio_version_template.series.wont_be_nil
   end
+
+  it 'can be created with valid attributes' do
+    audio_version_template.must_be :valid?
+  end
+
+  it 'reduce file templates when segment count lowered' do
+    audio_version_template.segment_count.must_equal 4
+    audio_version_template.audio_file_templates.count.must_equal 4
+    audio_version_template.segment_count = 2
+    audio_version_template.save
+    audio_version_template.audio_file_templates(true).count.must_equal 2
+  end
+
+  it 'add file templates when segment count raised' do
+    audio_version_template.segment_count.must_equal 4
+    audio_version_template.audio_file_templates.count.must_equal 4
+    audio_version_template.segment_count = 6
+    audio_version_template.save
+    audio_version_template.audio_file_templates(true).count.must_equal 6
+  end
 end

--- a/test/models/story_test.rb
+++ b/test/models/story_test.rb
@@ -2,54 +2,8 @@ require 'test_helper'
 
 describe Story do
 
-  let(:story) { build_stubbed(:story_with_audio, audio_versions_count: 10) }
+  let(:story) { build_stubbed(:story, audio_versions_count: 10) }
   let(:promos_only) { build_stubbed(:story_promos_only) }
-
-  describe 'publishing' do
-
-    let(:story) { create(:story) }
-
-    it 'publishes a story' do
-      story.published_at = nil
-      story.publish!
-      story.published_at.wont_be_nil
-    end
-
-    it 'wont publish when already published' do
-      lambda do
-        story.publish!
-        story.publish!
-      end.must_raise(RuntimeError)
-    end
-
-    it 'unpublishes a story' do
-      story.published_at = Time.now
-      story.unpublish!
-      story.published_at.must_be_nil
-    end
-
-    it 'wont unpublish an unpublished story' do
-      lambda do
-        story.unpublish!
-        story.unpublish!
-      end.must_raise(RuntimeError)
-    end
-  end
-
-  describe 'deleting' do
-    let(:story) { create(:story) }
-    let(:story_v3) { create(:story_v3) }
-
-    it 'actually deletes v4 stories' do
-      story.destroy!
-      Story.unscoped.where(id: story.id).count.must_equal 0
-    end
-
-    it 'soft deletes v3 stories' do
-      story_v3.destroy!
-      Story.unscoped.where(id: story_v3.id).count.must_equal 1
-    end
-  end
 
   describe 'basics' do
 
@@ -199,6 +153,52 @@ describe Story do
 
         story.episode_date.must_equal series.get_datetime_for_episode_number(3)
       end
+    end
+  end
+
+  describe 'publishing' do
+
+    let(:story) { create(:story) }
+
+    it 'publishes a story' do
+      story.published_at = nil
+      story.publish!
+      story.published_at.wont_be_nil
+    end
+
+    it 'wont publish when already published' do
+      lambda do
+        story.publish!
+        story.publish!
+      end.must_raise(RuntimeError)
+    end
+
+    it 'unpublishes a story' do
+      story.published_at = Time.now
+      story.unpublish!
+      story.published_at.must_be_nil
+    end
+
+    it 'wont unpublish an unpublished story' do
+      lambda do
+        story.unpublish!
+        story.unpublish!
+      end.must_raise(RuntimeError)
+    end
+  end
+
+  describe 'deleting' do
+    let(:story) { create(:story) }
+    let(:story_v3) { create(:story_v3) }
+
+    it 'actually deletes v4 stories' do
+      story.destroy!
+      Story.unscoped.where(id: story.id).count.must_equal 0
+    end
+
+    it 'soft deletes v3 stories' do
+      story_v3.destroy!
+      Story.unscoped.where(id: story_v3.id).count.must_equal 1
     end
   end
 

--- a/test/policies/audio_file_template_policy_test.rb
+++ b/test/policies/audio_file_template_policy_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+describe AudioFileTemplatePolicy do
+  let(:account) { create(:account) }
+  let(:series) { create(:series, account: account) }
+  let(:audio_version_template) { create(:audio_version_template, series: series) }
+  let(:audio_file_template) { build_stubbed(:audio_file_template, audio_version_template: audio_version_template) }
+  let(:token) { StubToken.new(series.account_id, ['member']) }
+  let(:non_member_token) { StubToken.new(series.account_id + 1, ['no']) }
+  let(:user) { build_stubbed(:user, id: token.user_id) }
+
+  describe '#update?' do
+    it 'returns true if user member of account that owns the template series' do
+      AudioFileTemplatePolicy.new(token, audio_file_template).must_allow :update?
+    end
+
+    it 'returns false otherwise' do
+      AudioFileTemplatePolicy.new(non_member_token, audio_file_template).wont_allow :update?
+    end
+  end
+end

--- a/test/policies/series_attribute_policy_test.rb
+++ b/test/policies/series_attribute_policy_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+describe SeriesAttributePolicy do
+  describe '#update?' do
+    let(:series) { build_stubbed(:series) }
+    let(:template) { build_stubbed(:audio_version_template, series: series) }
+    let(:member_token) { StubToken.new(series.account_id, ['member']) }
+    let(:n_m_token) { StubToken.new(series.account_id + 1, ['no']) }
+
+    it 'returns true if user is a member of series account' do
+      SeriesAttributePolicy.new(member_token, template).must_allow :update?
+    end
+
+    it 'returns false if user is not present' do
+      SeriesAttributePolicy.new(nil, template).wont_allow :update?
+    end
+
+    it 'returns false if user is not a member of series account' do
+      SeriesAttributePolicy.new(n_m_token, template).wont_allow :update?
+    end
+  end
+end

--- a/test/representers/api/audio_file_template_representer_test.rb
+++ b/test/representers/api/audio_file_template_representer_test.rb
@@ -1,0 +1,18 @@
+# encoding: utf-8
+
+require 'test_helper'
+require 'audio_file_template' if !defined?(AudioFileTemplate)
+
+describe Api::AudioFileTemplateRepresenter do
+  let(:audio_file_template) { create(:audio_file_template) }
+  let(:representer) { Api::AudioFileTemplateRepresenter.new(audio_file_template) }
+  let(:json) { JSON.parse(representer.to_json) }
+
+  it 'create representer' do
+    representer.wont_be_nil
+  end
+
+  it 'use representer to create json' do
+    json['id'].must_equal audio_file_template.id
+  end
+end

--- a/test/representers/api/audio_version_representer_test.rb
+++ b/test/representers/api/audio_version_representer_test.rb
@@ -5,7 +5,7 @@ require 'audio_version' if !defined?(AudioVersion)
 
 describe Api::AudioVersionRepresenter do
 
-  let(:audio_version) { FactoryGirl.create(:audio_version) }
+  let(:audio_version) { FactoryGirl.create(:audio_version_with_template) }
   let(:representer)   { Api::AudioVersionRepresenter.new(audio_version) }
   let(:json)          { JSON.parse(representer.to_json) }
 
@@ -32,5 +32,9 @@ describe Api::AudioVersionRepresenter do
       audio_version.explicit = nil
       json['explicit'].must_equal nil
     end
+  end
+
+  it 'returns a link to the template' do
+    json['_links']['prx:audio-version-template']['href'].wont_be_nil
   end
 end

--- a/test/representers/api/audio_version_template_representer_test.rb
+++ b/test/representers/api/audio_version_template_representer_test.rb
@@ -1,0 +1,18 @@
+# encoding: utf-8
+
+require 'test_helper'
+require 'audio_version_template' if !defined?(AudioVersionTemplate)
+
+describe Api::AudioVersionTemplateRepresenter do
+  let(:audio_version_template) { create(:audio_version_template) }
+  let(:representer) { Api::AudioVersionTemplateRepresenter.new(audio_version_template) }
+  let(:json) { JSON.parse(representer.to_json) }
+
+  it 'create representer' do
+    representer.wont_be_nil
+  end
+
+  it 'use representer to create json' do
+    json['id'].must_equal audio_version_template.id
+  end
+end

--- a/test/representers/api/story_representer_test.rb
+++ b/test/representers/api/story_representer_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 describe Api::StoryRepresenter do
 
-  let(:story) { create(:story_with_audio, audio_versions_count: 1) }
+  let(:story) { create(:story, audio_versions_count: 1) }
   let(:representer) { Api::StoryRepresenter.new(story) }
   let(:json) { JSON.parse(representer.to_json) }
 
@@ -29,8 +29,7 @@ describe Api::StoryRepresenter do
   describe 'serialize' do
 
     it 'can serialize an unsaved story' do
-      story_with_audio = create(:story_with_audio)
-      json = Api::StoryRepresenter.new(story_with_audio).to_json
+      json = Api::StoryRepresenter.new(story).to_json
       json.wont_be_nil
     end
 


### PR DESCRIPTION
fixes #147 

- [x]  Models
- [x]  Controllers
- [x]  Representers
- [x]  Validations
- [x]  Add template to `AudioVersion`
- [x]  Code styles validate

(Next PR will take on audio version/file validations, but will further incorporate idea of different distributions with their own validations (e.g. b'cast has different audio and data requirements than a podcast))