### PR TITLE
Fix public asset urls to be full, not relative

### DIFF
--- a/app/models/concerns/public_asset.rb
+++ b/app/models/concerns/public_asset.rb
@@ -34,7 +34,7 @@ module PublicAsset
   def public_url(options={})
     options = set_asset_option_defaults(options)
     options[:token] = public_url_token(options)
-    public_asset_path(options)
+    public_asset_url(options)
   end
 
   def asset_url(options={})

--- a/app/models/distributions/podcast_distribution.rb
+++ b/app/models/distributions/podcast_distribution.rb
@@ -40,14 +40,18 @@ class Distributions::PodcastDistribution < Distribution
       attrs[:description] = owner.description
       attrs[:summary] = owner.description
       if owner.images.profile
-        attrs[:itunes_image] = { url: owner.images.profile.public_url(version: 'original') }
+        attrs[:itunes_image] = { url: image_url(:profile) }
       end
 
       if owner.images.thumbnail
-        attrs[:feed_image] = { url: owner.images.thumbnail.public_url(version: 'original') }
+        attrs[:feed_image] = { url: image_url(:thumbnail) }
       end
     end
 
     attrs
+  end
+
+  def image_url(purpose)
+    owner.images.try(purpose).public_url(version: 'original')
   end
 end

--- a/test/controllers/api/series_images_controller_test.rb
+++ b/test/controllers/api/series_images_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe Api::SeriesImagesController do
   let(:user) { create(:user) }
   let(:series) { create(:series, account: user.individual_account) }
-  let(:series_image) { create(:series_image, series: series) }
+  let(:series_image) { create(:series_image, series: series, purpose: nil) }
   let(:token) { StubToken.new(series.account.id, ['member']) }
 
   before(:each) do
@@ -29,8 +29,7 @@ describe Api::SeriesImagesController do
   end
 
   it 'should add an image' do
-    original = series_image
-    original.id.must_equal series.default_image.id
+    original = series.default_image
 
     image_hash = {
       upload: 'http://thisisatest.com/guid1/image.gif',

--- a/test/factories/series_factory.rb
+++ b/test/factories/series_factory.rb
@@ -11,12 +11,14 @@ FactoryGirl.define do
       stories_count 2
       templates_count 1
       dist_count 1
+      images_count 1
     end
 
     after(:create) do |series, evaluator|
       FactoryGirl.create_list(:story, evaluator.stories_count, series: series)
       FactoryGirl.create_list(:audio_version_template, evaluator.templates_count, series: series)
       FactoryGirl.create_list(:podcast_distribution, evaluator.dist_count, distributable: series)
+      FactoryGirl.create_list(:series_image, evaluator.images_count, series: series)
     end
 
     factory :series_v3 do

--- a/test/factories/series_image_factory.rb
+++ b/test/factories/series_image_factory.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :series_image do
 
     series
+    purpose 'profile'
 
     after(:create) { |af| af.update_file!('test.png') }
 

--- a/test/models/concerns/public_asset_test.rb
+++ b/test/models/concerns/public_asset_test.rb
@@ -35,7 +35,7 @@ describe PublicAsset do
   end
 
   it 'generates a public url' do
-    public_asset.public_url.must_equal "/pub/5033d06991dc5b69e38275253bfb3b24/0/web/test_public_asset/1/original/test.mp3"
+    public_asset.public_url.must_match /http(.+)cms(.+)prx(.+)\/pub\/5033d06991dc5b69e38275253bfb3b24\/0\/web\/test_public_asset\/1\/original\/test\.mp3/
   end
 
   it 'generates an asset url' do

--- a/test/models/distributions/podcast_distribution_test.rb
+++ b/test/models/distributions/podcast_distribution_test.rb
@@ -59,9 +59,12 @@ describe Distributions::PodcastDistribution do
 
   it 'returns attributes for creating the podcast' do
     attrs = distribution.podcast_attributes
-    attrs.keys.count.must_equal 7
+    attrs.keys.count.must_equal 9
     attrs[:prx_uri].must_equal "/api/v1/series/#{distribution.owner.id}"
     attrs[:prx_account_uri].must_equal "/api/v1/accounts/#{distribution.account.id}"
     attrs[:published_at].wont_be_nil
+    attrs[:feed_image][:url].wont_be_nil
+    attrs[:itunes_image][:url].wont_be_nil
+    attrs[:itunes_image][:url].must_match /^http(.+)cms(.+)original\/test.png/
   end
 end

--- a/test/models/series_test.rb
+++ b/test/models/series_test.rb
@@ -25,7 +25,7 @@ describe Series do
   end
 
   describe '#images' do
-    let(:series) { create(:series) }
+    let(:series) { create(:series, images_count: 0) }
     let(:image_none) { create(:series_image, series: series, purpose: '') }
     let(:image_prof) { create(:series_image, series: series, purpose: 'profile') }
     let(:image_thum) { create(:series_image, series: series, purpose: 'thumbnail') }


### PR DESCRIPTION
Fixing an issue with urls sent on to feeder, these need to be full urls, not relative like other hal-json links.