### PR TITLE
Fix publish podcast

### DIFF
--- a/app/controllers/concerns/announce_actions.rb
+++ b/app/controllers/concerns/announce_actions.rb
@@ -40,7 +40,7 @@ module AnnounceActions
     end
 
     def new_announce_filter(action, options)
-      filter_options = options.slice(:action, :decorator, :subject)
+      filter_options = options.slice(:action, :decorator, :subject, :resource)
       filter_options[:action] ||= 'delete' if action.to_s == 'destroy'
       AnnounceActions::AnnounceFilter.new(action, filter_options)
     end

--- a/app/models/distributions/podcast_distribution.rb
+++ b/app/models/distributions/podcast_distribution.rb
@@ -23,9 +23,22 @@ class Distributions::PodcastDistribution < Distribution
   end
 
   def podcast_attributes
-    {
+    attrs = {
       prx_uri: polymorphic_url(['api', owner], only_path: true),
-      prx_account_uri: api_account_path(account)
+      prx_account_uri: api_account_path(account),
+      published_at: Time.now
     }
+
+    if owner.is_a?(Series)
+      attrs[:title] = owner.title
+      attrs[:subtitle] = owner.short_description
+      attrs[:description] = owner.description
+      attrs[:summary] = owner.description
+      if owner.image
+        attrs[:itunes_image] = { url: owner.image.public_url(version: 'original') }
+      end
+    end
+
+    attrs
   end
 end

--- a/test/controllers/api/series_images_controller_test.rb
+++ b/test/controllers/api/series_images_controller_test.rb
@@ -46,4 +46,12 @@ describe Api::SeriesImagesController do
     original.id.wont_equal new_image['id']
     series.image(true).id.must_equal new_image['id']
   end
+
+  it 'deletes the image, touches the series' do
+    series_update = series.updated_at
+    delete :destroy, api_request_opts(series_id: series.id, id: series_image.id)
+    assert_response :success
+    -> { SeriesImage.find(series_image.id) }.must_raise(ActiveRecord::RecordNotFound)
+    series_update.wont_equal series.reload.updated_at
+  end
 end

--- a/test/controllers/concerns/announce_actions_test.rb
+++ b/test/controllers/concerns/announce_actions_test.rb
@@ -2,37 +2,23 @@
 
 require 'announce_actions'
 
+class Cc1 < Api::TestObjectsController; end
+
 describe Api::TestObjectsController do
 
-  let (:controller_class) { Api::TestObjectsController }
-
-  before do
-    controller_class.class_eval { include AnnounceActions }
-    controller_class.announced_actions = []
-    clear_messages
-  end
-
-  it 'can declare announced actions' do
-    controller_class.announce_actions(:destroy)
-    controller_class.announced_actions.size.must_equal 1
-  end
-
-  it 'prevents dupe announcements' do
-    controller_class.announce_actions(:destroy)
-    controller_class.announce_actions(:destroy, :update)
-    controller_class.announced_actions.size.must_equal 2
-  end
-
-  it 'defaults to create, update, and destroy' do
-    default_actions = [:create, :destroy, :update]
-    controller_class.announce_actions
-    controller_class.announced_actions.sort.must_equal default_actions
-  end
-
   describe 'test callbacks' do
+    let (:controller_class) { Api::TestObjectsController }
 
-    before { define_routes }
-    after { Rails.application.reload_routes! }
+    before do
+      controller_class.class_eval { include AnnounceActions }
+      controller_class.announced_actions = []
+      clear_messages
+      define_routes
+    end
+
+    after do
+      Rails.application.reload_routes!
+    end
 
     it 'will call announce' do
       controller_class.announce_actions(:create)
@@ -52,6 +38,43 @@ describe Api::TestObjectsController do
       response.must_be :success?
       last_message['subject'].to_s.must_equal 'test_object'
       last_message['action'].to_s.must_equal 'delete'
+    end
+
+    it 'will call announce on a different resource' do
+      controller_class.announce_actions(:update, resource: :parent)
+
+      put :update, id: 1
+
+      response.must_be :success?
+      last_message['subject'].to_s.must_equal 'test_parent'
+      last_message['action'].to_s.must_equal 'update'
+    end
+  end
+
+  describe 'test setting announce actions' do
+    let (:controller_class) { Cc1 }
+
+    before do
+      controller_class.class_eval { include AnnounceActions }
+      controller_class.announced_actions = []
+      clear_messages
+    end
+
+    it 'can declare announced actions' do
+      controller_class.announce_actions(:destroy)
+      controller_class.announced_actions.size.must_equal 1
+    end
+
+    it 'prevents dupe announcements' do
+      controller_class.announce_actions(:destroy)
+      controller_class.announce_actions(:destroy, :update)
+      controller_class.announced_actions.size.must_equal 2
+    end
+
+    it 'defaults to create, update, and destroy' do
+      default_actions = [:create, :destroy, :update]
+      controller_class.announce_actions
+      controller_class.announced_actions.sort.must_equal default_actions
     end
   end
 end

--- a/test/models/distributions/podcast_distribution_test.rb
+++ b/test/models/distributions/podcast_distribution_test.rb
@@ -40,8 +40,9 @@ describe Distributions::PodcastDistribution do
 
   it 'returns attributes for creating the podcast' do
     attrs = distribution.podcast_attributes
-    attrs.keys.count.must_equal 2
+    attrs.keys.count.must_equal 7
     attrs[:prx_uri].must_equal "/api/v1/series/#{distribution.owner.id}"
     attrs[:prx_account_uri].must_equal "/api/v1/accounts/#{distribution.account.id}"
+    attrs[:published_at].wont_be_nil
   end
 end

--- a/test/test_models.rb
+++ b/test/test_models.rb
@@ -64,6 +64,10 @@ class Api::Min::TestObjectRepresenter < Api::BaseRepresenter
   end
 end
 
+class Api::TestParentRepresenter < Api::BaseRepresenter
+  property :id
+end
+
 class Api::TestObjectsController < ActionController::Base
   def index; head :no_content; end
 
@@ -77,6 +81,10 @@ class Api::TestObjectsController < ActionController::Base
 
   def resource
     @resource ||= TestObject.new('title', true)
+  end
+
+  def parent
+    @parent ||= TestParent.new(1, true)
   end
 end
 


### PR DESCRIPTION
- [x] Make sure announce message publish for the owner resource (e.g. the series) not the distribution #203 
- [x] Send `published_at` and series specific data for initial create of a podcast in feeder
- [x] Additional test for deleting series image, since there was a question about cms handling