### PR TITLE
Prevent podcast distributions with no podcast

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -63,4 +63,10 @@ class Api::BaseController < ApplicationController
     message = { error: 'You are not authorized to perform this action' }
     render json: message, status: 401
   end
+
+  def wrap_in_transaction
+    ActiveRecord::Base.transaction do
+      yield
+    end
+  end
 end

--- a/app/controllers/api/distributions_controller.rb
+++ b/app/controllers/api/distributions_controller.rb
@@ -13,6 +13,8 @@ class Api::DistributionsController < Api::BaseController
 
   announce_actions resource: :owner_resource
 
+  around_action :wrap_in_transaction, only: :create
+
   def owner_resource
     resource.try(:owner)
   end

--- a/app/controllers/api/story_distributions_controller.rb
+++ b/app/controllers/api/story_distributions_controller.rb
@@ -13,6 +13,8 @@ class Api::StoryDistributionsController < Api::BaseController
 
   announce_actions resource: :story_resource
 
+  around_action :wrap_in_transaction, only: :create
+
   def story_resource
     resource.try(:story)
   end

--- a/app/models/distributions/podcast_distribution.rb
+++ b/app/models/distributions/podcast_distribution.rb
@@ -15,7 +15,8 @@ class Distributions::PodcastDistribution < Distribution
     client = api(root: feeder_root, account: account.id)
     podcast = client.podcasts.first.post(podcast_attributes)
     podcast_url = URI.join(feeder_root, podcast.links['self'].href).to_s
-    update_attributes!(url: podcast_url) if podcast_url
+    raise 'Failed to get podcast url on create' if podcast_url.blank?
+    update_attributes!(url: podcast_url)
   end
 
   def get_podcast

--- a/app/models/story_distributions/episode_distribution.rb
+++ b/app/models/story_distributions/episode_distribution.rb
@@ -15,6 +15,7 @@ class StoryDistributions::EpisodeDistribution < StoryDistribution
     podcast = distribution.get_podcast
     episode = podcast.episodes.post(episode_attributes)
     episode_url = URI.join(feeder_root, episode.links['self'].href).to_s
+    raise 'Failed to get episode url on create' if episode_url.blank?
     update_attributes!(url: episode_url) if episode_url
   end
 

--- a/config/initializers/faraday.rb
+++ b/config/initializers/faraday.rb
@@ -1,0 +1,2 @@
+require 'faraday'
+Faraday.default_adapter = :excon

--- a/test/models/distributions/podcast_distribution_test.rb
+++ b/test/models/distributions/podcast_distribution_test.rb
@@ -24,6 +24,16 @@ describe Distributions::PodcastDistribution do
   end
 
   it 'creates the podcast on feeder' do
+    distribution.stub(:get_account_token, 'token') do
+      distribution.url = nil
+      distribution.account.wont_be_nil
+      distribution.save!
+      distribution.distribute!
+      distribution.url.must_equal(podcast_url)
+    end
+  end
+
+  it 'throws error and rolls back if podcast on feeder fails' do
     distribution.stub(:get_account_token, 'fail') do
       distribution.url = nil
       distribution.account.wont_be_nil
@@ -31,16 +41,6 @@ describe Distributions::PodcastDistribution do
       -> do
         distribution.distribute!
       end.must_raise(HyperResource::ServerError)
-    end
-  end
-
-  it 'throws error and rolls back if podcast on feeder fails' do
-    distribution.stub(:get_account_token, 'token') do
-      distribution.url = nil
-      distribution.account.wont_be_nil
-      distribution.save!
-      distribution.distribute!
-      distribution.url.must_equal(podcast_url)
     end
   end
 

--- a/test/models/distributions/podcast_distribution_test.rb
+++ b/test/models/distributions/podcast_distribution_test.rb
@@ -7,12 +7,16 @@ describe Distributions::PodcastDistribution do
 
   before do
     stub_request(:get, 'https://feeder.prx.org/api/v1').
-      with(headers: { 'Authorization' => 'Bearer token', 'Content-Type' => 'application/json' }).
+      with(headers: { 'Content-Type' => 'application/json' }).
       to_return(status: 200, body: json_file('feeder_root'))
 
     stub_request(:post, 'https://feeder.prx.org/api/v1/podcasts').
       with(headers: { 'Authorization' => 'Bearer token', 'Content-Type' => 'application/json' }).
       to_return(status: 200, body: json_file('podcast'), headers: {})
+
+      stub_request(:post, 'https://feeder.prx.org/api/v1/podcasts').
+        with(headers: { 'Authorization' => 'Bearer fail', 'Content-Type' => 'application/json' }).
+        to_return(status: 500, body: "{'code':'500', 'message':'dupe'}", headers: {})
 
     stub_request(:get, 'https://feeder.prx.org/api/v1/podcasts/23').
       with(headers: { 'Authorization' => 'Bearer token', 'Content-Type' => 'application/json' }).
@@ -20,6 +24,17 @@ describe Distributions::PodcastDistribution do
   end
 
   it 'creates the podcast on feeder' do
+    distribution.stub(:get_account_token, 'fail') do
+      distribution.url = nil
+      distribution.account.wont_be_nil
+      distribution.save!
+      -> do
+        distribution.distribute!
+      end.must_raise(HyperResource::ServerError)
+    end
+  end
+
+  it 'throws error and rolls back if podcast on feeder fails' do
     distribution.stub(:get_account_token, 'token') do
       distribution.url = nil
       distribution.account.wont_be_nil

--- a/test/models/distributions/podcast_distribution_test.rb
+++ b/test/models/distributions/podcast_distribution_test.rb
@@ -14,9 +14,9 @@ describe Distributions::PodcastDistribution do
       with(headers: { 'Authorization' => 'Bearer token', 'Content-Type' => 'application/json' }).
       to_return(status: 200, body: json_file('podcast'), headers: {})
 
-      stub_request(:post, 'https://feeder.prx.org/api/v1/podcasts').
-        with(headers: { 'Authorization' => 'Bearer fail', 'Content-Type' => 'application/json' }).
-        to_return(status: 500, body: "{'code':'500', 'message':'dupe'}", headers: {})
+    stub_request(:post, 'https://feeder.prx.org/api/v1/podcasts').
+      with(headers: { 'Authorization' => 'Bearer fail', 'Content-Type' => 'application/json' }).
+      to_return(status: 500, body: "{'code':'500', 'message':'dupe'}", headers: {})
 
     stub_request(:get, 'https://feeder.prx.org/api/v1/podcasts/23').
       with(headers: { 'Authorization' => 'Bearer token', 'Content-Type' => 'application/json' }).


### PR DESCRIPTION
fixes #209 
- [x] Raise errors when podcast_url is blank when trying to set
- [x] Wrap `controller.create` in a transaction; if feeder podcast create fails, rollback the distribution create