### PR TITLE
Check if Series audio version template was deleted before linking to it for Story

### DIFF
--- a/app/models/audio_version_template.rb
+++ b/app/models/audio_version_template.rb
@@ -5,7 +5,7 @@ class AudioVersionTemplate < BaseModel
 
   has_many :audio_file_templates, -> { order :position }, dependent: :destroy
 
-  has_many :audio_versions
+  has_many :audio_versions, dependent: :nullify
 
   after_save :touch_audio_versions
 

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -32,7 +32,7 @@ class Series < BaseModel
   has_many :stories, -> { order('episode_number DESC, position DESC, published_at DESC') }
   has_many :schedules
   has_many :audio_version_templates
-  has_many :distributions, as: :distributable
+  has_many :distributions, as: :distributable, dependent: :destroy
 
   has_many :images, -> { where(parent_id: nil) }, class_name: 'SeriesImage', dependent: :destroy
 

--- a/app/representers/api/audio_version_representer.rb
+++ b/app/representers/api/audio_version_representer.rb
@@ -24,7 +24,7 @@ class Api::AudioVersionRepresenter < Api::BaseRepresenter
   #       item_decorator: Api::AudioFileRepresenter
 
   link rel: :audio_version_template, writeable: true do
-    {#
+    {
       href: api_audio_version_template_path(represented.audio_version_template)
     } if represented.audio_version_template_id
   end

--- a/app/representers/api/audio_version_representer.rb
+++ b/app/representers/api/audio_version_representer.rb
@@ -26,7 +26,7 @@ class Api::AudioVersionRepresenter < Api::BaseRepresenter
   link rel: :audio_version_template, writeable: true do
     {
       href: api_audio_version_template_path(represented.audio_version_template)
-    } if represented.audio_version_template_id
+    } if represented.audio_version_template_id && AudioVersionTemplate.exists?(represented.audio_version_template_id)
   end
   embed :audio_version_template,
         class: AudioVersionTemplate,

--- a/app/representers/api/audio_version_representer.rb
+++ b/app/representers/api/audio_version_representer.rb
@@ -24,9 +24,9 @@ class Api::AudioVersionRepresenter < Api::BaseRepresenter
   #       item_decorator: Api::AudioFileRepresenter
 
   link rel: :audio_version_template, writeable: true do
-    {
+    {#
       href: api_audio_version_template_path(represented.audio_version_template)
-    } if represented.audio_version_template_id && AudioVersionTemplate.exists?(represented.audio_version_template_id)
+    } if represented.audio_version_template_id
   end
   embed :audio_version_template,
         class: AudioVersionTemplate,

--- a/test/representers/api/audio_version_representer_test.rb
+++ b/test/representers/api/audio_version_representer_test.rb
@@ -39,7 +39,7 @@ describe Api::AudioVersionRepresenter do
   end
 
   it 'doesnt return a link to the template if there is no template' do
-    representer.represented.audio_version_template = nil
+    representer.represented.audio_version_template_id = 'foo'
     json['_links']['prx:audio-version-template'].must_be_nil
   end
 end

--- a/test/representers/api/audio_version_representer_test.rb
+++ b/test/representers/api/audio_version_representer_test.rb
@@ -38,8 +38,9 @@ describe Api::AudioVersionRepresenter do
     json['_links']['prx:audio-version-template']['href'].wont_be_nil
   end
 
-  it 'doesnt return a link to the template if there is no template' do
-    representer.represented.audio_version_template_id = 'foo'
+  it 'doesnt link to the template if the template has been destroyed' do
+    representer.represented.audio_version_template.destroy!
+    representer.represented.reload
     json['_links']['prx:audio-version-template'].must_be_nil
   end
 end

--- a/test/representers/api/audio_version_representer_test.rb
+++ b/test/representers/api/audio_version_representer_test.rb
@@ -37,4 +37,9 @@ describe Api::AudioVersionRepresenter do
   it 'returns a link to the template' do
     json['_links']['prx:audio-version-template']['href'].wont_be_nil
   end
+
+  it 'doesnt return a link to the template if there is no template' do
+    representer.represented.audio_version_template = nil
+    json['_links']['prx:audio-version-template'].must_be_nil
+  end
 end


### PR DESCRIPTION
Handles what to do for child resources when Series is deleted, to nix 500 errors we're getting on Publish a) when you delete an Audio Version Template from a Series with existing Stories (solution: make the foreign_key of the audio version nil but keep the audio version), and b) when you delete a Series that has Distributions (solution: delete the Distributions too). 