### PR TITLE
Remove image info from podcast create call to feeder

### DIFF
--- a/app/models/distributions/podcast_distribution.rb
+++ b/app/models/distributions/podcast_distribution.rb
@@ -39,19 +39,8 @@ class Distributions::PodcastDistribution < Distribution
       attrs[:subtitle] = owner.short_description
       attrs[:description] = owner.description
       attrs[:summary] = owner.description
-      if owner.images.profile
-        attrs[:itunes_image] = { url: image_url(:profile) }
-      end
-
-      if owner.images.thumbnail
-        attrs[:feed_image] = { url: image_url(:thumbnail) }
-      end
     end
 
     attrs
-  end
-
-  def image_url(purpose)
-    owner.images.try(purpose).public_url(version: 'original')
   end
 end

--- a/test/models/distributions/podcast_distribution_test.rb
+++ b/test/models/distributions/podcast_distribution_test.rb
@@ -59,12 +59,14 @@ describe Distributions::PodcastDistribution do
 
   it 'returns attributes for creating the podcast' do
     attrs = distribution.podcast_attributes
-    attrs.keys.count.must_equal 9
+    attrs.keys.count.must_equal 7
     attrs[:prx_uri].must_equal "/api/v1/series/#{distribution.owner.id}"
     attrs[:prx_account_uri].must_equal "/api/v1/accounts/#{distribution.account.id}"
     attrs[:published_at].wont_be_nil
-    attrs[:feed_image][:url].wont_be_nil
-    attrs[:itunes_image][:url].wont_be_nil
-    attrs[:itunes_image][:url].must_match /^http(.+)cms(.+)original\/test.png/
+  end
+
+  it 'doesnt send image info on create' do
+    attrs = distribution.podcast_attributes
+    attrs.keys.each { |key| key.to_s.wont_match /image/ }
   end
 end


### PR DESCRIPTION
patch to fix #235: don't send image information to feeder on initial podcast create request. Instead, rely on the async updates to get the image information through once images have finished processing. 