### PR TITLE
Fix API responses

### DIFF
--- a/app/controllers/api/api_responder.rb
+++ b/app/controllers/api/api_responder.rb
@@ -1,4 +1,4 @@
-require "roar/rails/responder"
+require 'roar/rails/responder'
 
 class Api::ApiResponder < Roar::Rails::Responder
   def api_behavior

--- a/app/controllers/api/api_responder.rb
+++ b/app/controllers/api/api_responder.rb
@@ -1,0 +1,17 @@
+require "roar/rails/responder"
+
+class Api::ApiResponder < Roar::Rails::Responder
+  def api_behavior
+    raise MissingRenderer.new(format) unless has_renderer?
+
+    if post?
+      display(resource, status: :created)
+    elsif put?
+      display(resource, status: :ok)
+    elsif delete?
+      display(resource, status: :no_content)
+    else
+      super
+    end
+  end
+end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -3,6 +3,11 @@ require 'hal_api/rails'
 
 class Api::BaseController < ApplicationController
   include HalApi::Controller
+
+  def self.responder
+    Api::ApiResponder
+  end
+
   include Pundit
   include ApiVersioning
   include ApiFiltering
@@ -59,8 +64,11 @@ class Api::BaseController < ApplicationController
 
   private
 
-  def user_not_authorized
-    message = { error: 'You are not authorized to perform this action' }
+  def user_not_authorized(exception = nil)
+    message = { status: 401, message: 'You are not authorized to perform this action' }
+    if exception && Rails.configuration.try(:consider_all_requests_local)
+      message[:backtrace] = exception.backtrace
+    end
     render json: message, status: 401
   end
 

--- a/test/controllers/api/auth/stories_controller_test.rb
+++ b/test/controllers/api/auth/stories_controller_test.rb
@@ -98,12 +98,12 @@ describe Api::Auth::StoriesController do
     it 'does not update unowned stories' do
       @request.env['CONTENT_TYPE'] = 'application/json'
       put :update, { title: 'foobar' }.to_json, api_version: 'v1', id: random_story.id
-      assert_response :no_content # TODO: see hal_actions.rb
+      assert_response :not_found
     end
 
     it 'does not delete unowned stories' do
       delete :destroy, api_version: 'v1', id: random_story.id
-      assert_response :no_content # TODO: see hal_actions.rb
+      assert_response :not_found
     end
   end
 

--- a/test/controllers/api/stories_controller_test.rb
+++ b/test/controllers/api/stories_controller_test.rb
@@ -100,7 +100,7 @@ describe Api::StoriesController do
           format: 'json',
           id: story.id
       assert_response :success
-      Story.find(story.id).title.must_equal('this')
+      JSON.parse(response.body)['title'].must_equal('this')
     end
 
     it 'can publish a story' do


### PR DESCRIPTION
- [x] On updates (`PUT`), return the updated resource in the body, as with `POST` responses
- [x] Fix `DELETE` responses to correctly return an error when one is thrown, e.g. on 404
- [x] Fix authorization error response to match `hal_api-rails` errors, with `:status`, `:message`, and `:backtrace` attributes