### PR TITLE
Auto create story distros

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,9 @@ gem 'unf'
 gem 'oauth2'
 gem 'hyperresource'
 
+# Use Sanitize for HTML and CSS whitelisting
+gem 'sanitize'
+
 ## Controller
 gem 'responders', '~> 2.0'
 gem 'hal_api-rails', ' ~> 0.2.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,7 @@ GEM
     concurrent-ruby (1.0.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    crass (1.0.2)
     dalli (2.7.6)
     debug_inspector (0.0.2)
     diffy (3.1.0)
@@ -329,6 +330,8 @@ GEM
     newrelic_rpm (3.17.1.326)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
+    nokogumbo (1.4.10)
+      nokogiri
     oauth2 (1.2.0)
       faraday (>= 0.8, < 0.10)
       jwt (~> 1.0)
@@ -419,6 +422,10 @@ GEM
       uber (>= 0.0.5)
     ruby-progressbar (1.8.1)
     safe_yaml (1.0.4)
+    sanitize (4.4.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.4.4)
+      nokogumbo (~> 1.4.1)
     sdoc (0.4.2)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
@@ -528,6 +535,7 @@ DEPENDENCIES
   reverse_markdown
   roar
   roar-rails
+  sanitize
   sdoc
   shoryuken
   simplecov

--- a/app/controllers/api/stories_controller.rb
+++ b/app/controllers/api/stories_controller.rb
@@ -13,6 +13,12 @@ class Api::StoriesController < Api::BaseController
 
   announce_actions :create, :update, :delete, :publish, :unpublish
 
+  after_action :create_story_distributions, only: [:create], if: ->() { response.successful? }
+
+  def create_story_distributions
+    resource.create_story_distributions
+  end
+
   def publish
     publish_resource.tap do |res|
       authorize res

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -13,14 +13,13 @@ class Distribution < BaseModel
     # no op for the super class
   end
 
+  # default to the generic distro, override in subclass
   def story_distribution_class
     StoryDistribution
   end
 
   def create_story_distribution(story)
-    story_distribution_class.create(distribution: self, story: story).tap do |d|
-      d.distribute!
-    end
+    story_distribution_class.create(distribution: self, story: story).tap(&:distribute!)
   end
 
   def owner

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -13,6 +13,16 @@ class Distribution < BaseModel
     # no op for the super class
   end
 
+  def story_distribution_class
+    StoryDistribution
+  end
+
+  def create_story_distribution(story)
+    story_distribution_class.create(distribution: self, story: story).tap do |d|
+      d.distribute!
+    end
+  end
+
   def owner
     distributable
   end

--- a/app/models/distributions/podcast_distribution.rb
+++ b/app/models/distributions/podcast_distribution.rb
@@ -10,6 +10,10 @@ class Distributions::PodcastDistribution < Distribution
     add_podcast_to_feeder
   end
 
+  def story_distribution_class
+    StoryDistributions::EpisodeDistribution
+  end
+
   def add_podcast_to_feeder
     return unless url.blank?
     client = api(root: feeder_root, account: account.id)

--- a/app/models/story_distributions/episode_distribution.rb
+++ b/app/models/story_distributions/episode_distribution.rb
@@ -21,7 +21,15 @@ class StoryDistributions::EpisodeDistribution < StoryDistribution
 
   def episode_attributes
     {
-      prx_uri: api_story_path(story)
+      prx_uri: api_story_path(story),
+      title: story.title,
+      subtitle: Sanitize.fragment(story.short_description || '').strip,
+      description: Sanitize.fragment(story.short_description || '').strip,
+      summary: story.description,
+      content: story.description,
+      categories: story.tags,
+      published_at: story.published_at,
+      updated_at: story.updated_at
     }
   end
 end

--- a/app/representers/api/min/series_representer.rb
+++ b/app/representers/api/min/series_representer.rb
@@ -19,7 +19,8 @@ class Api::Min::SeriesRepresenter < Api::BaseRepresenter
         as: :stories,
         paged: true,
         item_class: Story,
-        item_decorator: Api::Min::StoryRepresenter
+        item_decorator: Api::Min::StoryRepresenter,
+        zoom: false
 
   link :image do
     {

--- a/app/representers/api/story_representer.rb
+++ b/app/representers/api/story_representer.rb
@@ -110,6 +110,17 @@ class Api::StoryRepresenter < Api::BaseRepresenter
     } if represented.id
   end
   embed :musical_works, paged: true, item_class: MusicalWork, zoom: false
+
+  link :distributions do
+    {
+      href: api_story_story_distributions_path(represented),
+      count: represented.distributions.count
+    } if represented.id
+  end
+  embed :distributions,
+        paged: true,
+        item_class: StoryDistribution,
+        item_decorator: Api::StoryDistributionRepresenter
 end
 
 # TODO:

--- a/test/controllers/api/stories_controller_test.rb
+++ b/test/controllers/api/stories_controller_test.rb
@@ -40,7 +40,11 @@ describe Api::StoriesController do
       stub_request(:post, 'https://id.prx.org/token').to_return(status: 500)
 
       series.wont_be_nil
-      story_hash = { title: 'create story', set_account_uri: "/api/v1/accounts/#{account.id}", set_series_uri: "/api/v1/series/#{series.id}" }
+      story_hash = {
+        title: 'create story',
+        set_account_uri: "/api/v1/accounts/#{account.id}",
+        set_series_uri: "/api/v1/series/#{series.id}"
+      }
       post :create, story_hash.to_json, api_version: 'v1', format: 'json'
       assert_response :success
       res = JSON.parse(response.body)

--- a/test/controllers/api/stories_controller_test.rb
+++ b/test/controllers/api/stories_controller_test.rb
@@ -3,7 +3,8 @@
 require 'test_helper'
 
 describe Api::StoriesController do
-  let(:story) { create(:story) }
+  let(:series) { create(:series) }
+  let(:story) { create(:story, series: series) }
 
   before { Story.delete_all }
 
@@ -32,6 +33,18 @@ describe Api::StoriesController do
       assert_response :success
       id = JSON.parse(response.body)['id']
       Story.find(id).account_id.must_equal account.id
+    end
+
+    it 'can create a new story and distributions' do
+      # feeder calls do't need to work, but webmock needs a response defined
+      stub_request(:post, 'https://id.prx.org/token').to_return(status: 500)
+
+      series.wont_be_nil
+      story_hash = { title: 'create story', set_account_uri: "/api/v1/accounts/#{account.id}", set_series_uri: "/api/v1/series/#{series.id}" }
+      post :create, story_hash.to_json, api_version: 'v1', format: 'json'
+      assert_response :success
+      res = JSON.parse(response.body)
+      Story.find(res['id']).distributions.count.must_equal 1
     end
 
     it 'can set description as markdown' do
@@ -119,13 +132,13 @@ describe Api::StoriesController do
   end
 
   it 'should list published stories of any app version' do
-    story.must_be :published
+    story1 = create(:story, published_at: 1.day.ago)
     story2 = create(:story, published_at: nil)
-    story3 = create(:story_v3)
+    story3 = create(:story_v3, published_at: 1.day.ago)
 
     get(:index, { api_version: 'v1', format: 'json' } )
     assert_response :success
-    assigns[:stories].must_include story
+    assigns[:stories].must_include story1
     assigns[:stories].wont_include story2
     assigns[:stories].must_include story3
   end
@@ -173,12 +186,13 @@ describe Api::StoriesController do
   end
 
   it 'should list only v4 stories' do
-    story.must_be :v4?
+    story1 = create(:story)
+    story1.must_be :v4?
     story2 = create(:story_v3)
     get(:index, api_version: 'v1', format: 'json', filters: 'v4')
     assert_response :success
     assert_not_nil assigns[:stories]
-    assigns[:stories].must_include story
+    assigns[:stories].must_include story1
     assigns[:stories].wont_include story2
   end
 

--- a/test/models/distribution_test.rb
+++ b/test/models/distribution_test.rb
@@ -32,13 +32,15 @@ describe Distribution do
   end
 
   it 'creates and distributes for story' do
+    mock_distro = MiniTest::Mock.new
     mock_story_distro = MiniTest::Mock.new
+
+    mock_distro.expect(:create, mock_story_distro, [Hash])
     mock_story_distro.expect(:tap, mock_story_distro)
     mock_story_distro.expect(:distribute!, true)
-    mock_distro = MiniTest::Mock.new
-    mock_distro.expect(:create, mock_story_distro, [Hash])
+
     distribution.stub(:story_distribution_class, mock_distro) do
-      story_distribution = distribution.create_story_distribution(story)
+      distribution.create_story_distribution(story)
     end
   end
 end

--- a/test/models/distribution_test.rb
+++ b/test/models/distribution_test.rb
@@ -1,8 +1,9 @@
 require 'test_helper'
+require 'minitest/mock'
 
 describe Distribution do
-
   let(:distribution) { create(:distribution) }
+  let(:story) { create(:story) }
 
   it 'has a table defined' do
     Distribution.table_name.must_equal 'distributions'
@@ -24,5 +25,20 @@ describe Distribution do
 
   it 'can be created with valid attributes' do
     distribution.must_be :valid?
+  end
+
+  it 'returns story distribution class' do
+    distribution.story_distribution_class.must_equal StoryDistribution
+  end
+
+  it 'creates and distributes for story' do
+    mock_story_distro = MiniTest::Mock.new
+    mock_story_distro.expect(:tap, mock_story_distro)
+    mock_story_distro.expect(:distribute!, true)
+    mock_distro = MiniTest::Mock.new
+    mock_distro.expect(:create, mock_story_distro, [Hash])
+    distribution.stub(:story_distribution_class, mock_distro) do
+      story_distribution = distribution.create_story_distribution(story)
+    end
   end
 end

--- a/test/models/distributions/podcast_distribution_test.rb
+++ b/test/models/distributions/podcast_distribution_test.rb
@@ -25,6 +25,10 @@ describe Distributions::PodcastDistribution do
       to_return(status: 200, body: json_file('podcast'), headers: {})
   end
 
+  it 'returns episode distribution class' do
+    distribution.story_distribution_class.must_equal StoryDistributions::EpisodeDistribution
+  end
+
   it 'creates the podcast on feeder' do
     distribution.stub(:get_account_token, 'token') do
       distribution.url = nil
@@ -40,9 +44,7 @@ describe Distributions::PodcastDistribution do
       distribution.url = nil
       distribution.account.wont_be_nil
       distribution.save!
-      -> do
-        distribution.distribute!
-      end.must_raise(HyperResource::ServerError)
+      -> { distribution.distribute! }.must_raise(HyperResource::ServerError)
     end
   end
 

--- a/test/models/story_test.rb
+++ b/test/models/story_test.rb
@@ -26,6 +26,28 @@ describe Story do
     end
   end
 
+  describe 'distributions' do
+    let(:series) { create(:series) }
+    let(:story) { create(:story, series: series) }
+
+    it 'creates story distributions' do
+      stub_request(:post, 'https://id.prx.org/token').
+        to_return(status: 200, body: '{"access_token":"abc123","token_type":"bearer"}',
+        headers: { 'Content-Type' => 'application/json; charset=utf-8' })
+
+      stub_request(:get, 'https://feeder.prx.org/api/v1/podcasts/23').
+        to_return(status: 200, body: json_file(:podcast), headers: {})
+
+      stub_request(:post, 'https://feeder.prx.org/api/v1/podcasts/23/episodes').
+        to_return(status: 200, body: json_file(:episode), headers: {})
+
+      series.distributions.count.must_equal 1
+      story.distributions(true).count.must_equal 0
+      story.create_story_distributions
+      story.distributions(true).count.must_equal 1
+    end
+  end
+
   describe 'using default audio version' do
     it 'finds default audio' do
       story.audio_versions.count.must_equal 10

--- a/test/models/story_test.rb
+++ b/test/models/story_test.rb
@@ -32,8 +32,9 @@ describe Story do
 
     it 'creates story distributions' do
       stub_request(:post, 'https://id.prx.org/token').
-        to_return(status: 200, body: '{"access_token":"abc123","token_type":"bearer"}',
-        headers: { 'Content-Type' => 'application/json; charset=utf-8' })
+        to_return(status: 200,
+                  body: '{"access_token":"abc123","token_type":"bearer"}',
+                  headers: { 'Content-Type' => 'application/json; charset=utf-8' })
 
       stub_request(:get, 'https://feeder.prx.org/api/v1/podcasts/23').
         to_return(status: 200, body: json_file(:podcast), headers: {})


### PR DESCRIPTION
- [x] create story distributions when a story is created and is in a series that has distributions associated with it
- [x] send story attributes to feeder on episode create
- [x] include distributions in the story representer
- [x] bug fix: don't include stories in the series min representer - makes it huge