### PR TITLE
Swap representer preference from min to full

### DIFF
--- a/app/controllers/concerns/announce_actions/announce_filter.rb
+++ b/app/controllers/concerns/announce_actions/announce_filter.rb
@@ -67,7 +67,6 @@ module AnnounceActions
       "Api::Msg::#{name}Representer".safe_constantize ||
       "Api::#{name}Representer".safe_constantize ||
       "Api::Min::#{name}Representer".safe_constantize
-
     end
   end
 end

--- a/app/controllers/concerns/announce_actions/announce_filter.rb
+++ b/app/controllers/concerns/announce_actions/announce_filter.rb
@@ -65,8 +65,8 @@ module AnnounceActions
 
     def decorator_class(name)
       "Api::Msg::#{name}Representer".safe_constantize ||
-      "Api::#{name}Representer".safe_constantize ||
-      "Api::Min::#{name}Representer".safe_constantize
+        "Api::#{name}Representer".safe_constantize ||
+        "Api::Min::#{name}Representer".safe_constantize
     end
   end
 end

--- a/app/controllers/concerns/announce_actions/announce_filter.rb
+++ b/app/controllers/concerns/announce_actions/announce_filter.rb
@@ -65,8 +65,9 @@ module AnnounceActions
 
     def decorator_class(name)
       "Api::Msg::#{name}Representer".safe_constantize ||
-      "Api::Min::#{name}Representer".safe_constantize ||
-      "Api::#{name}Representer".safe_constantize
+      "Api::#{name}Representer".safe_constantize ||
+      "Api::Min::#{name}Representer".safe_constantize
+
     end
   end
 end

--- a/app/models/story_distributions/episode_distribution.rb
+++ b/app/models/story_distributions/episode_distribution.rb
@@ -24,7 +24,7 @@ class StoryDistributions::EpisodeDistribution < StoryDistribution
       prx_uri: api_story_path(story),
       title: story.title,
       subtitle: Sanitize.fragment(story.short_description || '').strip,
-      description: Sanitize.fragment(story.short_description || '').strip,
+      description: Sanitize.fragment(story.description_html || '').strip,
       summary: story.description,
       content: story.description,
       categories: story.tags,

--- a/test/controllers/concerns/announce_actions/announce_filter_test.rb
+++ b/test/controllers/concerns/announce_actions/announce_filter_test.rb
@@ -38,9 +38,9 @@ describe AnnounceActions::AnnounceFilter do
     filter.announce_action.must_equal('foo')
   end
 
-  it 'defaults to the msg then min decorator when possible' do
+  it 'defaults to the msg decorator when possible' do
     dc = filter.decorator_class('TestObject')
-    dc.must_equal Api::Min::TestObjectRepresenter
+    dc.must_equal Api::TestObjectRepresenter
 
     class Api::Msg::TestObjectRepresenter < Api::Min::TestObjectRepresenter; end
     dc = filter.decorator_class('TestObject')
@@ -50,13 +50,13 @@ describe AnnounceActions::AnnounceFilter do
 
   it 'gets the decorator to use based on the resource' do
     dc = filter.decorator_for_model(resource)
-    dc.must_equal Api::Min::TestObjectRepresenter
+    dc.must_equal Api::TestObjectRepresenter
   end
 
   it 'gets the decorator to use based on the resource base class' do
     FooTestObject.base_class.must_equal TestObject
     dc = filter.decorator_for_model(FooTestObject.new('foo', true))
-    dc.must_equal Api::Min::TestObjectRepresenter
+    dc.must_equal Api::TestObjectRepresenter
   end
 
   it 'can use an optional decorator' do


### PR DESCRIPTION
- [x] Prefer full representer instead of min representer (will stop our current issue of episode.description being overwritten by `nil`!)
- [x] Also use `description_html` instead of `description` 