### PR TITLE
add in a release date used to set published_at on publish!

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -183,13 +183,12 @@ class Story < BaseModel
   end
 
   # raising exceptions here to prevent sending publish messages
-  #  when not actually a change to be published
-  def publish!(apublished_at = nil)
-    apublished_at = released_at || DateTime.now
+  # when not actually a change to be published
+  def publish!
     if !published_at.nil?
       raise "Story #{id} is already published."
     else
-      update_attributes!(published_at: apublished_at)
+      update_attributes!(published_at: (released_at || DateTime.now))
     end
   end
 

--- a/app/representers/api/story_representer.rb
+++ b/app/representers/api/story_representer.rb
@@ -8,7 +8,8 @@ class Api::StoryRepresenter < Api::BaseRepresenter
   property :episode_identifier
   property :created_at, writeable: false
   property :updated_at, writeable: false
-  property :published_at
+  property :published_at, writeable: false
+  property :released_at
   property :produced_on
 
   property :duration, writeable: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -312,6 +312,7 @@ ActiveRecord::Schema.define(version: 6) do
     t.string   "marketplace_subtitle",    limit: 255
     t.text     "marketplace_information", limit: 65535
     t.integer  "network_id",              limit: 4
+    t.datetime "released_at"
   end
 
   add_index "pieces", ["account_id"], name: "pieces_account_id_fk", using: :btree

--- a/test/controllers/api/distributions_controller_test.rb
+++ b/test/controllers/api/distributions_controller_test.rb
@@ -13,15 +13,20 @@ describe Api::DistributionsController do
     assert_response :success
   end
 
-  before(:each) do
-    class << @controller; attr_accessor :prx_auth_token; end
-    @controller.prx_auth_token = token
-  end
-
   describe '#create' do
+
+    before(:each) do
+      class << @controller; attr_accessor :prx_auth_token; end
+      @controller.prx_auth_token = token
+    end
+
     it 'can create a podcast distribution for a series' do
+      template_uri = "/api/v1/audio_version_templates/#{audio_version_template.id}"
+      podcast_uri = 'http://feeder.prx.org/api/v1/podcast/12345'
       pd_hash = {
-        kind: 'podcast'
+        kind: 'podcast',
+        guid: 'SET TEMPLATE',
+        set_audio_version_template_uri: template_uri
       }
       @request.env['CONTENT_TYPE'] = 'application/json'
       def @controller.after_create_resource(res)
@@ -30,7 +35,8 @@ describe Api::DistributionsController do
       post :create, pd_hash.to_json, api_request_opts(series_id: series.id)
       assert_response :success
       resource = JSON.parse(response.body)
-      resource['_links']['prx:podcast']['href'].must_equal 'http://feeder.prx.org/api/v1/podcast/12345'
+      resource['_links']['prx:podcast']['href'].must_equal podcast_uri
+      resource['_links']['prx:audio-version-template']['href'].must_equal template_uri
     end
   end
 end

--- a/test/models/story_test.rb
+++ b/test/models/story_test.rb
@@ -148,8 +148,17 @@ describe Story do
 
     it 'publishes a story' do
       story.published_at = nil
+      story.released_at = nil
       story.publish!
       story.published_at.wont_be_nil
+    end
+
+    it 'publishes a story with a release date' do
+      release_date = 1.week.ago
+      story.published_at = nil
+      story.released_at = release_date
+      story.publish!
+      story.published_at.must_equal release_date
     end
 
     it 'wont publish when already published' do
@@ -163,6 +172,14 @@ describe Story do
       story.published_at = Time.now
       story.unpublish!
       story.published_at.must_be_nil
+    end
+
+    it 'unpublishes a story with a release date' do
+      story.released_at = Time.now
+      story.published_at = story.released_at
+      story.unpublish!
+      story.published_at.must_be_nil
+      story.released_at.wont_be_nil
     end
 
     it 'wont unpublish an unpublished story' do


### PR DESCRIPTION
Rather than directly updating the published date, that value is set when a story is published!

Usually, the published_at will be set to the current time when the story is published.

If a released_at value has been saved for the story, then when it is published!, the published_at is instead set to the published_at, be it past, present, or future.

Story is still only made published (set published_at to a value from nil) via the publish action on the story controller, and likewise unpublished (set published_at to nil) via a controller action.