### PR TITLE
Multiple series images

### DIFF
--- a/app/controllers/api/series_images_controller.rb
+++ b/app/controllers/api/series_images_controller.rb
@@ -1,8 +1,6 @@
 # encoding: utf-8
 
 class Api::SeriesImagesController < Api::BaseController
-  include Announce::Publisher
-
   api_versions :v1
 
   filter_resources_by :series_id
@@ -10,10 +8,4 @@ class Api::SeriesImagesController < Api::BaseController
   announce_actions decorator: Api::Msg::ImageRepresenter, subject: :image
 
   represent_with Api::ImageRepresenter
-
-  child_resource parent: 'series', child: 'image'
-
-  def after_original_destroyed(original)
-    announce('image', 'destroy', Api::Msg::ImageRepresenter.new(original).to_json)
-  end
 end

--- a/app/models/distributions/podcast_distribution.rb
+++ b/app/models/distributions/podcast_distribution.rb
@@ -34,8 +34,12 @@ class Distributions::PodcastDistribution < Distribution
       attrs[:subtitle] = owner.short_description
       attrs[:description] = owner.description
       attrs[:summary] = owner.description
-      if owner.default_image
-        attrs[:itunes_image] = { url: owner.default_image.public_url(version: 'original') }
+      if owner.images.profile
+        attrs[:itunes_image] = { url: owner.images.profile.public_url(version: 'original') }
+      end
+
+      if owner.images.thumbnail
+        attrs[:feed_image] = { url: owner.owner.images.thumbnail.public_url(version: 'original') }
       end
     end
 

--- a/app/models/distributions/podcast_distribution.rb
+++ b/app/models/distributions/podcast_distribution.rb
@@ -34,8 +34,8 @@ class Distributions::PodcastDistribution < Distribution
       attrs[:subtitle] = owner.short_description
       attrs[:description] = owner.description
       attrs[:summary] = owner.description
-      if owner.image
-        attrs[:itunes_image] = { url: owner.image.public_url(version: 'original') }
+      if owner.default_image
+        attrs[:itunes_image] = { url: owner.default_image.public_url(version: 'original') }
       end
     end
 

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -12,6 +12,18 @@ class Image < BaseModel
   FAILED = 'failed'.freeze
   COMPLETE = 'complete'.freeze
 
+  PROFILE = 'profile'.freeze
+  THUMBNAIL = 'thumbnail'.freeze
+  PURPOSES = [PROFILE, THUMBNAIL]
+
+  def self.profile
+    order("field(purpose, '#{Image::PROFILE}') desc, created_at desc").first
+  end
+
+  def self.thumbnail
+    order("field(purpose, '#{Image::THUMBNAIL}') desc, created_at desc").first
+  end
+
   alias_attribute :upload, :upload_path
 
   mount_uploader :file, ImageUploader, mount_on: :filename

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -14,7 +14,7 @@ class Image < BaseModel
 
   PROFILE = 'profile'.freeze
   THUMBNAIL = 'thumbnail'.freeze
-  PURPOSES = [PROFILE, THUMBNAIL]
+  PURPOSES = [PROFILE, THUMBNAIL].freeze
 
   def self.profile
     order("field(purpose, '#{Image::PROFILE}') desc, created_at desc").first

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -20,7 +20,6 @@ class Series < BaseModel
   has_many :audio_version_templates
   has_many :distributions, as: :distributable
 
-  # has_one :image, -> { where(parent_id: nil) }, class_name: 'SeriesImage', dependent: :destroy
   has_many :images, -> { where(parent_id: nil) }, class_name: 'SeriesImage', dependent: :destroy
 
   before_validation :set_app_version, on: :create
@@ -36,7 +35,7 @@ class Series < BaseModel
   }
 
   def default_image
-    @default_image ||= images.first
+    @default_image ||= images.order('field(purpose, "profile") desc, created_at desc').first
   end
 
   def subscribable?

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -35,7 +35,7 @@ class Series < BaseModel
   }
 
   def default_image
-    @default_image ||= images.order('field(purpose, "profile") desc, created_at desc').first
+    @default_image ||= images.profile
   end
 
   def subscribable?

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -20,7 +20,8 @@ class Series < BaseModel
   has_many :audio_version_templates
   has_many :distributions, as: :distributable
 
-  has_one :image, -> { where(parent_id: nil) }, class_name: 'SeriesImage', dependent: :destroy
+  # has_one :image, -> { where(parent_id: nil) }, class_name: 'SeriesImage', dependent: :destroy
+  has_many :images, -> { where(parent_id: nil) }, class_name: 'SeriesImage', dependent: :destroy
 
   before_validation :set_app_version, on: :create
 
@@ -33,6 +34,10 @@ class Series < BaseModel
           "`series`.`short_description` like '%#{text}%' OR " +
           "`series`.`description` like '%#{text}%'")
   }
+
+  def default_image
+    @default_image ||= images.first
+  end
 
   def subscribable?
     subscription_approval_status == SUBSCRIPTION_PRX_APPROVED

--- a/app/representers/api/image_representer.rb
+++ b/app/representers/api/image_representer.rb
@@ -13,6 +13,7 @@ class Api::ImageRepresenter < Api::BaseRepresenter
   property :caption
   property :credit
   property :status, writeable: false
+  property :purpose
 
   # provide an accessible url to the image media file for upload
   property :upload, readable: false

--- a/app/representers/api/min/series_representer.rb
+++ b/app/representers/api/min/series_representer.rb
@@ -23,11 +23,11 @@ class Api::Min::SeriesRepresenter < Api::BaseRepresenter
 
   link :image do
     {
-      href: api_series_series_image_path(represented),
-      title: represented.image.try(:filename)
-    } if represented.id
+      href: api_series_series_image_path(represented, represented.default_image),
+      title: represented.default_image.try(:filename)
+    } if represented && represented.default_image
   end
-  embed :image, class: SeriesImage, decorator: Api::ImageRepresenter
+  embed :default_image, as: :image, class: SeriesImage, decorator: Api::ImageRepresenter
 
   link :account do
     {

--- a/app/representers/api/series_representer.rb
+++ b/app/representers/api/series_representer.rb
@@ -38,7 +38,7 @@ class Api::SeriesRepresenter < Api::BaseRepresenter
       count: represented.images.count
     } if represented.id
   end
-  embed :images, paged: true, item_class: SeriesImage, decorator: Api::ImageRepresenter
+  embed :images, paged: true, item_class: SeriesImage, item_decorator: Api::ImageRepresenter
 
   link :account do
     {

--- a/app/representers/api/series_representer.rb
+++ b/app/representers/api/series_representer.rb
@@ -26,18 +26,19 @@ class Api::SeriesRepresenter < Api::BaseRepresenter
 
   link :image do
     {
-      href: api_series_series_image_path(represented),
-      title: represented.image.filename
-    } if represented.id && represented.image
+      href: api_series_series_image_path(represented, represented.default_image),
+      title: represented.default_image.try(:filename)
+    } if represented && represented.default_image
   end
-  embed :image, class: SeriesImage, decorator: Api::ImageRepresenter
+  embed :default_image, as: :image, class: SeriesImage, decorator: Api::ImageRepresenter
 
-  link 'create-image' do
+  link :images do
     {
-      href: api_series_series_image_path(represented),
-      title: 'Create an image'
-    } if represented.id && !represented.image
+      href: api_series_series_images_path(represented),
+      count: represented.images.count
+    } if represented.id
   end
+  embed :images, paged: true, item_class: SeriesImage, decorator: Api::ImageRepresenter, zoom: false
 
   link :account do
     {

--- a/app/representers/api/series_representer.rb
+++ b/app/representers/api/series_representer.rb
@@ -38,7 +38,7 @@ class Api::SeriesRepresenter < Api::BaseRepresenter
       count: represented.images.count
     } if represented.id
   end
-  embed :images, paged: true, item_class: SeriesImage, decorator: Api::ImageRepresenter, zoom: false
+  embed :images, paged: true, item_class: SeriesImage, decorator: Api::ImageRepresenter
 
   link :account do
     {

--- a/app/representers/concerns/nested_image.rb
+++ b/app/representers/concerns/nested_image.rb
@@ -9,7 +9,7 @@ module NestedImage
     if represented.is_a?(StoryImage)
       api_story_story_image_path(represented.story, represented)
     elsif represented.is_a?(SeriesImage)
-      api_series_series_image_path(represented.series)
+      api_series_series_image_path(represented.series, represented)
     elsif represented.is_a?(AccountImage)
       api_account_account_image_path(represented.account)
     elsif represented.is_a?(UserImage)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ PRX::Application.routes.draw do
       end
 
       resources :series, except: [:new, :edit] do
-        resource :series_image, path: 'image', except: [:new, :edit]
+        resources :series_images, path: 'image', except: [:new, :edit]
         resources :stories, only: [:index, :create]
         resources :audio_version_templates, except: [:new, :edit]
         resources :distributions, except: [:new, :edit]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 6) do
     t.string   "status",       limit: 255
     t.string   "caption",      limit: 255
     t.string   "credit",       limit: 255
+    t.string   "purpose",      limit: 255
   end
 
   add_index "account_images", ["account_id"], name: "account_images_account_id_fk", using: :btree
@@ -263,6 +264,7 @@ ActiveRecord::Schema.define(version: 6) do
     t.datetime "updated_at"
     t.string   "upload_path",  limit: 255
     t.string   "status",       limit: 255
+    t.string   "purpose",      limit: 255
   end
 
   add_index "piece_images", ["piece_id"], name: "piece_images_piece_id_fk", using: :btree
@@ -449,6 +451,7 @@ ActiveRecord::Schema.define(version: 6) do
     t.datetime "updated_at"
     t.string   "upload_path",  limit: 255
     t.string   "status",       limit: 255
+    t.string   "purpose",      limit: 255
   end
 
   add_index "series_images", ["series_id"], name: "series_images_series_id_fk", using: :btree
@@ -510,6 +513,7 @@ ActiveRecord::Schema.define(version: 6) do
     t.string   "status",       limit: 255
     t.string   "caption",      limit: 255
     t.string   "credit",       limit: 255
+    t.string   "purpose",      limit: 255
   end
 
   add_index "user_images", ["user_id"], name: "user_images_user_id_fk", using: :btree

--- a/test/controllers/api/series_images_controller_test.rb
+++ b/test/controllers/api/series_images_controller_test.rb
@@ -15,7 +15,7 @@ describe Api::SeriesImagesController do
 
   it 'should show' do
     series_image
-    get(:show, api_request_opts(series_id: series_image.series_id))
+    get(:show, api_request_opts(series_id: series_image.series_id, id: series_image.id))
     assert_response :success
   end
 
@@ -28,9 +28,9 @@ describe Api::SeriesImagesController do
     SeriesImage.find(series_image.id).credit.must_equal('blah credit')
   end
 
-  it 'should create' do
+  it 'should add an image' do
     original = series_image
-    original.id.must_equal series.image.id
+    original.id.must_equal series.default_image.id
 
     image_hash = {
       upload: 'http://thisisatest.com/guid1/image.gif',
@@ -44,7 +44,7 @@ describe Api::SeriesImagesController do
     new_image = JSON.parse @response.body
 
     original.id.wont_equal new_image['id']
-    series.image(true).id.must_equal new_image['id']
+    series.images.last.id.must_equal new_image['id']
   end
 
   it 'deletes the image, touches the series' do

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class TestImage < Image
+  self.table_name = 'piece_images'
+end
+
+describe Image do
+  let(:image) { TestImage.new }
+
+  it 'is abstract and has no table' do
+    Image.table_name.must_be_nil
+  end
+
+  it 'defines constants' do
+    Image::COMPLETE.wont_be_nil
+    Image::PURPOSES.wont_be :blank?
+  end
+
+  it 'knows if the state is final' do
+    TestImage.new(status: Image::COMPLETE).must_be :fixerable_final?
+    TestImage.new(status: Image::FAILED).wont_be :fixerable_final?
+  end
+end

--- a/test/models/series_test.rb
+++ b/test/models/series_test.rb
@@ -24,6 +24,27 @@ describe Series do
     Series.where(id: v3_series.id).with_deleted.count.must_equal 1
   end
 
+  describe '#images' do
+    let(:series) { create(:series) }
+    let(:image_none) { create(:series_image, series: series, purpose: '') }
+    let(:image_prof) { create(:series_image, series: series, purpose: 'profile') }
+    let(:image_thum) { create(:series_image, series: series, purpose: 'thumbnail') }
+
+    it 'gets the profile image by default' do
+      image_none.wont_be_nil
+      image_prof.wont_be_nil
+      image_thum.wont_be_nil
+      series.default_image.must_equal image_prof
+      series.images.first.wont_equal image_prof
+    end
+
+    it 'gets any image if no profile image' do
+      image_none.wont_be_nil
+      series.default_image.must_equal image_none
+      series.images.first.must_equal image_none
+    end
+  end
+
   describe '#subscribable?' do
     it 'returns true if status is approved' do
       series.subscription_approval_status = Series::SUBSCRIPTION_PRX_APPROVED


### PR DESCRIPTION
- [x] Update models to add default image and has_many for series images
- [x] Update routes for series images to be resource(s)
- [x] Update representers
- [x] Add "use" or "purpose" attribute to model and filter for controller
- [x] Determine default image using purpose as well
- [x] Send the correct images to feeder based on `purpose`
- [x] Define common image purposes
- [x] Add filter by purpose to image controllers
- [x] Set both profile and thumbnail images on podcast