### PR TITLE
Fix representers to have consistent contents for embedded stories

### DIFF
--- a/app/controllers/api/auth/accounts_controller.rb
+++ b/app/controllers/api/auth/accounts_controller.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Api::Auth::AccountsController < Api::AccountsController
-
   include ApiAuthenticated
 
   api_versions :v1
@@ -17,5 +16,4 @@ class Api::Auth::AccountsController < Api::AccountsController
   def resources_base
     @accounts ||= current_user.approved_accounts
   end
-
 end

--- a/app/controllers/api/auth/networks_controller.rb
+++ b/app/controllers/api/auth/networks_controller.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Api::Auth::NetworksController < Api::NetworksController
-
   include ApiAuthenticated
 
   api_versions :v1
@@ -17,5 +16,4 @@ class Api::Auth::NetworksController < Api::NetworksController
   def resources_base
     @networks ||= current_user.networks
   end
-
 end

--- a/app/controllers/api/stories_controller.rb
+++ b/app/controllers/api/stories_controller.rb
@@ -38,7 +38,7 @@ class Api::StoriesController < Api::BaseController
   end
 
   def random
-    @story = Story.published.network_visible.series_visible.limit(1).order('RAND()').first
+    @story = Story.public_stories.limit(1).order('RAND()').first
     show
   end
 
@@ -73,7 +73,7 @@ class Api::StoriesController < Api::BaseController
   end
 
   def scoped(relation)
-    relation.published.network_visible.series_visible
+    Story.public_stories(relation)
   end
 
   def sorted(res)

--- a/app/controllers/api/stories_controller.rb
+++ b/app/controllers/api/stories_controller.rb
@@ -73,7 +73,7 @@ class Api::StoriesController < Api::BaseController
   end
 
   def scoped(relation)
-    Story.public_stories(relation)
+    relation.public_stories
   end
 
   def sorted(res)

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -9,8 +9,7 @@ class Account < BaseModel
   has_one :image, -> { where(parent_id: nil) }, class_name: 'AccountImage'
   has_one :portfolio
 
-  has_many :stories, -> { where('published_at is not null and network_only_at is null').order(published_at: :desc) }
-  has_many :all_stories, foreign_key: 'account_id', class_name: 'Story'
+  has_many :stories, -> { order(published_at: :desc) }
   has_many :series
   has_many :memberships
   has_many :websites, as: :browsable

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,6 +1,8 @@
 # encoding: utf-8
 
 class Account < BaseModel
+  include Storied
+
   acts_as_paranoid
 
   belongs_to :opener, -> { with_deleted }, class_name: 'User', foreign_key: 'opener_id'

--- a/app/models/base_model.rb
+++ b/app/models/base_model.rb
@@ -14,8 +14,4 @@ class BaseModel < ActiveRecord::Base
     raw_write_attribute(:filename, name)
     save!
   end
-
-  def public_stories(arel = nil)
-    Story.public_stories(arel || stories)
-  end
 end

--- a/app/models/base_model.rb
+++ b/app/models/base_model.rb
@@ -14,4 +14,8 @@ class BaseModel < ActiveRecord::Base
     raw_write_attribute(:filename, name)
     save!
   end
+
+  def public_stories(arel=nil)
+    Story.public_stories(arel || stories)
+  end
 end

--- a/app/models/base_model.rb
+++ b/app/models/base_model.rb
@@ -15,7 +15,7 @@ class BaseModel < ActiveRecord::Base
     save!
   end
 
-  def public_stories(arel=nil)
+  def public_stories(arel = nil)
     Story.public_stories(arel || stories)
   end
 end

--- a/app/models/concerns/storied.rb
+++ b/app/models/concerns/storied.rb
@@ -1,0 +1,9 @@
+# encoding: utf-8
+
+module Storied
+  extend ActiveSupport::Concern
+
+  def public_stories
+    stories.public_stories
+  end
+end

--- a/app/models/network.rb
+++ b/app/models/network.rb
@@ -3,8 +3,7 @@
 class Network < BaseModel
   belongs_to :account
 
-  has_many :stories, -> { where('published_at is not null and network_only_at is null').order(published_at: :desc) }
-  has_many :all_stories, -> { where('published_at is not null').order(published_at: :desc) }, foreign_key: 'network_id', class_name: 'Story'
+  has_many :stories, -> { published.series_visible.order(published_at: :desc) }
 
   def self.policy_class
     AccountablePolicy

--- a/app/models/network.rb
+++ b/app/models/network.rb
@@ -1,6 +1,8 @@
 # encoding: utf-8
 
 class Network < BaseModel
+  include Storied
+
   belongs_to :account
 
   has_many :stories, -> { published.series_visible.order(published_at: :desc) }

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 class Playlist < BaseModel
+  include Storied
 
   acts_as_paranoid
 

--- a/app/models/playlist_section.rb
+++ b/app/models/playlist_section.rb
@@ -1,6 +1,8 @@
 # encoding: utf-8
 
 class PlaylistSection < BaseModel
+  include Storied
+
   self.table_name = 'playlist_sections'
 
   belongs_to :playlist, touch: true

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -13,8 +13,7 @@ class Series < BaseModel
   belongs_to :account, -> { with_deleted }
   belongs_to :creator, -> { with_deleted }, class_name: 'User', foreign_key: 'creator_id'
 
-  has_many :stories, -> { where('published_at is not null and network_only_at is null').order('episode_number DESC, position DESC, published_at DESC') }
-  has_many :all_stories, foreign_key: 'series_id', class_name: 'Story'
+  has_many :stories, -> { order('episode_number DESC, position DESC, published_at DESC') }
   has_many :schedules
 
   has_one :image, -> { where(parent_id: nil) }, class_name: 'SeriesImage'
@@ -30,10 +29,6 @@ class Series < BaseModel
           "`series`.`short_description` like '%#{text}%' OR " +
           "`series`.`description` like '%#{text}%'")
   }
-
-  def story_count
-    @story_count ||= stories.published.network_visible.series_visible.count
-  end
 
   def subscribable?
     subscription_approval_status == SUBSCRIPTION_PRX_APPROVED

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -8,6 +8,8 @@ class Series < BaseModel
     SUBSCRIPTION_PRX_APPROVED  = 'PRX Approved'
   ]
 
+  include Storied
+
   acts_as_paranoid
 
   belongs_to :account, -> { with_deleted }

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -75,9 +75,7 @@ class Story < BaseModel
           "`pieces`.`description` like '%#{text}%'")
   }
 
-  def self.public_stories(arel = nil)
-    (arel || self).published.network_visible.series_visible
-  end
+  scope :public_stories, -> { published.network_visible.series_visible }
 
   def points(level=point_level)
     has_custom_points? ? self.custom_points : Economy.points(level, self.length)

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -75,7 +75,7 @@ class Story < BaseModel
           "`pieces`.`description` like '%#{text}%'")
   }
 
-  def self.public_stories(arel=nil)
+  def self.public_stories(arel = nil)
     (arel || self).published.network_visible.series_visible
   end
 

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -75,6 +75,10 @@ class Story < BaseModel
           "`pieces`.`description` like '%#{text}%'")
   }
 
+  def self.public_stories(arel=nil)
+    (arel || self).published.network_visible.series_visible
+  end
+
   def points(level=point_level)
     has_custom_points? ? self.custom_points : Economy.points(level, self.length)
   end

--- a/app/representers/api/account_representer.rb
+++ b/app/representers/api/account_representer.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Api::AccountRepresenter < Api::BaseRepresenter
-
   property :id, writeable: false
   property :type
   property :name
@@ -34,16 +33,20 @@ class Api::AccountRepresenter < Api::BaseRepresenter
 
   link :stories do
     {
-      href: "#{api_account_stories_path(represented)}{?page,per,zoom,filters}",
+      href: "#{api_account_stories_path(represented)}#{index_url_params}",
       templated: true,
-      count: represented.stories.count
+      count: represented.public_stories.count
     } if represented.id
   end
-  embed :stories, paged: true, item_class: Story, item_decorator: Api::Min::StoryRepresenter
+  embed :public_stories,
+    as: :stories,
+    paged: true,
+    item_class: Story,
+    item_decorator: Api::Min::StoryRepresenter
 
   link :series do
     {
-      href: "#{api_account_series_index_path(represented)}{?page,per,zoom,filters}",
+      href: "#{api_account_series_index_path(represented)}#{index_url_params}",
       templated: true,
       count: represented.series.count
     } if represented.id

--- a/app/representers/api/account_representer.rb
+++ b/app/representers/api/account_representer.rb
@@ -39,10 +39,10 @@ class Api::AccountRepresenter < Api::BaseRepresenter
     } if represented.id
   end
   embed :public_stories,
-    as: :stories,
-    paged: true,
-    item_class: Story,
-    item_decorator: Api::Min::StoryRepresenter
+        as: :stories,
+        paged: true,
+        item_class: Story,
+        item_decorator: Api::Min::StoryRepresenter
 
   link :series do
     {

--- a/app/representers/api/address_representer.rb
+++ b/app/representers/api/address_representer.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Api::AddressRepresenter < Api::BaseRepresenter
-
   property :id, writeable: false
   property :street_1
   property :street_2

--- a/app/representers/api/api_representer.rb
+++ b/app/representers/api/api_representer.rb
@@ -14,7 +14,7 @@ class Api::ApiRepresenter < Api::BaseRepresenter
         title: 'Get a single story',
         profile: profile_url(:story),
         href: api_story_path_template(api_version: represented.version, id: '{id}') +
-              show_url_params,
+          show_url_params,
         templated: true
       }
     ]
@@ -37,7 +37,7 @@ class Api::ApiRepresenter < Api::BaseRepresenter
         title: 'Get a single series',
         profile: profile_url(:series),
         href: api_series_path_template(api_version: represented.version, id: '{id}') +
-              show_url_params,
+          show_url_params,
         templated: true
       },
       {
@@ -55,7 +55,7 @@ class Api::ApiRepresenter < Api::BaseRepresenter
         title: 'Get a single account',
         profile: profile_url(:account),
         href: api_account_path_template(api_version: represented.version, id: '{id}') +
-              show_url_params,
+          show_url_params,
         templated: true
       }
     ]
@@ -98,7 +98,7 @@ class Api::ApiRepresenter < Api::BaseRepresenter
         title: 'Get a single network',
         profile: profile_url(:network),
         href: api_network_path_template(api_version: represented.version, id: '{id}') +
-              show_url_params,
+          show_url_params,
         templated: true
       }
     ]

--- a/app/representers/api/api_representer.rb
+++ b/app/representers/api/api_representer.rb
@@ -11,9 +11,9 @@ class Api::ApiRepresenter < Api::BaseRepresenter
   links :story do
     [
       {
-        title:     "Get a single story",
-        profile:   profile_url(:story),
-        href:      api_story_path_template(api_version: represented.version, id: '{id}') + '{?zoom}',
+        title: 'Get a single story',
+        profile: profile_url(:story),
+        href: api_story_path_template(api_version: represented.version, id: '{id}') + '{?zoom}',
         templated: true
       }
     ]
@@ -22,9 +22,9 @@ class Api::ApiRepresenter < Api::BaseRepresenter
   links :stories do
     [
       {
-        title:     "Get a paged collection of stories",
-        profile:   profile_url(:collection, :story),
-        href:      api_stories_path_template(api_version: represented.version) + index_url_params,
+        title: 'Get a paged collection of stories',
+        profile: profile_url(:collection, :story),
+        href: api_stories_path_template(api_version: represented.version) + index_url_params,
         templated: true
       }
     ]
@@ -33,15 +33,15 @@ class Api::ApiRepresenter < Api::BaseRepresenter
   links :series do
     [
       {
-        title:     "Get a single series",
-        profile:   profile_url(:series),
-        href:      api_series_path_template(api_version: represented.version, id: '{id}') + '{?zoom}',
+        title: 'Get a single series',
+        profile: profile_url(:series),
+        href: api_series_path_template(api_version: represented.version, id: '{id}') + '{?zoom}',
         templated: true
       },
       {
-        title:     "Get a paged collection of series",
-        profile:   profile_url(:collection, :series),
-        href:      api_series_index_path_template(api_version: represented.version) + index_url_params,
+        title: 'Get a paged collection of series',
+        profile: profile_url(:collection, :series),
+        href: api_series_index_path_template(api_version: represented.version) + index_url_params,
         templated: true
       }
     ]
@@ -50,9 +50,9 @@ class Api::ApiRepresenter < Api::BaseRepresenter
   links :account do
     [
       {
-        title:     "Get a single account",
-        profile:   profile_url(:account),
-        href:      api_account_path_template(api_version: represented.version, id: '{id}') + '{?zoom}',
+        title: 'Get a single account',
+        profile: profile_url(:account),
+        href: api_account_path_template(api_version: represented.version, id: '{id}') + '{?zoom}',
         templated: true
       }
     ]
@@ -61,9 +61,9 @@ class Api::ApiRepresenter < Api::BaseRepresenter
   links :accounts do
     [
       {
-        title:     "Get a paged collection of accounts",
-        profile:   profile_url(:collection, :account),
-        href:      api_accounts_path_template(api_version: represented.version) + index_url_params,
+        title: 'Get a paged collection of accounts',
+        profile: profile_url(:collection, :account),
+        href: api_accounts_path_template(api_version: represented.version) + index_url_params,
         templated: true
       }
     ]
@@ -72,9 +72,9 @@ class Api::ApiRepresenter < Api::BaseRepresenter
   links :picks do
     [
       {
-        title:     "Get a paged collection of the most recent picks",
-        profile:   profile_url(:collection, :pick),
-        href:      api_picks_path_template(api_version: represented.version) + index_url_params,
+        title: 'Get a paged collection of the most recent picks',
+        profile: profile_url(:collection, :pick),
+        href: api_picks_path_template(api_version: represented.version) + index_url_params,
         templated: true
       }
     ]
@@ -92,9 +92,9 @@ class Api::ApiRepresenter < Api::BaseRepresenter
   links :network do
     [
       {
-        title:     "Get a single network",
-        profile:   profile_url(:network),
-        href:      api_network_path_template(api_version: represented.version, id: '{id}') + '{?zoom}',
+        title: 'Get a single network',
+        profile: profile_url(:network),
+        href: api_network_path_template(api_version: represented.version, id: '{id}') + '{?zoom}',
         templated: true
       }
     ]
@@ -103,9 +103,9 @@ class Api::ApiRepresenter < Api::BaseRepresenter
   links :networks do
     [
       {
-        title:     "Get a paged collection of networks",
-        profile:   profile_url(:collection, :network),
-        href:      api_networks_path_template(api_version: represented.version) + index_url_params,
+        title: 'Get a paged collection of networks',
+        profile: profile_url(:collection, :network),
+        href: api_networks_path_template(api_version: represented.version) + index_url_params,
         templated: true
       }
     ]

--- a/app/representers/api/api_representer.rb
+++ b/app/representers/api/api_representer.rb
@@ -13,7 +13,7 @@ class Api::ApiRepresenter < Api::BaseRepresenter
       {
         title: 'Get a single story',
         profile: profile_url(:story),
-        href: api_story_path_template(api_version: represented.version, id: '{id}') + '{?zoom}',
+        href: api_story_path_template(api_version: represented.version, id: '{id}') + show_url_params,
         templated: true
       }
     ]
@@ -35,7 +35,7 @@ class Api::ApiRepresenter < Api::BaseRepresenter
       {
         title: 'Get a single series',
         profile: profile_url(:series),
-        href: api_series_path_template(api_version: represented.version, id: '{id}') + '{?zoom}',
+        href: api_series_path_template(api_version: represented.version, id: '{id}') + show_url_params,
         templated: true
       },
       {
@@ -52,7 +52,7 @@ class Api::ApiRepresenter < Api::BaseRepresenter
       {
         title: 'Get a single account',
         profile: profile_url(:account),
-        href: api_account_path_template(api_version: represented.version, id: '{id}') + '{?zoom}',
+        href: api_account_path_template(api_version: represented.version, id: '{id}') + show_url_params,
         templated: true
       }
     ]
@@ -94,7 +94,7 @@ class Api::ApiRepresenter < Api::BaseRepresenter
       {
         title: 'Get a single network',
         profile: profile_url(:network),
-        href: api_network_path_template(api_version: represented.version, id: '{id}') + '{?zoom}',
+        href: api_network_path_template(api_version: represented.version, id: '{id}') + show_url_params,
         templated: true
       }
     ]

--- a/app/representers/api/api_representer.rb
+++ b/app/representers/api/api_representer.rb
@@ -13,7 +13,8 @@ class Api::ApiRepresenter < Api::BaseRepresenter
       {
         title: 'Get a single story',
         profile: profile_url(:story),
-        href: api_story_path_template(api_version: represented.version, id: '{id}') + show_url_params,
+        href: api_story_path_template(api_version: represented.version, id: '{id}') +
+              show_url_params,
         templated: true
       }
     ]
@@ -35,7 +36,8 @@ class Api::ApiRepresenter < Api::BaseRepresenter
       {
         title: 'Get a single series',
         profile: profile_url(:series),
-        href: api_series_path_template(api_version: represented.version, id: '{id}') + show_url_params,
+        href: api_series_path_template(api_version: represented.version, id: '{id}') +
+              show_url_params,
         templated: true
       },
       {
@@ -52,7 +54,8 @@ class Api::ApiRepresenter < Api::BaseRepresenter
       {
         title: 'Get a single account',
         profile: profile_url(:account),
-        href: api_account_path_template(api_version: represented.version, id: '{id}') + show_url_params,
+        href: api_account_path_template(api_version: represented.version, id: '{id}') +
+              show_url_params,
         templated: true
       }
     ]
@@ -94,7 +97,8 @@ class Api::ApiRepresenter < Api::BaseRepresenter
       {
         title: 'Get a single network',
         profile: profile_url(:network),
-        href: api_network_path_template(api_version: represented.version, id: '{id}') + show_url_params,
+        href: api_network_path_template(api_version: represented.version, id: '{id}') +
+              show_url_params,
         templated: true
       }
     ]

--- a/app/representers/api/api_representer.rb
+++ b/app/representers/api/api_representer.rb
@@ -24,7 +24,7 @@ class Api::ApiRepresenter < Api::BaseRepresenter
       {
         title:     "Get a paged collection of stories",
         profile:   profile_url(:collection, :story),
-        href:      api_stories_path_template(api_version: represented.version) + '{?page,per,zoom,filters}',
+        href:      api_stories_path_template(api_version: represented.version) + index_url_params,
         templated: true
       }
     ]
@@ -41,7 +41,7 @@ class Api::ApiRepresenter < Api::BaseRepresenter
       {
         title:     "Get a paged collection of series",
         profile:   profile_url(:collection, :series),
-        href:      api_series_index_path_template(api_version: represented.version) + '{?page,per,zoom}',
+        href:      api_series_index_path_template(api_version: represented.version) + index_url_params,
         templated: true
       }
     ]
@@ -63,7 +63,7 @@ class Api::ApiRepresenter < Api::BaseRepresenter
       {
         title:     "Get a paged collection of accounts",
         profile:   profile_url(:collection, :account),
-        href:      api_accounts_path_template(api_version: represented.version) + '{?page,per,zoom}',
+        href:      api_accounts_path_template(api_version: represented.version) + index_url_params,
         templated: true
       }
     ]
@@ -74,7 +74,7 @@ class Api::ApiRepresenter < Api::BaseRepresenter
       {
         title:     "Get a paged collection of the most recent picks",
         profile:   profile_url(:collection, :pick),
-        href:      api_picks_path_template(api_version: represented.version) + '{?page,per,zoom}',
+        href:      api_picks_path_template(api_version: represented.version) + index_url_params,
         templated: true
       }
     ]
@@ -105,7 +105,7 @@ class Api::ApiRepresenter < Api::BaseRepresenter
       {
         title:     "Get a paged collection of networks",
         profile:   profile_url(:collection, :network),
-        href:      api_networks_path_template(api_version: represented.version) + '{?page,per,zoom}',
+        href:      api_networks_path_template(api_version: represented.version) + index_url_params,
         templated: true
       }
     ]

--- a/app/representers/api/audio_file_representer.rb
+++ b/app/representers/api/audio_file_representer.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Api::AudioFileRepresenter < Api::BaseRepresenter
-
   property :id, writeable: false
   property :position
 

--- a/app/representers/api/auth/account_min_representer.rb
+++ b/app/representers/api/auth/account_min_representer.rb
@@ -1,19 +1,21 @@
 # encoding: utf-8
 
 class Api::Auth::AccountMinRepresenter < Api::Min::AccountRepresenter
-
   # point to authorized stories (including unpublished)
   link :stories do
     {
-      href: "#{api_authorization_account_stories_path(represented)}{?page,per,zoom,filters}",
-      templated: true
+      href: "#{api_authorization_account_stories_path(represented)}#{index_url_params}",
+      templated: true,
+      count: represented.stories.count
     }
   end
-  embed :all_stories, as: :stories, paged: true, item_class: Story,
-                      item_decorator: Api::Auth::StoryMinRepresenter, zoom: false
+  embed :stories,
+    paged: true,
+    item_class: Story,
+    item_decorator: Api::Auth::StoryMinRepresenter,
+    zoom: false
 
   def self_url(r)
     api_authorization_account_path(r)
   end
-
 end

--- a/app/representers/api/auth/account_min_representer.rb
+++ b/app/representers/api/auth/account_min_representer.rb
@@ -10,10 +10,10 @@ class Api::Auth::AccountMinRepresenter < Api::Min::AccountRepresenter
     }
   end
   embed :stories,
-    paged: true,
-    item_class: Story,
-    item_decorator: Api::Auth::StoryMinRepresenter,
-    zoom: false
+        paged: true,
+        item_class: Story,
+        item_decorator: Api::Auth::StoryMinRepresenter,
+        zoom: false
 
   def self_url(r)
     api_authorization_account_path(r)

--- a/app/representers/api/auth/account_representer.rb
+++ b/app/representers/api/auth/account_representer.rb
@@ -10,10 +10,10 @@ class Api::Auth::AccountRepresenter < Api::AccountRepresenter
     } if represented.id
   end
   embed :stories,
-    paged: true,
-    item_class: Story,
-    item_decorator: Api::Auth::StoryMinRepresenter,
-    url: ->(_r) { api_authorization_account_stories_path(represented.parent) }
+        paged: true,
+        item_class: Story,
+        item_decorator: Api::Auth::StoryMinRepresenter,
+        url: ->(_r) { api_authorization_account_stories_path(represented.parent) }
 
   def self_url(r)
     api_authorization_account_path(r)

--- a/app/representers/api/auth/account_representer.rb
+++ b/app/representers/api/auth/account_representer.rb
@@ -4,14 +4,16 @@ class Api::Auth::AccountRepresenter < Api::AccountRepresenter
   # point to authorized stories (including unpublished)
   link :stories do
     {
-      href: "#{api_authorization_account_stories_path(represented)}{?page,per,zoom,filters}",
+      href: "#{api_authorization_account_stories_path(represented)}#{index_url_params}",
       templated: true,
-      count: represented.all_stories.count
+      count: represented.stories.count
     } if represented.id
   end
-  embed :all_stories, as: :stories, paged: true, item_class: Story,
-                      item_decorator: Api::Auth::StoryMinRepresenter,
-                      url: ->(_r) { api_authorization_account_stories_path(represented.parent) }
+  embed :stories,
+    paged: true,
+    item_class: Story,
+    item_decorator: Api::Auth::StoryMinRepresenter,
+    url: ->(_r) { api_authorization_account_stories_path(represented.parent) }
 
   def self_url(r)
     api_authorization_account_path(r)

--- a/app/representers/api/auth/network_representer.rb
+++ b/app/representers/api/auth/network_representer.rb
@@ -10,10 +10,10 @@ class Api::Auth::NetworkRepresenter < Api::NetworkRepresenter
     } if represented.id
   end
   embed :stories,
-    paged: true,
-    item_class: Story,
-    item_decorator: Api::Auth::StoryMinRepresenter,
-    url: ->(_r) { api_authorization_network_stories_path(represented.parent) }
+        paged: true,
+        item_class: Story,
+        item_decorator: Api::Auth::StoryMinRepresenter,
+        url: ->(_r) { api_authorization_network_stories_path(represented.parent) }
 
   def self_url(r)
     api_authorization_network_path(r)

--- a/app/representers/api/auth/network_representer.rb
+++ b/app/representers/api/auth/network_representer.rb
@@ -4,14 +4,16 @@ class Api::Auth::NetworkRepresenter < Api::NetworkRepresenter
   # point to authorized stories (including unpublished)
   link :stories do
     {
-      href: "#{api_authorization_network_stories_path(represented)}{?page,per,zoom,filters}",
+      href: "#{api_authorization_network_stories_path(represented)}#{index_url_params}",
       templated: true,
-      count: represented.all_stories.count
+      count: represented.stories.count
     } if represented.id
   end
-  embed :all_stories, as: :stories, paged: true, item_class: Story,
-                      item_decorator: Api::Auth::StoryMinRepresenter,
-                      url: ->(_r) { api_authorization_network_stories_path(represented.parent) }
+  embed :stories,
+    paged: true,
+    item_class: Story,
+    item_decorator: Api::Auth::StoryMinRepresenter,
+    url: ->(_r) { api_authorization_network_stories_path(represented.parent) }
 
   def self_url(r)
     api_authorization_network_path(r)

--- a/app/representers/api/auth/series_representer.rb
+++ b/app/representers/api/auth/series_representer.rb
@@ -10,11 +10,11 @@ class Api::Auth::SeriesRepresenter < Api::SeriesRepresenter
     } if represented.id
   end
   embed :stories,
-    paged: true,
-    item_class: Story,
-    item_decorator: Api::Auth::StoryMinRepresenter,
-    url: ->(_r) { api_authorization_series_stories_path(represented.parent) },
-    zoom: false
+        paged: true,
+        item_class: Story,
+        item_decorator: Api::Auth::StoryMinRepresenter,
+        url: ->(_r) { api_authorization_series_stories_path(represented.parent) },
+        zoom: false
 
   def self_url(r)
     api_authorization_series_path(r)

--- a/app/representers/api/auth/series_representer.rb
+++ b/app/representers/api/auth/series_representer.rb
@@ -1,25 +1,22 @@
 # encoding: utf-8
 
 class Api::Auth::SeriesRepresenter < Api::SeriesRepresenter
-
   # point to authorized stories (including unpublished)
   link :stories do
     {
-      href: "#{api_authorization_series_stories_path(represented)}{?page,per,zoom,filters}",
+      href: "#{api_authorization_series_stories_path(represented)}#{index_url_params}",
       templated: true,
-      count: represented.all_stories.count
+      count: represented.stories.count
     } if represented.id
   end
-  embed :all_stories, as: :stories, paged: true, item_class: Story,
-                      item_decorator: Api::Auth::StoryMinRepresenter,
-                      url: ->(_r) { api_authorization_series_stories_path(represented.parent) },
-                      zoom: false
-
-  # TODO: why is this necessary? maybe because :all_stories != :stories ???
-  embed :stories, zoom: false
+  embed :stories,
+    paged: true,
+    item_class: Story,
+    item_decorator: Api::Auth::StoryMinRepresenter,
+    url: ->(_r) { api_authorization_series_stories_path(represented.parent) },
+    zoom: false
 
   def self_url(r)
     api_authorization_series_path(r)
   end
-
 end

--- a/app/representers/api/auth/story_min_representer.rb
+++ b/app/representers/api/auth/story_min_representer.rb
@@ -1,11 +1,9 @@
 # encoding: utf-8
 
 class Api::Auth::StoryMinRepresenter < Api::Min::StoryRepresenter
-
   # just make sure "self" stays under authorization, because unpublished
   # stories won't exist under the public stories path
   def self_url(r)
     api_authorization_story_path(r)
   end
-
 end

--- a/app/representers/api/auth/story_representer.rb
+++ b/app/representers/api/auth/story_representer.rb
@@ -1,11 +1,9 @@
 # encoding: utf-8
 
 class Api::Auth::StoryRepresenter < Api::StoryRepresenter
-
   # make sure "self" stays under authorization, because unpublished
   # stories won't exist under the public stories path
   def self_url(r)
     api_authorization_story_path(r)
   end
-
 end

--- a/app/representers/api/authorization_representer.rb
+++ b/app/representers/api/authorization_representer.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Api::AuthorizationRepresenter < Api::BaseRepresenter
-
   property :id, writeable: false
   property :name
 
@@ -14,7 +13,7 @@ class Api::AuthorizationRepresenter < Api::BaseRepresenter
 
   link :accounts do
     {
-      href: "#{api_authorization_accounts_path}{?page,per,zoom}",
+      href: "#{api_authorization_accounts_path}#{index_url_params}",
       templated: true,
       count: represented.accounts.count
     }
@@ -31,7 +30,7 @@ class Api::AuthorizationRepresenter < Api::BaseRepresenter
         count: represented.approved_account_series.count
       },
       {
-        href: "#{api_authorization_series_index_path}{?page,per,zoom,filters}",
+        href: "#{api_authorization_series_index_path}#{index_url_params}",
         templated: true,
         count: represented.approved_account_series.count
       }
@@ -40,7 +39,7 @@ class Api::AuthorizationRepresenter < Api::BaseRepresenter
 
   link :stories do
     {
-      href: "#{api_authorization_stories_path}{?page,per,zoom,filters}",
+      href: "#{api_authorization_stories_path}#{index_url_params}",
       templated: true,
       count: represented.approved_account_stories.count
     }
@@ -63,5 +62,4 @@ class Api::AuthorizationRepresenter < Api::BaseRepresenter
   def self_url(_r)
     api_authorization_path
   end
-
 end

--- a/app/representers/api/authorization_representer.rb
+++ b/app/representers/api/authorization_representer.rb
@@ -25,7 +25,7 @@ class Api::AuthorizationRepresenter < Api::BaseRepresenter
   links :series do
     [
       {
-        href: "#{api_authorization_series_path_template(id: '{id}')}{?zoom}",
+        href: "#{api_authorization_series_path_template(id: '{id}')}#{show_url_params}",
         templated: true,
         count: represented.approved_account_series.count
       },
@@ -47,14 +47,14 @@ class Api::AuthorizationRepresenter < Api::BaseRepresenter
 
   link :story do
     {
-      href: "#{api_authorization_story_path_template(id: '{id}')}{?zoom}",
+      href: "#{api_authorization_story_path_template(id: '{id}')}#{show_url_params}",
       templated: true,
     }
   end
 
   link :network do
     {
-      href: "#{api_authorization_network_path_template(id: '{id}')}{?zoom}",
+      href: "#{api_authorization_network_path_template(id: '{id}')}#{show_url_params}",
       templated: true,
     }
   end

--- a/app/representers/api/base_representer.rb
+++ b/app/representers/api/base_representer.rb
@@ -17,4 +17,8 @@ class Api::BaseRepresenter < HalApi::Representer
   def self.profile_host
     ENV['META_HOST'] || 'meta.prx.org'
   end
+
+  def index_url_params
+    "{?page,per,zoom,filters,sorts}"
+  end
 end

--- a/app/representers/api/base_representer.rb
+++ b/app/representers/api/base_representer.rb
@@ -21,4 +21,8 @@ class Api::BaseRepresenter < HalApi::Representer
   def index_url_params
     '{?page,per,zoom,filters,sorts}'
   end
+
+  def show_url_params
+    '{?zoom}'
+  end
 end

--- a/app/representers/api/base_representer.rb
+++ b/app/representers/api/base_representer.rb
@@ -19,6 +19,6 @@ class Api::BaseRepresenter < HalApi::Representer
   end
 
   def index_url_params
-    "{?page,per,zoom,filters,sorts}"
+    '{?page,per,zoom,filters,sorts}'
   end
 end

--- a/app/representers/api/image_representer.rb
+++ b/app/representers/api/image_representer.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Api::ImageRepresenter < Api::BaseRepresenter
-
   def self_url(represented)
     if represented.is_a?(StoryImage)
       api_story_story_image_path(represented.story, represented)

--- a/app/representers/api/license_representer.rb
+++ b/app/representers/api/license_representer.rb
@@ -3,7 +3,6 @@ require 'roar/json/hal'
 require 'hal_api/representer/caches'
 
 class Api::LicenseRepresenter < Roar::Decorator
-
   include Roar::JSON::HAL
   include HalApi::Representer::Caches
 

--- a/app/representers/api/membership_representer.rb
+++ b/app/representers/api/membership_representer.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Api::MembershipRepresenter < Api::BaseRepresenter
-
   property :id, writeable: false
   property :role
   property :approved

--- a/app/representers/api/min/account_representer.rb
+++ b/app/representers/api/min/account_representer.rb
@@ -39,11 +39,11 @@ class Api::Min::AccountRepresenter < Api::BaseRepresenter
     }
   end
   embed :public_stories,
-    as: :stories,
-    paged: true,
-    item_class: Story,
-    item_decorator: Api::Min::StoryRepresenter,
-    zoom: false
+        as: :stories,
+        paged: true,
+        item_class: Story,
+        item_decorator: Api::Min::StoryRepresenter,
+        zoom: false
 
   link :series do
     {

--- a/app/representers/api/min/account_representer.rb
+++ b/app/representers/api/min/account_representer.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Api::Min::AccountRepresenter < Api::BaseRepresenter
-
   property :id, writeable: false
   property :type
   property :name
@@ -34,15 +33,21 @@ class Api::Min::AccountRepresenter < Api::BaseRepresenter
 
   link :stories do
     {
-      href: "#{api_account_stories_path(represented)}{?page,per,zoom,filters}",
-      templated: true
+      href: "#{api_account_stories_path(represented)}#{index_url_params}",
+      templated: true,
+      count: represented.public_stories.count
     }
   end
-  embed :stories, paged: true, item_class: Story, item_decorator: Api::Min::StoryRepresenter, zoom: false
+  embed :public_stories,
+    as: :stories,
+    paged: true,
+    item_class: Story,
+    item_decorator: Api::Min::StoryRepresenter,
+    zoom: false
 
   link :series do
     {
-      href: "#{api_account_series_index_path(represented)}{?page,per,zoom,filters}",
+      href: "#{api_account_series_index_path(represented)}#{index_url_params}",
       templated: true
     }
   end

--- a/app/representers/api/min/series_representer.rb
+++ b/app/representers/api/min/series_representer.rb
@@ -16,10 +16,10 @@ class Api::Min::SeriesRepresenter < Api::BaseRepresenter
     } if represented.id
   end
   embed :public_stories,
-    as: :stories,
-    paged: true,
-    item_class: Story,
-    item_decorator: Api::Min::StoryRepresenter
+        as: :stories,
+        paged: true,
+        item_class: Story,
+        item_decorator: Api::Min::StoryRepresenter
 
   link :image do
     api_series_image_path(represented.image) if represented.image

--- a/app/representers/api/min/series_representer.rb
+++ b/app/representers/api/min/series_representer.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Api::Min::SeriesRepresenter < Api::BaseRepresenter
-
   property :id, writeable: false
   property :title
   property :short_description
@@ -11,11 +10,16 @@ class Api::Min::SeriesRepresenter < Api::BaseRepresenter
 
   link :stories do
     {
-      href: api_series_stories_path(represented),
-      count: represented.story_count
-    }
+      href: "#{api_series_stories_path(represented)}#{index_url_params}",
+      templated: true,
+      count: represented.public_stories.count
+    } if represented.id
   end
-  embed :stories, paged: true, item_class: Story, item_decorator: Api::Min::StoryRepresenter, zoom: false
+  embed :public_stories,
+    as: :stories,
+    paged: true,
+    item_class: Story,
+    item_decorator: Api::Min::StoryRepresenter
 
   link :image do
     api_series_image_path(represented.image) if represented.image

--- a/app/representers/api/min/story_representer.rb
+++ b/app/representers/api/min/story_representer.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Api::Min::StoryRepresenter < Api::BaseRepresenter
-
   property :id, writeable: false
   property :title
   property :short_description

--- a/app/representers/api/min/user_representer.rb
+++ b/app/representers/api/min/user_representer.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Api::Min::UserRepresenter < Api::BaseRepresenter
-
   property :id, writeable: false
   property :first_name
   property :last_name

--- a/app/representers/api/msg/audio_file_representer.rb
+++ b/app/representers/api/msg/audio_file_representer.rb
@@ -4,7 +4,6 @@
 # Representer for Announce messaging
 #
 class Api::Msg::AudioFileRepresenter < Api::BaseRepresenter
-
   property :id, writeable: false
   property :filename, writeable: false
   property :size
@@ -15,5 +14,4 @@ class Api::Msg::AudioFileRepresenter < Api::BaseRepresenter
 
   # destination for the uploaded file
   property :fixerable_final_path, as: :destination_path
-
 end

--- a/app/representers/api/msg/image_representer.rb
+++ b/app/representers/api/msg/image_representer.rb
@@ -4,7 +4,6 @@
 # Representer for Announce messaging
 #
 class Api::Msg::ImageRepresenter < Api::BaseRepresenter
-
   property :id, writeable: false
   property :filename, writeable: false
   property :size
@@ -23,5 +22,4 @@ class Api::Msg::ImageRepresenter < Api::BaseRepresenter
 
   # destination for the uploaded file
   property :fixerable_final_path, as: :destination_path
-
 end

--- a/app/representers/api/musical_work_representer.rb
+++ b/app/representers/api/musical_work_representer.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Api::MusicalWorkRepresenter < Api::BaseRepresenter
-
   property :id, writeable: false
   property :position
   property :title

--- a/app/representers/api/network_representer.rb
+++ b/app/representers/api/network_representer.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Api::NetworkRepresenter < Api::BaseRepresenter
-
   property :id, writeable: false
   property :path
   property :name
@@ -23,10 +22,14 @@ class Api::NetworkRepresenter < Api::BaseRepresenter
 
   link :stories do
     {
-      href: "#{api_network_stories_path(represented)}{?page,per,zoom,filters}",
+      href: "#{api_network_stories_path(represented)}#{index_url_params}",
       templated: true,
-      count: represented.stories.count
+      count: represented.public_stories.count
     } if represented.id
   end
-  embed :stories, paged: true, item_class: Story, item_decorator: Api::Min::StoryRepresenter
+  embed :public_stories,
+    as: :stories,
+    paged: true,
+    item_class: Story,
+    item_decorator: Api::Min::StoryRepresenter
 end

--- a/app/representers/api/network_representer.rb
+++ b/app/representers/api/network_representer.rb
@@ -28,8 +28,8 @@ class Api::NetworkRepresenter < Api::BaseRepresenter
     } if represented.id
   end
   embed :public_stories,
-    as: :stories,
-    paged: true,
-    item_class: Story,
-    item_decorator: Api::Min::StoryRepresenter
+        as: :stories,
+        paged: true,
+        item_class: Story,
+        item_decorator: Api::Min::StoryRepresenter
 end

--- a/app/representers/api/paged_collection_representer.rb
+++ b/app/representers/api/paged_collection_representer.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Api::PagedCollectionRepresenter < Api::BaseRepresenter
-
   property :count
   property :total
 

--- a/app/representers/api/pick_representer.rb
+++ b/app/representers/api/pick_representer.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Api::PickRepresenter < Api::BaseRepresenter
-
   property :id, writeable: false
   property :comment
   property :editors_title

--- a/app/representers/api/producer_representer.rb
+++ b/app/representers/api/producer_representer.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Api::ProducerRepresenter < Api::BaseRepresenter
-
   property :id, writeable: false
   property :user_id
   property :name

--- a/app/representers/api/series_representer.rb
+++ b/app/representers/api/series_representer.rb
@@ -19,10 +19,10 @@ class Api::SeriesRepresenter < Api::BaseRepresenter
     } if represented.id
   end
   embed :public_stories,
-    as: :stories,
-    paged: true,
-    item_class: Story,
-    item_decorator: Api::Min::StoryRepresenter
+        as: :stories,
+        paged: true,
+        item_class: Story,
+        item_decorator: Api::Min::StoryRepresenter
 
   link :image do
     api_series_image_path(represented.image) if represented.image

--- a/app/representers/api/series_representer.rb
+++ b/app/representers/api/series_representer.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Api::SeriesRepresenter < Api::BaseRepresenter
-
   property :id, writeable: false
   property :title
   property :short_description
@@ -14,12 +13,16 @@ class Api::SeriesRepresenter < Api::BaseRepresenter
 
   link :stories do
     {
-      href: "#{api_series_stories_path(represented)}{?page,per,zoom}",
+      href: "#{api_series_stories_path(represented)}#{index_url_params}",
       templated: true,
-      count: represented.story_count
+      count: represented.public_stories.count
     } if represented.id
   end
-  embed :stories, paged: true, item_class: Story, item_decorator: Api::Min::StoryRepresenter
+  embed :public_stories,
+    as: :stories,
+    paged: true,
+    item_class: Story,
+    item_decorator: Api::Min::StoryRepresenter
 
   link :image do
     api_series_image_path(represented.image) if represented.image
@@ -34,5 +37,4 @@ class Api::SeriesRepresenter < Api::BaseRepresenter
     }
   end
   embed :account, class: Account, decorator: Api::Min::AccountRepresenter
-
 end

--- a/app/representers/api/story_representer.rb
+++ b/app/representers/api/story_representer.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Api::StoryRepresenter < Api::BaseRepresenter
-
   property :id, writeable: false
   property :title
   property :short_description
@@ -99,7 +98,7 @@ class Api::StoryRepresenter < Api::BaseRepresenter
 
   link :musical_works do
     {
-      href: "#{api_story_musical_works_path(represented)}{?page,per,zoom}",
+      href: "#{api_story_musical_works_path(represented)}#{index_url_params}",
       templated: true,
       count: represented.musical_works.count
     } if represented.id

--- a/app/representers/api/user_representer.rb
+++ b/app/representers/api/user_representer.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Api::UserRepresenter < Api::BaseRepresenter
-
   property :id, writeable: false
   property :first_name
   property :last_name
@@ -9,12 +8,16 @@ class Api::UserRepresenter < Api::BaseRepresenter
 
   link :accounts do
     {
-      href: "#{api_user_accounts_path(represented)}{?page,per,zoom}",
+      href: "#{api_user_accounts_path(represented)}#{index_url_params}",
       templated: true,
       count: represented.accounts.count
     } if represented.id
   end
-  embed :accounts, paged: true, item_class: Account, item_decorator: Api::Min::AccountRepresenter, zoom: false
+  embed :accounts,
+    paged: true,
+    item_class: Account,
+    item_decorator: Api::Min::AccountRepresenter,
+    zoom: false
 
   link :image do
     {

--- a/app/representers/api/user_representer.rb
+++ b/app/representers/api/user_representer.rb
@@ -14,10 +14,10 @@ class Api::UserRepresenter < Api::BaseRepresenter
     } if represented.id
   end
   embed :accounts,
-    paged: true,
-    item_class: Account,
-    item_decorator: Api::Min::AccountRepresenter,
-    zoom: false
+        paged: true,
+        item_class: Account,
+        item_decorator: Api::Min::AccountRepresenter,
+        zoom: false
 
   link :image do
     {

--- a/test/controllers/api/auth/stories_controller_test.rb
+++ b/test/controllers/api/auth/stories_controller_test.rb
@@ -4,7 +4,7 @@ describe Api::Auth::StoriesController do
   let (:user) { create(:user) }
   let (:token) { StubToken.new(account.id, ['member'], user.id) }
   let (:account) { user.individual_account }
-  let (:unpublished_story) { account.all_stories.first }
+  let (:unpublished_story) { account.stories.first }
   let (:random_story) { create(:story, published_at: nil) }
   let (:network) { create(:network, account: user.individual_account) }
   let (:network_story) { create(:story, network_id: network.id, network_only_at: Time.now) }
@@ -22,14 +22,14 @@ describe Api::Auth::StoriesController do
     it 'indexes stories under their account' do
       get(:index, api_version: 'v1', account_id: account.id)
       assert_response :success
-      JSON.parse(response.body)['count'].must_equal account.all_stories.count
-      account.all_stories.count.must_be :>, account.stories.count
+      JSON.parse(response.body)['count'].must_equal account.stories.count
+      account.stories.count.must_be :>, account.public_stories.count
     end
 
     it 'indexes stories in a network' do
       get(:index, api_version: 'v1', network_id: network.id)
       assert_response :success
-      JSON.parse(response.body)['count'].must_equal network.all_stories.count
+      JSON.parse(response.body)['count'].must_equal network.stories.count
     end
 
     it 'filters v4 stories' do

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -15,12 +15,12 @@ describe Account do
     account.stories.count.must_be :>, 0
   end
 
-  it 'does not include unpublished stories by default' do
-    account.stories.where(id: unpublished_story.id).count.must_equal 0
+  it 'does not include unpublished stories in public_stories' do
+    account.public_stories.where(id: unpublished_story.id).count.must_equal 0
   end
 
   it 'has unpublished (or any) stories' do
-    account.all_stories.where(id: unpublished_story.id).count.must_equal 1
+    account.stories.where(id: unpublished_story.id).count.must_equal 1
   end
 
   it 'has name as short name' do

--- a/test/models/concerns/fixerable_test.rb
+++ b/test/models/concerns/fixerable_test.rb
@@ -2,7 +2,8 @@ require 'test_helper'
 
 describe Fixerable do
 
-  class FixerableTestModel < ActionController::Base
+  class FixerableTestModel
+    include ActiveModel::Model
     include Fixerable
     fixerable_upload :the_temp_field, :the_final_field
     attr_accessor :the_temp_field

--- a/test/models/concerns/storied_test.rb
+++ b/test/models/concerns/storied_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+require 'active_record'
+
+describe Storied do
+
+  class StoriedTestModel
+    include ActiveModel::Model
+    include Storied
+
+    def stories
+      Story.all
+    end
+  end
+
+  let(:model) { StoriedTestModel.new }
+
+  it 'can get relation to public stories' do
+    StoriedTestModel.new.public_stories.wont_be_nil
+    StoriedTestModel.new.public_stories.must_be_instance_of Story::ActiveRecord_Relation
+  end
+end

--- a/test/models/network_test.rb
+++ b/test/models/network_test.rb
@@ -13,6 +13,5 @@ describe Network do
 
   it 'returns a list of stories' do
     network.stories.count.must_equal 2
-    network.all_stories.count.must_equal 2
   end
 end

--- a/test/models/series_test.rb
+++ b/test/models/series_test.rb
@@ -10,7 +10,8 @@ describe Series do
   end
 
   it 'has a story count' do
-    series.public_stories.count.must_equal series.stories.published.network_visible.series_visible.count
+    public_stories_count = series.stories.published.network_visible.series_visible.count
+    series.public_stories.count.must_equal public_stories_count
   end
 
   it 'actually deletes v4 series' do

--- a/test/models/series_test.rb
+++ b/test/models/series_test.rb
@@ -10,7 +10,7 @@ describe Series do
   end
 
   it 'has a story count' do
-    series.story_count.must_equal series.stories.published.network_visible.series_visible.count
+    series.public_stories.count.must_equal series.stories.published.network_visible.series_visible.count
   end
 
   it 'actually deletes v4 series' do

--- a/test/models/story_test.rb
+++ b/test/models/story_test.rb
@@ -210,7 +210,9 @@ describe Story do
     end
 
     it 'wont include subscriber_only stories' do
-      series = create(:series, subscription_approval_status: Series::SUBSCRIPTION_PRX_APPROVED, subscriber_only_at: Time.now)
+      series = create(:series,
+                      subscription_approval_status: Series::SUBSCRIPTION_PRX_APPROVED,
+                      subscriber_only_at: Time.now)
       story = create(:story, series_id: series.id)
       Story.where(id: story.id).must_include story
       Story.where(id: story.id).series_visible.wont_include story
@@ -241,7 +243,9 @@ describe Story do
     it 'returns public only stories' do
       story = create(:story)
       story_n = create(:story, network_only_at: Time.now)
-      series = create(:series, subscription_approval_status: Series::SUBSCRIPTION_PRX_APPROVED, subscriber_only_at: Time.now)
+      series = create(:series,
+                      subscription_approval_status: Series::SUBSCRIPTION_PRX_APPROVED,
+                      subscriber_only_at: Time.now)
       story_s = create(:story, series_id: series.id)
       story_u = create(:story, published_at: nil)
 

--- a/test/models/story_test.rb
+++ b/test/models/story_test.rb
@@ -211,7 +211,7 @@ describe Story do
 
     it 'wont include subscriber_only stories' do
       series = create(:series, subscription_approval_status: Series::SUBSCRIPTION_PRX_APPROVED, subscriber_only_at: Time.now)
-      story = create(:story, network_only_at: Time.now, series_id: series.id)
+      story = create(:story, series_id: series.id)
       Story.where(id: story.id).must_include story
       Story.where(id: story.id).series_visible.wont_include story
     end
@@ -236,6 +236,19 @@ describe Story do
       Story.match_text('unique').must_include story
       Story.match_text('lack').must_include story
       Story.match_text('random').wont_include story
+    end
+
+    it 'returns public only stories' do
+      story = create(:story)
+      story_n = create(:story, network_only_at: Time.now)
+      series = create(:series, subscription_approval_status: Series::SUBSCRIPTION_PRX_APPROVED, subscriber_only_at: Time.now)
+      story_s = create(:story, series_id: series.id)
+      story_u = create(:story, published_at: nil)
+
+      Story.public_stories.must_include story
+      Story.public_stories.wont_include story_n
+      Story.public_stories.wont_include story_s
+      Story.public_stories.wont_include story_u
     end
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -40,7 +40,7 @@ describe User do
   end
 
   it 'has a list of stories for approved accounts' do
-    start_count = user.individual_account.all_stories.count
+    start_count = user.individual_account.stories.count
     create(:account, user: user, stories_count: 2)
     user.approved_account_stories.count.must_equal start_count + 2
   end

--- a/test/representers/api/auth/account_min_representer_test.rb
+++ b/test/representers/api/auth/account_min_representer_test.rb
@@ -16,6 +16,6 @@ describe Api::Auth::AccountMinRepresenter do
 
   it 'links to authorized stories' do
     get_link_href('prx:stories').must_match /authorization\/accounts\/\d+\/stories/
+    get_link_href('prx:stories').must_match /\{\?page,per,zoom,filters,sorts\}/
   end
-
 end

--- a/test/representers/api/auth/account_representer_test.rb
+++ b/test/representers/api/auth/account_representer_test.rb
@@ -7,7 +7,7 @@ describe Api::Auth::AccountRepresenter do
   let(:json) { JSON.parse(representer.to_json) }
 
   before do
-    account.all_stories.last.update(published_at: nil)
+    account.stories.last.update(published_at: nil)
   end
 
   def get_link(rel, key = 'href')
@@ -28,9 +28,8 @@ describe Api::Auth::AccountRepresenter do
   end
 
   it 'embeds all authorized stories' do
-    account.stories.count.must_equal 1
-    account.all_stories.count.must_equal 2
+    account.public_stories.count.must_equal 1
+    account.stories.count.must_equal 2
     get_embed('prx:stories', 'total').must_equal 2
   end
-
 end

--- a/test/representers/api/base_representer_test.rb
+++ b/test/representers/api/base_representer_test.rb
@@ -3,12 +3,16 @@
 require 'test_helper'
 
 describe Api::BaseRepresenter do
-
   let(:t_object) { TestObject.new("test", true) }
   let(:representer) { Api::BaseRepresenter.new(t_object) }
-  let(:json)        { JSON.parse(representer.to_json) }
+  let(:json) { JSON.parse(representer.to_json) }
 
   it 'create representer' do
     representer.wont_be_nil
+  end
+
+  it '#index_url_params' do
+    representer.index_url_params.wont_be_nil
+    representer.index_url_params.must_equal "{?page,per,zoom,filters,sorts}"
   end
 end

--- a/test/representers/api/base_representer_test.rb
+++ b/test/representers/api/base_representer_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 describe Api::BaseRepresenter do
-  let(:t_object) { TestObject.new("test", true) }
+  let(:t_object) { TestObject.new('test', true) }
   let(:representer) { Api::BaseRepresenter.new(t_object) }
   let(:json) { JSON.parse(representer.to_json) }
 
@@ -13,6 +13,6 @@ describe Api::BaseRepresenter do
 
   it '#index_url_params' do
     representer.index_url_params.wont_be_nil
-    representer.index_url_params.must_equal "{?page,per,zoom,filters,sorts}"
+    representer.index_url_params.must_equal '{?page,per,zoom,filters,sorts}'
   end
 end

--- a/test/representers/api/min/account_representer_test.rb
+++ b/test/representers/api/min/account_representer_test.rb
@@ -1,0 +1,18 @@
+# encoding: utf-8
+
+require 'test_helper'
+require 'account' if !defined?(Account)
+
+describe Api::Min::AccountRepresenter do
+  let(:account) { create(:account) }
+  let(:representer) { Api::Min::AccountRepresenter.new(account) }
+  let(:json) { JSON.parse(representer.to_json) }
+
+  it 'use representer to create json' do
+    json['id'].must_equal account.id
+  end
+
+  it 'includes short name in json' do
+    json['shortName'].must_equal account.short_name
+  end
+end

--- a/test/representers/api/min/series_representer_test.rb
+++ b/test/representers/api/min/series_representer_test.rb
@@ -1,0 +1,18 @@
+# encoding: utf-8
+
+require 'test_helper'
+require 'series' if !defined?(Series)
+
+describe Api::Min::SeriesRepresenter do
+  let(:series) { FactoryGirl.create(:series) }
+  let(:representer) { Api::Min::SeriesRepresenter.new(series) }
+  let(:json) { JSON.parse(representer.to_json) }
+
+  it 'create representer' do
+    representer.wont_be_nil
+  end
+
+  it 'use representer to create json' do
+    json['id'].must_equal series.id
+  end
+end

--- a/test/representers/api/min/story_representer_test.rb
+++ b/test/representers/api/min/story_representer_test.rb
@@ -1,0 +1,29 @@
+# encoding: utf-8
+
+require 'test_helper'
+require 'series' if !defined?(Series)
+
+describe Api::Min::StoryRepresenter do
+  let(:story) { create(:story, audio_versions_count: 1) }
+  let(:representer) { Api::Min::StoryRepresenter.new(story) }
+  let(:json) { JSON.parse(representer.to_json) }
+
+  it 'can serialize an unsaved story' do
+    json = Api::Min::StoryRepresenter.new(story).to_json
+    json.wont_be_nil
+  end
+
+  it 'use representer to create json' do
+    json['id'].must_equal story.id
+  end
+
+  it 'has a story profile' do
+    json['_links']['profile']['href'].must_equal 'http://meta.prx.org/model/story/min'
+  end
+
+  it 'serializes the length of the story as duration' do
+    story.stub(:duration, 212) do
+      json['duration'].must_equal 212
+    end
+  end
+end

--- a/test/representers/api/min/user_representer_test.rb
+++ b/test/representers/api/min/user_representer_test.rb
@@ -1,0 +1,18 @@
+# encoding: utf-8
+
+require 'test_helper'
+require 'user' if !defined?(User)
+
+describe Api::Min::UserRepresenter do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:representer) { Api::Min::UserRepresenter.new(user) }
+  let(:json) { JSON.parse(representer.to_json) }
+
+  it 'create representer' do
+    representer.wont_be_nil
+  end
+
+  it 'use representer to create json' do
+    json['id'].must_equal user.id
+  end
+end

--- a/test/representers/api/msg/audio_file_representer_test.rb
+++ b/test/representers/api/msg/audio_file_representer_test.rb
@@ -1,12 +1,10 @@
 require 'test_helper'
 
 describe Api::Msg::AudioFileRepresenter do
-
   let(:representer) { Api::Msg::AudioFileRepresenter.new(audio) }
   let(:json)        { JSON.parse(representer.to_json) }
 
   describe 'with a completed upload' do
-
     let(:audio) { FactoryGirl.create(:audio_file) }
 
     it 'includes basic data' do
@@ -23,11 +21,9 @@ describe Api::Msg::AudioFileRepresenter do
     it 'has a destination path' do
       json['destinationPath'].must_equal "public/audio_files/#{audio.id}"
     end
-
   end
 
   describe 'with an in-progress upload' do
-
     let(:audio) { FactoryGirl.create(:audio_file_uploaded) }
 
     it 'includes basic data' do
@@ -46,7 +42,5 @@ describe Api::Msg::AudioFileRepresenter do
     it 'has a destination path' do
       json['destinationPath'].must_equal "public/audio_files/#{audio.id}"
     end
-
   end
-
 end

--- a/test/representers/api/msg/image_representer_test.rb
+++ b/test/representers/api/msg/image_representer_test.rb
@@ -1,12 +1,10 @@
 require 'test_helper'
 
 describe Api::Msg::ImageRepresenter do
-
   let(:representer) { Api::Msg::ImageRepresenter.new(image) }
   let(:json)        { JSON.parse(representer.to_json) }
 
   describe 'with a completed upload' do
-
     let(:image) { FactoryGirl.create(:story_image) }
 
     it 'includes basic data' do
@@ -30,22 +28,18 @@ describe Api::Msg::ImageRepresenter do
       json['pieceId'].must_equal image.piece_id
       json['userId'].must_be_nil
     end
-
   end
 
   describe 'with a user image' do
-
     let(:image) { FactoryGirl.create(:user_image) }
 
     it 'knows the id of the parent user' do
       json['userId'].must_equal image.user_id
       json['pieceId'].must_be_nil
     end
-
   end
 
   describe 'with an in-progress upload' do
-
     let(:image) { FactoryGirl.create(:story_image_uploaded) }
 
     it 'includes basic data' do
@@ -64,7 +58,5 @@ describe Api::Msg::ImageRepresenter do
     it 'has a destination path' do
       json['destinationPath'].must_equal "public/piece_images/#{image.id}"
     end
-
   end
-
 end


### PR DESCRIPTION
- [x] Implement standard method for what are public stories, using story scopes
- [x] Change default story relations to include all stories, and add public filters as needed in representers and controllers, matching in both. This essentially renames `all_stories` to `stories`, and adds a `public_stories` method to indicate when only stories visible to non-authenticated users will be returned
- [x] Add standard url template suffix for supported query params, like page, per, zoom, sorts, filters
