### PR TITLE
Fix image routes

### DIFF
--- a/app/controllers/api/series_images_controller.rb
+++ b/app/controllers/api/series_images_controller.rb
@@ -1,10 +1,17 @@
 # encoding: utf-8
 
 class Api::SeriesImagesController < Api::BaseController
-
   api_versions :v1
 
   filter_resources_by :series_id
 
   represent_with Api::ImageRepresenter
+
+  def resource
+    @series_image ||= series.try(:image) || super
+  end
+
+  def series
+    @series ||= Series.find(params[:series_id]) if params[:series_id]
+  end
 end

--- a/app/controllers/api/story_images_controller.rb
+++ b/app/controllers/api/story_images_controller.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 class Api::StoryImagesController < Api::BaseController
-
   api_versions :v1
 
   filter_resources_by :story_id

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -82,7 +82,7 @@ class Story < BaseModel
   end
 
   def default_image
-    @default_image ||= images.first || series.try(:image)
+    @default_image ||= images.first
   end
 
   def default_audio_version

--- a/app/representers/api/account_representer.rb
+++ b/app/representers/api/account_representer.rb
@@ -17,7 +17,7 @@ class Api::AccountRepresenter < Api::BaseRepresenter
 
   link :image do
     {
-      href:  api_account_account_image_path(represented),
+      href: api_account_account_image_path(represented),
       title: represented.image.try(:filename)
     } if represented.id
   end
@@ -25,7 +25,7 @@ class Api::AccountRepresenter < Api::BaseRepresenter
 
   link rel: :opener, writeable: true do
     {
-      href:  api_user_path(represented.opener),
+      href: api_user_path(represented.opener),
       title: represented.opener.login
     } if represented.opener && represented.opener.id
   end

--- a/app/representers/api/audio_file_template_representer.rb
+++ b/app/representers/api/audio_file_template_representer.rb
@@ -8,7 +8,9 @@ class Api::AudioFileTemplateRepresenter < Api::BaseRepresenter
   property :length_maximum
 
   def self_url(represented)
-    polymorphic_path([:api, represented.audio_version_template, represented])
+    api_audio_version_template_audio_file_template_path(
+      represented.audio_version_template,
+      represented)
   end
 
   set_link_property(rel: :audio_version_template, writeable: true)

--- a/app/representers/api/audio_file_template_representer.rb
+++ b/app/representers/api/audio_file_template_representer.rb
@@ -10,7 +10,8 @@ class Api::AudioFileTemplateRepresenter < Api::BaseRepresenter
   def self_url(represented)
     api_audio_version_template_audio_file_template_path(
       represented.audio_version_template,
-      represented)
+      represented
+    )
   end
 
   set_link_property(rel: :audio_version_template, writeable: true)

--- a/app/representers/api/image_representer.rb
+++ b/app/representers/api/image_representer.rb
@@ -5,9 +5,9 @@ class Api::ImageRepresenter < Api::BaseRepresenter
     if represented.is_a?(StoryImage)
       api_story_story_image_path(represented.story, represented)
     elsif represented.is_a?(SeriesImage)
-      api_series_series_image_path(represented.series, represented)
+      api_series_series_image_path(represented.series)
     elsif represented.is_a?(AccountImage)
-      api_account_account_image_path(represented.account, represented)
+      api_account_account_image_path(represented.account)
     elsif represented.is_a?(UserImage)
       api_user_user_image_path(represented.user)
     else

--- a/app/representers/api/image_representer.rb
+++ b/app/representers/api/image_representer.rb
@@ -1,18 +1,10 @@
 # encoding: utf-8
 
 class Api::ImageRepresenter < Api::BaseRepresenter
+  include NestedImage
+
   def self_url(represented)
-    if represented.is_a?(StoryImage)
-      api_story_story_image_path(represented.story, represented)
-    elsif represented.is_a?(SeriesImage)
-      api_series_series_image_path(represented.series)
-    elsif represented.is_a?(AccountImage)
-      api_account_account_image_path(represented.account)
-    elsif represented.is_a?(UserImage)
-      api_user_user_image_path(represented.user)
-    else
-      super
-    end
+    nested_image_path(represented) || super
   end
 
   property :id, writeable: false

--- a/app/representers/api/min/account_representer.rb
+++ b/app/representers/api/min/account_representer.rb
@@ -16,10 +16,9 @@ class Api::Min::AccountRepresenter < Api::BaseRepresenter
 
   link :image do
     {
-      href:    polymorphic_path([:api, represented.image]),
-      title:   represented.image.filename,
-      profile: model_uri(represented.image)
-    } if represented.image
+      href: api_account_account_image_path(represented),
+      title: represented.image.try(:filename)
+    } if represented.id
   end
   embed :image, class: Image, decorator: Api::ImageRepresenter
 

--- a/app/representers/api/min/series_representer.rb
+++ b/app/representers/api/min/series_representer.rb
@@ -22,7 +22,10 @@ class Api::Min::SeriesRepresenter < Api::BaseRepresenter
         item_decorator: Api::Min::StoryRepresenter
 
   link :image do
-    api_series_image_path(represented.image) if represented.image
+    {
+      href: api_series_series_image_path(represented),
+      title: represented.image.try(:filename)
+    } if represented.id
   end
   embed :image, class: SeriesImage, decorator: Api::ImageRepresenter
 

--- a/app/representers/api/min/story_representer.rb
+++ b/app/representers/api/min/story_representer.rb
@@ -36,8 +36,8 @@ class Api::Min::StoryRepresenter < Api::BaseRepresenter
 
   link :image do
     {
-      href: polymorphic_path([:api, represented.default_image]),
-      profile: model_uri(represented.default_image)
+      href: api_story_story_image_path(represented, represented.default_image),
+      title: represented.default_image.try(:filename)
     } if represented.default_image
   end
   embed :default_image, as: :image, decorator: Api::ImageRepresenter

--- a/app/representers/api/min/user_representer.rb
+++ b/app/representers/api/min/user_representer.rb
@@ -15,7 +15,10 @@ class Api::Min::UserRepresenter < Api::BaseRepresenter
   embed :accounts, paged: true, item_class: Account, item_decorator: Api::Min::AccountRepresenter, zoom: false
 
   link :image do
-    api_user_image_path(represented.image) if represented.image
+    {
+      href:  api_user_user_image_path(represented),
+      title: represented.image.try(:filename)
+    } if represented.id
   end
   embed :image, class: Image, decorator: Api::ImageRepresenter
 end

--- a/app/representers/api/msg/image_representer.rb
+++ b/app/representers/api/msg/image_representer.rb
@@ -4,6 +4,20 @@
 # Representer for Announce messaging
 #
 class Api::Msg::ImageRepresenter < Api::BaseRepresenter
+  def self_url(represented)
+    if represented.is_a?(StoryImage)
+      api_story_story_image_path(represented.story, represented)
+    elsif represented.is_a?(SeriesImage)
+      api_series_series_image_path(represented.series)
+    elsif represented.is_a?(AccountImage)
+      api_account_account_image_path(represented.account)
+    elsif represented.is_a?(UserImage)
+      api_user_user_image_path(represented.user)
+    else
+      super
+    end
+  end
+
   property :id, writeable: false
   property :filename, writeable: false
   property :size

--- a/app/representers/api/msg/image_representer.rb
+++ b/app/representers/api/msg/image_representer.rb
@@ -4,18 +4,10 @@
 # Representer for Announce messaging
 #
 class Api::Msg::ImageRepresenter < Api::BaseRepresenter
+  include NestedImage
+
   def self_url(represented)
-    if represented.is_a?(StoryImage)
-      api_story_story_image_path(represented.story, represented)
-    elsif represented.is_a?(SeriesImage)
-      api_series_series_image_path(represented.series)
-    elsif represented.is_a?(AccountImage)
-      api_account_account_image_path(represented.account)
-    elsif represented.is_a?(UserImage)
-      api_user_user_image_path(represented.user)
-    else
-      super
-    end
+    nested_image_path(represented) || super
   end
 
   property :id, writeable: false

--- a/app/representers/api/musical_work_representer.rb
+++ b/app/representers/api/musical_work_representer.rb
@@ -11,6 +11,6 @@ class Api::MusicalWorkRepresenter < Api::BaseRepresenter
   property :duration
 
   def self_url(musical_work)
-    polymorphic_path([:api, musical_work.story, musical_work])
+    api_story_musical_work_path(musical_work.story, musical_work)
   end
 end

--- a/app/representers/api/producer_representer.rb
+++ b/app/representers/api/producer_representer.rb
@@ -6,7 +6,7 @@ class Api::ProducerRepresenter < Api::BaseRepresenter
   property :name
 
   def self_url(represented)
-    polymorphic_path([:api, represented.story, represented])
+    api_story_producer_path(represented.story, represented)
   end
 
   link :user do

--- a/app/representers/api/series_representer.rb
+++ b/app/representers/api/series_representer.rb
@@ -25,7 +25,10 @@ class Api::SeriesRepresenter < Api::BaseRepresenter
         item_decorator: Api::Min::StoryRepresenter
 
   link :image do
-    api_series_image_path(represented.image) if represented.image
+    {
+      href: api_series_series_image_path(represented),
+      title: represented.image.try(:filename)
+    } if represented.id
   end
   embed :image, class: SeriesImage, decorator: Api::ImageRepresenter
 

--- a/app/representers/api/story_representer.rb
+++ b/app/representers/api/story_representer.rb
@@ -58,8 +58,8 @@ class Api::StoryRepresenter < Api::BaseRepresenter
 
   link :image do
     {
-      href: polymorphic_path([:api, represented.default_image]),
-      profile: model_uri(represented.default_image)
+      href: api_story_story_image_path(represented, represented.default_image),
+      title: represented.default_image.try(:filename)
     } if represented.default_image
   end
   embed :default_image, as: :image, decorator: Api::ImageRepresenter

--- a/app/representers/concerns/nested_image.rb
+++ b/app/representers/concerns/nested_image.rb
@@ -1,0 +1,19 @@
+# encoding: utf-8
+
+require 'active_support/concern'
+
+module NestedImage
+  extend ActiveSupport::Concern
+
+  def nested_image_path(represented)
+    if represented.is_a?(StoryImage)
+      api_story_story_image_path(represented.story, represented)
+    elsif represented.is_a?(SeriesImage)
+      api_series_series_image_path(represented.series)
+    elsif represented.is_a?(AccountImage)
+      api_account_account_image_path(represented.account)
+    elsif represented.is_a?(UserImage)
+      api_user_user_image_path(represented.user)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,11 +10,6 @@ PRX::Application.routes.draw do
         get 'original', on: :member
       end
 
-      resources :account_images, only: [:show, :index]
-      resources :series_images, only: [:show, :index]
-      resources :story_images, only: [:show, :index]
-      resources :user_images, only: [:show, :index]
-
       resources :audio_versions, except: [:new, :edit] do
         resources :audio_files, except: [:new, :edit]
       end
@@ -32,7 +27,7 @@ PRX::Application.routes.draw do
       end
 
       resources :series, except: [:new, :edit] do
-        resources :series_images, path: 'images', except: [:new, :edit]
+        resource :series_image, path: 'image', except: [:new, :edit]
         resources :stories, only: [:index, :create]
         resources :audio_version_templates, except: [:new, :edit]
       end

--- a/test/controllers/api/series_images_controller_test.rb
+++ b/test/controllers/api/series_images_controller_test.rb
@@ -6,13 +6,8 @@ describe Api::SeriesImagesController do
   let(:series_image) { create(:series_image, series: series) }
 
   it 'should show' do
-    get(:show, { api_version: 'v1', format: 'json', id: series_image.id } )
-    assert_response :success
-  end
-
-  it 'should list' do
-    series_image.id.wont_be_nil
-    get(:index, { api_version: 'v1', format: 'json' } )
+    series_image
+    get(:show, api_request_opts(series_id: series_image.series_id))
     assert_response :success
   end
 end

--- a/test/controllers/api/story_images_controller_test.rb
+++ b/test/controllers/api/story_images_controller_test.rb
@@ -13,21 +13,20 @@ describe Api::StoryImagesController do
   end
 
   it 'should show' do
-    get(:show, api_request_opts(id: story_image.id))
+    get(:show, api_request_opts(story_id: story.id, id: story_image.id))
     assert_response :success
   end
 
   it 'should list' do
     story_image.id.wont_be_nil
-    get(:index, api_request_opts)
+    get(:index, api_request_opts(story_id: story.id))
     assert_response :success
   end
 
   it 'should update' do
     image_hash = { credit: 'blah credit' }
-    put :update, image_hash.to_json, api_request_opts(story_id: story.id, id: story_image.id)
+    put(:update, image_hash.to_json, api_request_opts(story_id: story.id, id: story_image.id))
     assert_response :success
     StoryImage.find(story_image.id).credit.must_equal('blah credit')
   end
-
 end

--- a/test/models/story_test.rb
+++ b/test/models/story_test.rb
@@ -1,12 +1,10 @@
 require 'test_helper'
 
 describe Story do
-
   let(:story) { build_stubbed(:story, audio_versions_count: 10) }
   let(:promos_only) { build_stubbed(:story_promos_only) }
 
   describe 'basics' do
-
     it 'has a table defined' do
       Story.table_name.must_equal 'pieces'
     end
@@ -29,7 +27,6 @@ describe Story do
   end
 
   describe 'using default audio version' do
-
     it 'finds default audio' do
       story.audio_versions.count.must_equal 10
       story.default_audio_version.audio_files.count.must_be :>=, 1
@@ -74,7 +71,6 @@ describe Story do
   end
 
   describe '#default_image' do
-
     it 'returns the first image when one is present' do
       story.stub(:images, [:image, :second_image]) do
         story.default_image.must_equal :image
@@ -86,15 +82,6 @@ describe Story do
         story.default_image.must_equal nil
       end
     end
-
-    it 'falls back to series image when present' do
-      series = build_stubbed(:series, image: build_stubbed(:series_image))
-      story.images = []
-      story.stub(:series, series) do
-        story.default_image.must_equal series.image
-      end
-    end
-
   end
 
   describe '#tags' do
@@ -157,7 +144,6 @@ describe Story do
   end
 
   describe 'publishing' do
-
     let(:story) { create(:story) }
 
     it 'publishes a story' do

--- a/test/representers/api/msg/image_representer_test.rb
+++ b/test/representers/api/msg/image_representer_test.rb
@@ -5,7 +5,7 @@ describe Api::Msg::ImageRepresenter do
   let(:json)        { JSON.parse(representer.to_json) }
 
   describe 'with a completed upload' do
-    let(:image) { FactoryGirl.create(:story_image) }
+    let(:image) { create(:story_image) }
 
     it 'includes basic data' do
       json['id'].must_equal image.id
@@ -31,7 +31,7 @@ describe Api::Msg::ImageRepresenter do
   end
 
   describe 'with a user image' do
-    let(:image) { FactoryGirl.create(:user_image) }
+    let(:image) { create(:user_image) }
 
     it 'knows the id of the parent user' do
       json['userId'].must_equal image.user_id
@@ -40,7 +40,7 @@ describe Api::Msg::ImageRepresenter do
   end
 
   describe 'with an in-progress upload' do
-    let(:image) { FactoryGirl.create(:story_image_uploaded) }
+    let(:image) { create(:story_image_uploaded) }
 
     it 'includes basic data' do
       json['id'].must_equal image.id

--- a/test/representers/api/story_representer_test.rb
+++ b/test/representers/api/story_representer_test.rb
@@ -64,15 +64,6 @@ describe Api::StoryRepresenter do
       json['_links']['profile']['href'].must_equal 'http://meta.prx.org/model/story'
     end
 
-    it 'has a profile for the default image' do
-      image = create(:story_image)
-      representer.stub(:model_uri, 'string') do
-        story.stub(:default_image, image) do
-          json['_links']['prx:image']['profile'].must_equal 'string'
-        end
-      end
-    end
-
     it 'includes a content advisory' do
       sigil = 'sigil'
       story.stub(:content_advisory, sigil) do

--- a/test/representers/concerns/nested_image_test.rb
+++ b/test/representers/concerns/nested_image_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+describe NestedImage do
+
+  class NestedImageTestClass < Api::BaseRepresenter
+    include NestedImage
+  end
+
+  it 'gets path to image of any type' do
+    %w(account series story user).each do |parent|
+      represented = create("#{parent}_image")
+      representer = NestedImageTestClass.new(represented)
+      path = representer.nested_image_path(represented)
+      path.must_match /\/api\/v1\/#{parent.pluralize}\/#{represented.public_send(parent).id}\/image/
+    end
+  end
+end


### PR DESCRIPTION
- [x] Get rid of direct access to image resources (use nested only)
- [x] Don't return the series image if a story has none
- [x] Don't use polymorphic_url when it isn't needed
- [x] Don't add a profile attribute if the link is a consistent type
- [x] Add helper method for image representers to resolve url to image resource
