### PR TITLE
Correct assignment of episode description.

### DIFF
--- a/app/models/story_distributions/episode_distribution.rb
+++ b/app/models/story_distributions/episode_distribution.rb
@@ -24,7 +24,7 @@ class StoryDistributions::EpisodeDistribution < StoryDistribution
       prx_uri: api_story_path(story),
       title: story.title,
       subtitle: Sanitize.fragment(story.short_description || '').strip,
-      description: Sanitize.fragment(story.short_description || '').strip,
+      description: Sanitize.fragment(story.description || '').strip,
       summary: story.description,
       content: story.description,
       categories: story.tags,


### PR DESCRIPTION
EpisodeDistribution.rb was incorrectly assigning the description attribute (to `short_description` instead of `description`). 