### PR TITLE
Filter by text for series and stories

### DIFF
--- a/app/controllers/api/series_controller.rb
+++ b/app/controllers/api/series_controller.rb
@@ -6,10 +6,11 @@ class Api::SeriesController < Api::BaseController
 
   filter_resources_by :account_id
 
-  filter_params :v4
+  filter_params :v4, :text
 
   def filtered(resources)
     resources = resources.v4 if filters.v4?
+    resources = resources.match_text(filters.text) if filters.text?
     super
   end
 end

--- a/app/controllers/api/stories_controller.rb
+++ b/app/controllers/api/stories_controller.rb
@@ -6,7 +6,7 @@ class Api::StoriesController < Api::BaseController
 
   filter_resources_by :series_id, :account_id, :network_id
 
-  filter_params :highlighted, :purchased, :v4
+  filter_params :highlighted, :purchased, :v4, :text
 
   announce_actions :create, :update, :delete, :publish, :unpublish
 
@@ -51,6 +51,7 @@ class Api::StoriesController < Api::BaseController
 
   def filtered(resources)
     resources = resources.v4 if filters.v4?
+    resources = resources.match_text(filters.text) if filters.text?
     if highlighted?
       resources
     else

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -25,6 +25,10 @@ class Series < BaseModel
 
   scope :v4, -> { where('`app_version` = ?', PRX::APP_VERSION) }
 
+  scope :match_text, ->(text) { where("`series`.`title` like '%#{text}%' OR " +
+                                      "`series`.`short_description` like '%#{text}%' OR " +
+                                      "`series`.`description` like '%#{text}%'")
+                              }
   def story_count
     @story_count ||= stories.published.network_visible.series_visible.count
   end

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -25,10 +25,12 @@ class Series < BaseModel
 
   scope :v4, -> { where('`app_version` = ?', PRX::APP_VERSION) }
 
-  scope :match_text, ->(text) { where("`series`.`title` like '%#{text}%' OR " +
-                                      "`series`.`short_description` like '%#{text}%' OR " +
-                                      "`series`.`description` like '%#{text}%'")
-                              }
+  scope :match_text, ->(text) {
+    where("`series`.`title` like '%#{text}%' OR " +
+          "`series`.`short_description` like '%#{text}%' OR " +
+          "`series`.`description` like '%#{text}%'")
+  }
+
   def story_count
     @story_count ||= stories.published.network_visible.series_visible.count
   end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -74,10 +74,11 @@ class Story < BaseModel
            Series::SUBSCRIPTION_PRX_APPROVED])
   }
 
-  scope :match_text, ->(text) { where("`pieces`.`title` like '%#{text}%' OR " +
-                                      "`pieces`.`short_description` like '%#{text}%' OR " +
-                                      "`pieces`.`description` like '%#{text}%'")
-                              }
+  scope :match_text, ->(text) {
+    where("`pieces`.`title` like '%#{text}%' OR " +
+          "`pieces`.`short_description` like '%#{text}%' OR " +
+          "`pieces`.`description` like '%#{text}%'")
+  }
 
   def points(level=point_level)
     has_custom_points? ? self.custom_points : Economy.points(level, self.length)

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -74,6 +74,11 @@ class Story < BaseModel
            Series::SUBSCRIPTION_PRX_APPROVED])
   }
 
+  scope :match_text, ->(text) { where("`pieces`.`title` like '%#{text}%' OR " +
+                                      "`pieces`.`short_description` like '%#{text}%' OR " +
+                                      "`pieces`.`description` like '%#{text}%'")
+                              }
+
   def points(level=point_level)
     has_custom_points? ? self.custom_points : Economy.points(level, self.length)
   end

--- a/test/controllers/api/series_controller_test.rb
+++ b/test/controllers/api/series_controller_test.rb
@@ -31,6 +31,16 @@ describe Api::SeriesController do
     assigns[:series].wont_include v3_series
   end
 
+  it 'should list matching series for text' do
+    series = create(:series, title: 'You are all Weirdos')
+    series2 = create(:series, title: 'We are all Freakazoids')
+    get(:index, api_version: 'v1', format: 'json', filters: 'text=weirdos')
+    assert_response :success
+    assert_not_nil assigns[:series]
+    assigns[:series].must_include series
+    assigns[:series].wont_include series2
+  end
+
   describe 'with a valid token' do
 
     around do |test|

--- a/test/controllers/api/stories_controller_test.rb
+++ b/test/controllers/api/stories_controller_test.rb
@@ -166,4 +166,14 @@ describe Api::StoriesController do
     assert_response :success
     assert_not_nil assigns[:story]
   end
+
+  it 'should list matching stories for text' do
+    story = create(:story, title: 'You are all Weirdos')
+    story2 = create(:story, title: 'We are all Freakazoids')
+    get(:index, api_version: 'v1', format: 'json', filters: 'text=weirdos')
+    assert_response :success
+    assert_not_nil assigns[:stories]
+    assigns[:stories].must_include story
+    assigns[:stories].wont_include story2
+  end
 end

--- a/test/models/series_test.rb
+++ b/test/models/series_test.rb
@@ -79,6 +79,18 @@ describe Series do
       Series.where(id: [series.id, v3_series.id]).v4.must_include series
       Series.where(id: [series.id, v3_series.id]).v4.wont_include v3_series
     end
+
+    it 'searches text for title and description' do
+      series = create(:series,
+                      title: 'Some Weirdo',
+                      description: 'Unique thing',
+                      short_description: 'Lacking sense')
+
+      Series.match_text('weirdo').must_include series
+      Series.match_text('unique').must_include series
+      Series.match_text('lack').must_include series
+      Series.match_text('random').wont_include series
+    end
   end
 
 end

--- a/test/models/story_test.rb
+++ b/test/models/story_test.rb
@@ -225,6 +225,18 @@ describe Story do
       story.update_attributes(app_version: 'foobar', deleted_at: nil)
       Story.where(id: story.id).v4.wont_include story
     end
+
+    it 'searches text for title and description' do
+      story = create(:story,
+                     title: 'Some Weirdo',
+                     description: 'Unique thing',
+                     short_description: 'Lacking sense')
+
+      Story.match_text('weirdo').must_include story
+      Story.match_text('unique').must_include story
+      Story.match_text('lack').must_include story
+      Story.match_text('random').wont_include story
+    end
   end
 
   describe 'default scope' do
@@ -250,5 +262,4 @@ describe Story do
       Story.where(id: story.id).must_include story
     end
   end
-
 end


### PR DESCRIPTION
The ticket #156 was only for series, but went ahead and added the same for stories.

- [x] Scope added for `match_text(text)` to models
- [x] Controllers declare `text` filter param, use match_text scope for filter text to get resources

Use these by adding a `filters` param to the get request:
`https://cms.prx.org/api/v1/accounts/8/series?filters=text%3Dweirdos`
(where `%3D` decodes to `=`)

The series/stories will be filtered to match case-insensitively in the title, short description, or description against the text `weirdos`.