### PR TITLE
Stop using segment_count

### DIFF
--- a/app/models/audio_version_template.rb
+++ b/app/models/audio_version_template.rb
@@ -5,8 +5,6 @@ class AudioVersionTemplate < BaseModel
 
   has_many :audio_file_templates, -> { order :position }, dependent: :destroy
 
-  after_save :sync_audio_file_templates
-
   validates :label, presence: true
 
   validates :length_minimum,
@@ -16,19 +14,6 @@ class AudioVersionTemplate < BaseModel
   validates :length_maximum,
             presence: true,
             numericality: { greater_than_or_equal_to: :length_minimum }
-
-  validates :segment_count,
-            presence: true,
-            numericality: { only_integer: true, greater_than: 0 }
-
-  def sync_audio_file_templates
-    diff = segment_count - audio_file_templates.count
-    if diff > 0
-      diff.times { audio_file_templates.create! }
-    elsif diff < 0
-      self.audio_file_templates = audio_file_templates[0, segment_count]
-    end
-  end
 
   def self.policy_class
     SeriesAttributePolicy

--- a/app/representers/api/audio_version_template_representer.rb
+++ b/app/representers/api/audio_version_template_representer.rb
@@ -4,7 +4,6 @@ class Api::AudioVersionTemplateRepresenter < Api::BaseRepresenter
   property :id, writeable: false
   property :label
   property :promos
-  property :segment_count
   property :length_minimum
   property :length_maximum
 

--- a/test/factories/audio_version_template_factory.rb
+++ b/test/factories/audio_version_template_factory.rb
@@ -2,7 +2,6 @@ FactoryGirl.define do
   factory :audio_version_template do
     series
     label 'test'
-    segment_count 4
     length_minimum 10
     length_maximum 100
   end

--- a/test/models/audio_version_template_test.rb
+++ b/test/models/audio_version_template_test.rb
@@ -15,20 +15,4 @@ describe AudioVersionTemplate do
   it 'can be created with valid attributes' do
     audio_version_template.must_be :valid?
   end
-
-  it 'reduce file templates when segment count lowered' do
-    audio_version_template.segment_count.must_equal 4
-    audio_version_template.audio_file_templates.count.must_equal 4
-    audio_version_template.segment_count = 2
-    audio_version_template.save
-    audio_version_template.audio_file_templates(true).count.must_equal 2
-  end
-
-  it 'add file templates when segment count raised' do
-    audio_version_template.segment_count.must_equal 4
-    audio_version_template.audio_file_templates.count.must_equal 4
-    audio_version_template.segment_count = 6
-    audio_version_template.save
-    audio_version_template.audio_file_templates(true).count.must_equal 6
-  end
 end


### PR DESCRIPTION
Instead of using the segment_count attribute, rely on the count of audio_file_templates for the count of files that should be present in the template.

This count is also provided in the attributes of the link to the list of file templates.