### PR TITLE
Fix story controller multiple-filters

### DIFF
--- a/app/controllers/api/auth/stories_controller.rb
+++ b/app/controllers/api/auth/stories_controller.rb
@@ -30,11 +30,8 @@ class Api::Auth::StoriesController < Api::StoriesController
   end
 
   def filtered(resources)
-    if filters.noseries?
-      resources.unseries
-    else
-      super
-    end
+    resources = resources.unseries if filters.noseries?
+    super
   end
 
   def resources_base

--- a/test/controllers/api/auth/stories_controller_test.rb
+++ b/test/controllers/api/auth/stories_controller_test.rb
@@ -44,6 +44,19 @@ describe Api::Auth::StoriesController do
       assigns[:stories].wont_include v3_story
     end
 
+    it 'applies multiple filters' do
+      create(:series, stories: [unpublished_story])
+      unpublished_story.series.wont_be_nil
+      v3_story.wont_be :v4?
+      v3_story.series.must_be_nil
+
+      get(:index, api_version: 'v1', filters: 'v4,noseries')
+      assert_response :success
+      assert_not_nil assigns[:stories]
+      assigns[:stories].wont_include unpublished_story
+      assigns[:stories].wont_include v3_story
+    end
+
     it 'error for network user access' do
       other_network = create(:network)
       get(:index, api_version: 'v1', network_id: other_network.id)


### PR DESCRIPTION
The `noseries` filter was masking parent controller filters.  So I couldn't combine `?filters=noseries,v4`.