### PR TITLE
Include created story distributions in story create response

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -7,6 +7,7 @@ class Api::BaseController < ApplicationController
   include ApiVersioning
   include ApiFiltering
   include ApiSorting
+  include ResourceCallbacks
   include ChildResource
   include PolymorphicResource
   include AnnounceActions

--- a/app/controllers/api/stories_controller.rb
+++ b/app/controllers/api/stories_controller.rb
@@ -13,10 +13,8 @@ class Api::StoriesController < Api::BaseController
 
   announce_actions :create, :update, :delete, :publish, :unpublish
 
-  after_action :create_story_distributions, only: [:create], if: ->() { response.successful? }
-
-  def create_story_distributions
-    resource.create_story_distributions
+  def after_create_resource(res)
+    res.create_story_distributions
   end
 
   def publish

--- a/app/controllers/concerns/abstract_resource.rb
+++ b/app/controllers/concerns/abstract_resource.rb
@@ -46,6 +46,5 @@ module AbstractResource
     class_name.safe_constantize
   end
 
-  def after_create_resource(_resource = nil)
-  end
+  def after_create_resource(_resource = nil); end
 end

--- a/app/controllers/concerns/abstract_resource.rb
+++ b/app/controllers/concerns/abstract_resource.rb
@@ -46,6 +46,6 @@ module AbstractResource
     class_name.safe_constantize
   end
 
-  def after_create_resource(_resource)
+  def after_create_resource(_resource = nil)
   end
 end

--- a/app/controllers/concerns/resource_callbacks.rb
+++ b/app/controllers/concerns/resource_callbacks.rb
@@ -34,12 +34,7 @@ module ResourceCallbacks
     end
   end
 
-  def after_create_resource(_resource = nil)
-  end
-
-  def after_update_resource(_resource = nil)
-  end
-
-  def after_destroy_resource(_resource = nil)
-  end
+  def after_create_resource(_resource = nil); end
+  def after_update_resource(_resource = nil); end
+  def after_destroy_resource(_resource = nil); end
 end

--- a/app/controllers/concerns/resource_callbacks.rb
+++ b/app/controllers/concerns/resource_callbacks.rb
@@ -1,0 +1,45 @@
+# encoding: utf-8
+
+require 'active_support/concern'
+
+module ResourceCallbacks
+  extend ActiveSupport::Concern
+
+  def create
+    create_resource.tap do |res|
+      consume! res, create_options
+      hal_authorize res
+      res.save!
+      after_create_resource(res)
+      respond_with root_resource(res), create_options
+    end
+  end
+
+  def update
+    update_resource.tap do |res|
+      consume! res, show_options
+      hal_authorize res
+      res.save!
+      after_update_resource(res)
+      respond_with root_resource(res), show_options
+    end
+  end
+
+  def destroy
+    destroy_resource.tap do |res|
+      hal_authorize res
+      res.destroy
+      after_destroy_resource(res)
+      head :no_content
+    end
+  end
+
+  def after_create_resource(_resource = nil)
+  end
+
+  def after_update_resource(_resource = nil)
+  end
+
+  def after_destroy_resource(_resource = nil)
+  end
+end

--- a/app/controllers/concerns/resource_callbacks.rb
+++ b/app/controllers/concerns/resource_callbacks.rb
@@ -35,6 +35,8 @@ module ResourceCallbacks
   end
 
   def after_create_resource(_resource = nil); end
+
   def after_update_resource(_resource = nil); end
+
   def after_destroy_resource(_resource = nil); end
 end


### PR DESCRIPTION
- [x] Introduce new callbacks for controllers for after a resource is saved, but before the response
- [x] Use the `after_create_resource` callback to create story distributions for newly created story