### PR TITLE
Use markdown for V4 stories and series, but continue to return html for description

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,8 @@ gem 'roar'
 gem 'roar-rails'
 gem 'oj'
 gem 'oj_mimic_json'
+gem 'redcarpet'
+gem 'reverse_markdown'
 
 ## Messaging
 gem 'shoryuken'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -401,10 +401,13 @@ GEM
       nokogiri (~> 1.5)
       trollop (~> 2.1)
     rdoc (4.3.0)
+    redcarpet (3.3.4)
     representable (2.3.0)
       uber (~> 0.0.7)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
+    reverse_markdown (1.0.3)
+      nokogiri
     roar (1.0.4)
       representable (>= 2.0.1, < 2.4.0)
     roar-rails (1.0.1)
@@ -520,7 +523,9 @@ DEPENDENCIES
   rails (~> 4.2.1)
   rails_12factor
   rake
+  redcarpet
   responders (~> 2.0)
+  reverse_markdown
   roar
   roar-rails
   sdoc

--- a/app/models/concerns/render_markdown.rb
+++ b/app/models/concerns/render_markdown.rb
@@ -30,7 +30,7 @@ module RenderMarkdown
       safe_links_only: true,
       hard_wrap: true,
       with_toc_data: true,
-      link_attributes: { rel: 'nofollow', target: "_blank" },
+      link_attributes: { rel: 'nofollow', target: '_blank' },
     }
     Redcarpet::Render::HTML.new(options)
   end

--- a/app/models/concerns/render_markdown.rb
+++ b/app/models/concerns/render_markdown.rb
@@ -1,0 +1,37 @@
+# encoding: utf-8
+
+require 'active_support/concern'
+require 'redcarpet'
+require 'reverse_markdown'
+
+module RenderMarkdown
+  extend ActiveSupport::Concern
+
+  def html_to_markdown(str)
+    ReverseMarkdown.convert(str)
+  end
+
+  def markdown_to_html(str = '')
+    md = Redcarpet::Markdown.new(markdown_html_renderer, markdown_extensions)
+    md.render(str || '')
+  end
+
+  def markdown_extensions
+    {
+      tables: true,
+      autolink: true
+    }
+  end
+
+  def markdown_html_renderer
+    options = {
+      filter_html: false,
+      no_styles: true,
+      safe_links_only: true,
+      hard_wrap: true,
+      with_toc_data: true,
+      link_attributes: { rel: 'nofollow', target: "_blank" },
+    }
+    Redcarpet::Render::HTML.new(options)
+  end
+end

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require 'render_markdown'
 
 class Series < BaseModel
   SUBSCRIPTION_STATES = [
@@ -9,6 +10,19 @@ class Series < BaseModel
   ]
 
   include Storied
+  include RenderMarkdown
+
+  def description_html
+    v4? ? markdown_to_html(description) : description
+  end
+
+  def description_md=(md)
+    self.description = md
+  end
+
+  def description_md
+    v4? ? description : html_to_markdown(description)
+  end
 
   acts_as_paranoid
 

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -1,7 +1,22 @@
 # encoding: utf-8
+require 'render_markdown'
 
 class Story < BaseModel
   self.table_name = 'pieces'
+
+  include RenderMarkdown
+
+  def description_html
+    v4? ? markdown_to_html(description) : description
+  end
+
+  def description_md=(md)
+    self.description = md
+  end
+
+  def description_md
+    v4? ? description : html_to_markdown(description)
+  end
 
   acts_as_paranoid
 

--- a/app/representers/api/series_representer.rb
+++ b/app/representers/api/series_representer.rb
@@ -4,7 +4,7 @@ class Api::SeriesRepresenter < Api::BaseRepresenter
   property :id, writeable: false
   property :title
   property :short_description
-  property :description
+  property :description, getter: ->(_o) { description_html }
   property :created_at, writeable: false
   property :updated_at, writeable: false
   property :app_version, writeable: false

--- a/app/representers/api/series_representer.rb
+++ b/app/representers/api/series_representer.rb
@@ -5,6 +5,7 @@ class Api::SeriesRepresenter < Api::BaseRepresenter
   property :title
   property :short_description
   property :description, getter: ->(_o) { description_html }
+  property :description_md
   property :created_at, writeable: false
   property :updated_at, writeable: false
   property :app_version, writeable: false

--- a/app/representers/api/story_representer.rb
+++ b/app/representers/api/story_representer.rb
@@ -15,7 +15,8 @@ class Api::StoryRepresenter < Api::BaseRepresenter
   property :points, writeable: false
   property :app_version, writeable: false
 
-  property :description
+  property :description, getter: ->(_o) { description_html }
+  property :description_md
   property :related_website
   property :broadcast_history
   property :timing_and_cues

--- a/test/controllers/api/stories_controller_test.rb
+++ b/test/controllers/api/stories_controller_test.rb
@@ -60,8 +60,7 @@ describe Api::StoriesController do
 
     it 'returns descriptionMd for v3 stories' do
       story_v3 = create(:story_v3, description: "<p><em>description</em></p>\n")
-
-      get(:show, { api_version: 'v1', format: 'json', id: story_v3.id } )
+      get(:show, api_request_opts(id: story_v3.id))
       assert_response :success
       res = JSON.parse(response.body)
       res['descriptionMd'].must_equal "_description_\n\n"

--- a/test/controllers/api/stories_controller_test.rb
+++ b/test/controllers/api/stories_controller_test.rb
@@ -66,7 +66,6 @@ describe Api::StoriesController do
       res['descriptionMd'].must_equal "_description_\n\n"
     end
 
-
     it 'rejects new stories with an invalid account' do
       new_account = create(:account)
       post :create,

--- a/test/models/concerns/render_markdown_test.rb
+++ b/test/models/concerns/render_markdown_test.rb
@@ -1,0 +1,20 @@
+# encoding: utf-8
+
+require 'test_helper'
+require 'render_markdown'
+
+class TestMarkdownModel
+  include RenderMarkdown
+end
+
+describe TestMarkdownModel do
+  let(:model) { TestMarkdownModel.new }
+
+  it 'converts markdown to html' do
+    model.markdown_to_html("_This is markdown_\n\n").must_equal "<p><em>This is markdown</em></p>\n"
+  end
+
+  it 'converts html to markdown ' do
+    model.html_to_markdown("<p><em>This is markdown</em></p>\n").must_equal "_This is markdown_\n\n"
+  end
+end


### PR DESCRIPTION
- [x] Add description_md attribute with md value of description
- [x] Render v4 descriptions from md -> html for description field
- [x] Render v3 descriptions from html ->  for description_md field
- [x] Allow updating the desc also as description_md