### PR TITLE
Set the audio version template for a distribution

### DIFF
--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -3,7 +3,10 @@ require 'hash_serializer'
 
 class Distribution < BaseModel
   belongs_to :distributable, polymorphic: true, touch: true
+  belongs_to :audio_version_template
+
   has_many :story_distributions
+
   serialize :properties, HashSerializer
 
   def distribute!

--- a/app/representers/api/distribution_representer.rb
+++ b/app/representers/api/distribution_representer.rb
@@ -17,4 +17,13 @@ class Api::DistributionRepresenter < Api::BaseRepresenter
       profile: model_uri(represented.owner)
     } if represented.id && represented.owner
   end
+
+  link rel: :audio_version_template, writeable: true do
+    {
+      href: api_audio_version_template_path(represented.audio_version_template)
+    } if represented.audio_version_template_id
+  end
+  embed :audio_version_template,
+        class: AudioVersionTemplate,
+        decorator: Api::AudioVersionTemplateRepresenter
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -170,12 +170,13 @@ ActiveRecord::Schema.define(version: 6) do
   add_index "audio_versions", ["piece_id"], name: "audio_versions_piece_id_fk", using: :btree
 
   create_table "distributions", force: :cascade do |t|
-    t.string   "type",               limit: 255
-    t.string   "distributable_type", limit: 255
-    t.integer  "distributable_id",   limit: 4
-    t.string   "url",                limit: 255
-    t.string   "guid",               limit: 255
-    t.text     "properties",         limit: 65535
+    t.string   "type",                      limit: 255
+    t.string   "distributable_type",        limit: 255
+    t.integer  "distributable_id",          limit: 4
+    t.integer  "audio_version_template_id", limit: 4
+    t.string   "url",                       limit: 255
+    t.string   "guid",                      limit: 255
+    t.text     "properties",                limit: 65535
     t.datetime "created_at"
     t.datetime "updated_at"
   end

--- a/test/controllers/api/distributions_controller_test.rb
+++ b/test/controllers/api/distributions_controller_test.rb
@@ -2,10 +2,11 @@ require 'test_helper'
 
 describe Api::DistributionsController do
 
-  let(:distribution) { create(:distribution) }
   let(:account) { create(:account) }
-  let(:token) { StubToken.new(account.id, ['member']) }
   let(:series) { create(:series, account: account) }
+  let(:audio_version_template) { create(:audio_version_template, series: series) }
+  let(:distribution) { create(:distribution, audio_version_template: audio_version_template) }
+  let(:token) { StubToken.new(account.id, ['member']) }
 
   it 'should show' do
     get :show, api_request_opts(series_id: distribution.owner.id, id: distribution.id)

--- a/test/models/distributions/podcast_distribution_test.rb
+++ b/test/models/distributions/podcast_distribution_test.rb
@@ -2,7 +2,9 @@ require 'test_helper'
 
 describe Distributions::PodcastDistribution do
 
-  let(:distribution) { build(:podcast_distribution) }
+  let(:series) { create(:series) }
+  let(:audio_version_template) { create(:audio_version_template, series: series) }
+  let(:distribution) { build(:podcast_distribution, audio_version_template: audio_version_template) }
   let(:podcast_url) { URI.join(distribution.feeder_root, '/api/v1/podcasts/23').to_s }
 
   before do

--- a/test/models/distributions/podcast_distribution_test.rb
+++ b/test/models/distributions/podcast_distribution_test.rb
@@ -3,8 +3,8 @@ require 'test_helper'
 describe Distributions::PodcastDistribution do
 
   let(:series) { create(:series) }
-  let(:audio_version_template) { create(:audio_version_template, series: series) }
-  let(:distribution) { build(:podcast_distribution, audio_version_template: audio_version_template) }
+  let(:template) { create(:audio_version_template, series: series) }
+  let(:distribution) { build(:podcast_distribution, audio_version_template: template) }
   let(:podcast_url) { URI.join(distribution.feeder_root, '/api/v1/podcasts/23').to_s }
 
   before do

--- a/test/representers/api/distributions/podcast_distribution_representer_test.rb
+++ b/test/representers/api/distributions/podcast_distribution_representer_test.rb
@@ -26,4 +26,9 @@ describe Api::Distributions::PodcastDistributionRepresenter do
     json['id'].must_equal distribution.id
     json['properties']['explicit'].must_equal 'clean'
   end
+
+  it 'should have a link to an audio version template' do
+    template_path = "/api/v1/audio_version_templates/#{audio_version_template.id}"
+    json['_links']['prx:audio-version-template']['href'].must_equal template_path
+  end
 end

--- a/test/representers/api/distributions/podcast_distribution_representer_test.rb
+++ b/test/representers/api/distributions/podcast_distribution_representer_test.rb
@@ -2,9 +2,11 @@ require 'test_helper'
 
 describe Api::Distributions::PodcastDistributionRepresenter do
 
-  let(:distribution) { create(:podcast_distribution) }
-  let(:representer)  { Api::Distributions::PodcastDistributionRepresenter.new(distribution) }
-  let(:json)         { JSON.parse(representer.to_json) }
+  let(:series) { create(:series) }
+  let(:audio_version_template) { create(:audio_version_template, series: series) }
+  let(:distribution) { create(:podcast_distribution, audio_version_template: audio_version_template) }
+  let(:representer) { Api::Distributions::PodcastDistributionRepresenter.new(distribution) }
+  let(:json) { JSON.parse(representer.to_json) }
 
   before do
     stub_request(:get, "http://feeder.docker/api/v1").

--- a/test/representers/api/distributions/podcast_distribution_representer_test.rb
+++ b/test/representers/api/distributions/podcast_distribution_representer_test.rb
@@ -9,12 +9,12 @@ describe Api::Distributions::PodcastDistributionRepresenter do
   let(:json) { JSON.parse(representer.to_json) }
 
   before do
-    stub_request(:get, "http://feeder.docker/api/v1").
-      with(headers: { 'Authorization'=>'Bearer token', 'Content-Type'=>'application/json' }).
+    stub_request(:get, 'http://feeder.docker/api/v1').
+      with(headers: { 'Authorization' => 'Bearer token', 'Content-Type' => 'application/json' }).
       to_return(status: 200, body: json_file('feeder_root'))
 
-    stub_request(:post, "http://feeder.docker/api/v1/podcasts").
-      with(headers: {'Authorization'=>'Bearer token', 'Content-Type'=>'application/json'}).
+    stub_request(:post, 'http://feeder.docker/api/v1/podcasts').
+      with(headers: { 'Authorization' => 'Bearer token', 'Content-Type' => 'application/json' }).
       to_return(status: 200, body: json_file('podcast'))
   end
 

--- a/test/representers/api/distributions/podcast_distribution_representer_test.rb
+++ b/test/representers/api/distributions/podcast_distribution_representer_test.rb
@@ -3,19 +3,19 @@ require 'test_helper'
 describe Api::Distributions::PodcastDistributionRepresenter do
 
   let(:series) { create(:series) }
-  let(:audio_version_template) { create(:audio_version_template, series: series) }
-  let(:distribution) { create(:podcast_distribution, audio_version_template: audio_version_template) }
+  let(:template) { create(:audio_version_template, series: series) }
+  let(:distribution) { create(:podcast_distribution, audio_version_template: template) }
   let(:representer) { Api::Distributions::PodcastDistributionRepresenter.new(distribution) }
   let(:json) { JSON.parse(representer.to_json) }
 
   before do
     stub_request(:get, "http://feeder.docker/api/v1").
-      with(:headers => {'Accept'=>'application/json', 'Authorization'=>'Bearer token', 'Content-Type'=>'application/json'}).
-      to_return(:status => 200, :body => json_file('feeder_root'))
+      with(headers: { 'Authorization'=>'Bearer token', 'Content-Type'=>'application/json' }).
+      to_return(status: 200, body: json_file('feeder_root'))
 
     stub_request(:post, "http://feeder.docker/api/v1/podcasts").
-      with(:headers => {'Authorization'=>'Bearer token', 'Content-Type'=>'application/json'}).
-      to_return(:status => 200, :body => json_file('podcast'), :headers => {})
+      with(headers: {'Authorization'=>'Bearer token', 'Content-Type'=>'application/json'}).
+      to_return(status: 200, body: json_file('podcast'))
   end
 
   it 'create representer' do
@@ -28,7 +28,7 @@ describe Api::Distributions::PodcastDistributionRepresenter do
   end
 
   it 'should have a link to an audio version template' do
-    template_path = "/api/v1/audio_version_templates/#{audio_version_template.id}"
+    template_path = "/api/v1/audio_version_templates/#{template.id}"
     json['_links']['prx:audio-version-template']['href'].must_equal template_path
   end
 end


### PR DESCRIPTION
- [x] Add in relationship between a distribution and an audio template
- [x] Show this link in representers for the distribution

This isn't validating audio by this, or specifying which audio to send to a distribution yet, need to handle those, esp. when we have multiple versions, but I believe that can wait for a later day.