### PR TITLE
Public asset fixes

### DIFF
--- a/app/controllers/public_assets_controller.rb
+++ b/app/controllers/public_assets_controller.rb
@@ -3,19 +3,35 @@
 class PublicAssetsController < ApplicationController
 
   def show
-    version = nil
-    asset = params[:class].camelize.constantize.find(params[:id])
-    if asset.public_url_valid?(params)
-      params[:head] = true if request.head?
+    if asset = find_valid_asset
       redirect_to asset.asset_url(params)
     else
       head 401
     end
   end
 
-  def options
+  def show_head
+    if asset = find_valid_asset
+      redirect_to asset.asset_url params.merge(head: true)
+    else
+      head 401
+    end
+  end
+
+  def show_options
     headers['Access-Control-Allow-Methods'] = 'GET, OPTIONS'
     head :no_content
+  end
+
+  private
+
+  def find_valid_asset
+    asset = params[:class].camelize.constantize.find(params[:id])
+    if asset.public_url_valid?(params)
+      asset
+    else
+      nil
+    end
   end
 
 end

--- a/app/controllers/public_assets_controller.rb
+++ b/app/controllers/public_assets_controller.rb
@@ -27,11 +27,7 @@ class PublicAssetsController < ApplicationController
 
   def find_valid_asset
     asset = params[:class].camelize.constantize.find(params[:id])
-    if asset.public_url_valid?(params)
-      asset
-    else
-      nil
-    end
+    asset if asset.public_url_valid?(params)
   end
 
 end

--- a/app/controllers/public_assets_controller.rb
+++ b/app/controllers/public_assets_controller.rb
@@ -6,9 +6,16 @@ class PublicAssetsController < ApplicationController
     version = nil
     asset = params[:class].camelize.constantize.find(params[:id])
     if asset.public_url_valid?(params)
+      params[:head] = true if request.head?
       redirect_to asset.asset_url(params)
     else
       head 401
     end
   end
+
+  def options
+    headers['Access-Control-Allow-Methods'] = 'GET, OPTIONS'
+    head :no_content
+  end
+
 end

--- a/app/models/concerns/fixerable.rb
+++ b/app/models/concerns/fixerable.rb
@@ -108,7 +108,11 @@ module Fixerable
     if options.key?(:expiration) && options[:expiration].to_i > 0
       f.fog_authenticated_url_expiration = options[:expiration].to_i
     end
-    f.url
+    if options.delete(:head)
+      f.authenticated_head_url
+    else
+      f.url
+    end
   end
 
   def fixerable_final_path

--- a/app/models/concerns/fixerable.rb
+++ b/app/models/concerns/fixerable.rb
@@ -57,12 +57,17 @@ module Fixerable
 
       credentials = uploader.fog_credentials
       connection = Fog::Storage.new(credentials)
+      expiration = fixerable_url_expires_at(uploader, options)
 
-      if provider == credentials[:provider]
-        # avoid a get by using local references
-        local_directory = connection.directories.new(key: bucket)
-        local_file = local_directory.files.new(key: path)
-        local_file.url(fixerable_url_expires_at(uploader, options), options)
+      if provider === credentials[:provider]
+        if provider === 'AWS' && options.delete(:head)
+          connection.head_object_url(bucket, path, expiration, options)
+        else
+          # avoid a get by using local references
+          local_directory = connection.directories.new(key: bucket)
+          local_file = local_directory.files.new(key: path)
+          local_file.url(expiration, options)
+        end
       end
     end
 
@@ -108,7 +113,7 @@ module Fixerable
     if options.key?(:expiration) && options[:expiration].to_i > 0
       f.fog_authenticated_url_expiration = options[:expiration].to_i
     end
-    if options.delete(:head)
+    if options.delete(:head) && f.respond_to?(:authenticated_head_url)
       f.authenticated_head_url
     else
       f.url

--- a/app/uploaders/audio_file_uploader.rb
+++ b/app/uploaders/audio_file_uploader.rb
@@ -45,7 +45,7 @@ class AudioFileUploader < CarrierWave::Uploader::Base
   end
 
   def authenticated_head_url(options = {})
-    if fog_credentials[:provider] == "AWS"
+    if fog_credentials[:provider] === 'AWS'
       storage.connection.head_object_url(
         fog_directory,
         path,

--- a/app/uploaders/audio_file_uploader.rb
+++ b/app/uploaders/audio_file_uploader.rb
@@ -43,4 +43,16 @@ class AudioFileUploader < CarrierWave::Uploader::Base
   def version_ext(version)
     AudioFileUploader.version_formats[version.to_s]['format']
   end
+
+  def authenticated_head_url(options = {})
+    if fog_credentials[:provider] == "AWS"
+      storage.connection.head_object_url(
+        fog_directory,
+        path,
+        (::Fog::Time.now + fog_authenticated_url_expiration),
+        options
+      )
+    end
+  end
+
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -68,4 +68,15 @@ class ImageUploader < CarrierWave::Uploader::Base
     "#{base}_#{version}#{ext}"
   end
 
+  def authenticated_head_url(options = {})
+    if fog_credentials[:provider] === 'AWS'
+      storage.connection.head_object_url(
+        fog_directory,
+        path,
+        (::Fog::Time.now + fog_authenticated_url_expiration),
+        options
+      )
+    end
+  end
+
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,6 +50,11 @@ module PRX
         origins '*'
         resource '/api/*', methods: [:get]
       end
+
+      allow do
+        origins '*'
+        resource '/pub/*', methods: [:get, :head, :options], headers: :any
+      end
     end
 
     config.active_job.queue_adapter = :shoryuken

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,9 +85,10 @@ PRX::Application.routes.draw do
   match '/', via: [:get], to: redirect("/api/v1")
 
   public_asset = 'pub/:token/:expires/:use/:class/:id/:version/:name.:extension'
-  public_name = {name: /[^\/]+/}
+  public_name = { name: /[^\/]+/ }
   match public_asset, to: 'public_assets#show_head', via: :head, constraints: public_name
   match public_asset, to: 'public_assets#show_options', via: :options, constraints: public_name
-  match public_asset, to: 'public_assets#show', via: :get, constraints: public_name, as: :public_asset
+  match public_asset, to: 'public_assets#show', via: :get, constraints: public_name,
+                      as: :public_asset
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,5 +85,6 @@ PRX::Application.routes.draw do
   match '/', via: [:get], to: redirect("/api/v1")
 
   get 'pub/:token/:expires/:use/:class/:id/:version/:name.:extension' => 'public_assets#show', as: :public_asset, constraints: {name: /[^\/]+/}
+  match 'pub/*any', via: [:options], to: 'public_assets#options'
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,7 +84,10 @@ PRX::Application.routes.draw do
   match '/api', via: [:get], to: redirect("/api/v1")
   match '/', via: [:get], to: redirect("/api/v1")
 
-  get 'pub/:token/:expires/:use/:class/:id/:version/:name.:extension' => 'public_assets#show', as: :public_asset, constraints: {name: /[^\/]+/}
-  match 'pub/*any', via: [:options], to: 'public_assets#options'
+  public_asset = 'pub/:token/:expires/:use/:class/:id/:version/:name.:extension'
+  public_name = {name: /[^\/]+/}
+  match public_asset, to: 'public_assets#show_head', via: :head, constraints: public_name
+  match public_asset, to: 'public_assets#show_options', via: :options, constraints: public_name
+  match public_asset, to: 'public_assets#show', via: :get, constraints: public_name, as: :public_asset
 
 end

--- a/test/controllers/public_assets_controller_test.rb
+++ b/test/controllers/public_assets_controller_test.rb
@@ -30,8 +30,21 @@ describe PublicAssetsController do
     assert_response :redirect
   end
 
+  it 'should get redirected to asset for valid HEAD request' do
+    options = audio_file.set_asset_option_defaults
+    options[:token] = audio_file.public_url_token(options)
+
+    get(:show_head, options)
+
+    assert_response :redirect
+  end
+
   it 'has no content for options requests' do
-    process :options, 'OPTIONS', any: '1'
+    options = audio_file.set_asset_option_defaults
+    options[:token] = audio_file.public_url_token(options)
+
+    process :show_options, 'OPTIONS', options
+
     response.status.must_equal 204
   end
 

--- a/test/controllers/public_assets_controller_test.rb
+++ b/test/controllers/public_assets_controller_test.rb
@@ -29,4 +29,10 @@ describe PublicAssetsController do
 
     assert_response :redirect
   end
+
+  it 'has no content for options requests' do
+    process :options, 'OPTIONS', any: '1'
+    response.status.must_equal 204
+  end
+
 end

--- a/test/models/concerns/fixerable_test.rb
+++ b/test/models/concerns/fixerable_test.rb
@@ -15,9 +15,11 @@ describe Fixerable do
 
   class FixerableTestUploader < CarrierWave::Uploader::Base
     storage :fog
+
     def self.version_formats
       {}
     end
+
     def authenticated_head_url
       'some-head-url'
     end

--- a/test/uploaders/audio_file_uploader_test.rb
+++ b/test/uploaders/audio_file_uploader_test.rb
@@ -29,6 +29,12 @@ describe AudioFileUploader do
     extract_filename(uploader.url(:preview)).must_equal 'test_preview.mp3'
   end
 
+  it 'signs head requests' do
+    signed_get = uploader.url
+    signed_get.must_equal(uploader.url)
+    signed_get.wont_equal(uploader.authenticated_head_url)
+  end
+
   it 'has a whitelist' do
     uploader.extension_white_list.must_include 'mp2'
   end

--- a/test/uploaders/image_uploader_test.rb
+++ b/test/uploaders/image_uploader_test.rb
@@ -2,7 +2,11 @@ require 'test_helper'
 
 require 'account_image'
 
-describe AudioFileUploader do
+def extract_filename(uri)
+  URI.parse(uri).path.split('?')[0].split('/').last
+end
+
+describe ImageUploader do
 
   include CarrierWave::Test::Matchers
 
@@ -26,6 +30,12 @@ describe AudioFileUploader do
 
   it 'has a whitelist' do
     uploader.extension_white_list.must_include 'gif'
+  end
+
+  it 'signs head requests' do
+    signed_get = uploader.url
+    signed_get.must_equal(uploader.url)
+    signed_get.wont_equal(uploader.authenticated_head_url)
   end
 
 end


### PR DESCRIPTION
Addresses a couple of issues with public assets for Publish...

- CORS headers not being set on `/pub/` paths, preventing Publish from following the redirect for non-native (aurora) mp3 playback
- HEAD requests for `/pub/` S3 assets were not being signed correctly
- No OPTIONS set for `/pub/`