### PR TITLE
Use token list of accounts for user authorization

### DIFF
--- a/app/controllers/api/auth/accounts_controller.rb
+++ b/app/controllers/api/auth/accounts_controller.rb
@@ -14,6 +14,6 @@ class Api::Auth::AccountsController < Api::AccountsController
   end
 
   def resources_base
-    Authorization.new(prx_auth_token).token_auth_accounts
+    authorization.token_auth_accounts
   end
 end

--- a/app/controllers/api/auth/accounts_controller.rb
+++ b/app/controllers/api/auth/accounts_controller.rb
@@ -14,6 +14,10 @@ class Api::Auth::AccountsController < Api::AccountsController
   end
 
   def resources_base
-    @accounts ||= current_user.approved_accounts
+    @accounts ||= token_accounts
+  end
+
+  def token_accounts
+    current_user.approved_accounts = Account.where({ id: prx_auth_token.authorized_resources.keys })
   end
 end

--- a/app/controllers/api/auth/accounts_controller.rb
+++ b/app/controllers/api/auth/accounts_controller.rb
@@ -14,10 +14,6 @@ class Api::Auth::AccountsController < Api::AccountsController
   end
 
   def resources_base
-    @accounts ||= token_accounts
-  end
-
-  def token_accounts
-    current_user.approved_accounts = Account.where({ id: prx_auth_token.authorized_resources.keys })
+    current_user.approved_accounts
   end
 end

--- a/app/controllers/api/auth/accounts_controller.rb
+++ b/app/controllers/api/auth/accounts_controller.rb
@@ -14,6 +14,6 @@ class Api::Auth::AccountsController < Api::AccountsController
   end
 
   def resources_base
-    current_user.approved_accounts
+    Authorization.new(prx_auth_token).token_auth_accounts
   end
 end

--- a/app/controllers/api/auth/series_controller.rb
+++ b/app/controllers/api/auth/series_controller.rb
@@ -10,6 +10,6 @@ class Api::Auth::SeriesController < Api::SeriesController
   represent_with Api::Auth::SeriesRepresenter
 
   def resources_base
-    @series ||= Authorization.new(prx_auth_token).token_auth_series
+    @series ||= authorization.token_auth_series
   end
 end

--- a/app/controllers/api/auth/series_controller.rb
+++ b/app/controllers/api/auth/series_controller.rb
@@ -10,6 +10,6 @@ class Api::Auth::SeriesController < Api::SeriesController
   represent_with Api::Auth::SeriesRepresenter
 
   def resources_base
-    @series ||= current_user.approved_account_series
+    @series ||= Authorization.new(prx_auth_token).token_auth_series
   end
 end

--- a/app/controllers/api/auth/stories_controller.rb
+++ b/app/controllers/api/auth/stories_controller.rb
@@ -38,7 +38,7 @@ class Api::Auth::StoriesController < Api::StoriesController
     @stories ||= if params[:network_id]
       super.published
     else
-      Authorization.new(prx_auth_token).token_auth_stories
+      authorization.token_auth_stories
     end
   end
 
@@ -46,8 +46,8 @@ class Api::Auth::StoriesController < Api::StoriesController
     super.tap do |story|
       story.creator_id = current_user.id
       story.account_id ||= story.series.try(:account_id)
-      story.account_id ||= current_user.account_id
-      story.account_id ||= current_user.approved_accounts.first.try(:id) # not sure if I should change this to look at token
+      story.account_id ||= current_user.account_id if authorization.authorized?(current_user.default_account)
+      story.account_id ||= authorization.token_auth_accounts.first.try(:id)
     end
   end
 end

--- a/app/controllers/api/auth/stories_controller.rb
+++ b/app/controllers/api/auth/stories_controller.rb
@@ -38,7 +38,7 @@ class Api::Auth::StoriesController < Api::StoriesController
     @stories ||= if params[:network_id]
       super.published
     else
-      current_user.approved_account_stories
+      Authorization.new(prx_auth_token).token_auth_stories
     end
   end
 
@@ -47,7 +47,7 @@ class Api::Auth::StoriesController < Api::StoriesController
       story.creator_id = current_user.id
       story.account_id ||= story.series.try(:account_id)
       story.account_id ||= current_user.account_id
-      story.account_id ||= current_user.approved_accounts.first.try(:id)
+      story.account_id ||= current_user.approved_accounts.first.try(:id) # not sure if I should change this to look at token
     end
   end
 end

--- a/app/controllers/api/authorizations_controller.rb
+++ b/app/controllers/api/authorizations_controller.rb
@@ -10,6 +10,6 @@ class Api::AuthorizationsController < Api::BaseController
   private
 
   def resource
-    current_user
+    authorization
   end
 end

--- a/app/controllers/concerns/api_authenticated.rb
+++ b/app/controllers/concerns/api_authenticated.rb
@@ -7,18 +7,11 @@ module ApiAuthenticated
   extend ActiveSupport::Concern
 
   included do
-    before_filter :authenticate_user!, :get_authorized_resources
+    before_filter :authenticate_user!
   end
 
   def authenticate_user!
     user_not_authorized unless current_user
-  end
-
-  def get_authorized_resources
-    token_accounts = prx_auth_token.authorized_resources.try(:keys)
-    if token_accounts
-      current_user.approved_accounts ||= Account.where(id: token_accounts)
-    end
   end
 
   def cache_show?

--- a/app/controllers/concerns/api_authenticated.rb
+++ b/app/controllers/concerns/api_authenticated.rb
@@ -14,6 +14,10 @@ module ApiAuthenticated
     user_not_authorized unless current_user
   end
 
+  def authorization
+    Authorization.new(prx_auth_token)
+  end
+
   def cache_show?
     false
   end

--- a/app/controllers/concerns/api_authenticated.rb
+++ b/app/controllers/concerns/api_authenticated.rb
@@ -7,11 +7,17 @@ module ApiAuthenticated
   extend ActiveSupport::Concern
 
   included do
-    before_filter :authenticate_user!
+    before_filter :authenticate_user!, :get_authorized_resources
   end
 
   def authenticate_user!
     user_not_authorized unless current_user
+  end
+
+  def get_authorized_resources
+    if prx_auth_token.authorized_resources
+      current_user.approved_accounts ||= Account.where({ id: prx_auth_token.authorized_resources.keys })
+    end
   end
 
   def cache_show?

--- a/app/controllers/concerns/api_authenticated.rb
+++ b/app/controllers/concerns/api_authenticated.rb
@@ -15,8 +15,9 @@ module ApiAuthenticated
   end
 
   def get_authorized_resources
-    if prx_auth_token.authorized_resources
-      current_user.approved_accounts ||= Account.where({ id: prx_auth_token.authorized_resources.keys })
+    token_accounts = prx_auth_token.authorized_resources.try(:keys)
+    if token_accounts
+      current_user.approved_accounts ||= Account.where(id: token_accounts)
     end
   end
 

--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -6,10 +6,6 @@ class Authorization
 
   def initialize(token)
     @token = token
-    get_authorized_resources
-  end
-
-  def get_authorized_resources
   end
 
   def token_auth_accounts

--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -1,0 +1,27 @@
+# encoding: utf-8
+
+class Authorization
+  attr_accessor :token
+  attr_reader :token_auth_accounts
+
+  def initialize(token)
+    @token = token
+    get_authorized_resources
+  end
+
+  def get_authorized_resources
+  end
+
+  def token_auth_accounts
+    token_ids = token.authorized_resources.try(:keys)
+    @token_auth_accounts = Account.where(id: token_ids) if token_ids
+  end
+
+  def token_auth_stories
+    Story.where(account_id: token_auth_accounts.try(:ids)) unless token_auth_accounts.nil?
+  end
+
+  def token_auth_series
+    Series.where(account_id: token_auth_accounts.try(:ids)) unless token_auth_accounts.nil?
+  end
+end

--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -8,6 +8,14 @@ class Authorization
     @token = token
   end
 
+  def id
+    default_account.id
+  end
+
+  def default_account
+    User.find(token.user_id).default_account
+  end
+
   def token_auth_accounts
     token_ids = token.authorized_resources.try(:keys)
     @token_auth_accounts = Account.where(id: token_ids) if token_ids
@@ -19,5 +27,9 @@ class Authorization
 
   def token_auth_series
     Series.where(account_id: token_auth_accounts.try(:ids)) unless token_auth_accounts.nil?
+  end
+
+  def authorized?(account)
+    token_auth_accounts.include?(account)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,8 @@ class User < BaseModel
 
   after_commit :create_individual_account, on: [:create]
 
+  attr_accessor :approved_accounts
+
   def individual_account
     accounts.where('type = \'IndividualAccount\'').first
   end
@@ -45,25 +47,15 @@ class User < BaseModel
     "#{first_name} #{last_name}"
   end
 
-  def approved_accounts
-    Account.
-      joins('LEFT OUTER JOIN `memberships` ON `memberships`.`account_id` = `accounts`.`id`').
-      where(['memberships.user_id = ? and memberships.approved is true', id])
-  end
-
   def approved_active_accounts
     approved_accounts.active
   end
 
   def approved_account_stories
-    Story.
-      joins('LEFT OUTER JOIN `memberships` ON `memberships`.`account_id` = `pieces`.`account_id`').
-      where(['memberships.user_id = ? and memberships.approved is true', id])
+    Story.where({ account_id: [approved_accounts] })
   end
 
   def approved_account_series
-    Series.
-      joins('LEFT OUTER JOIN `memberships` ON `memberships`.`account_id` = `series`.`account_id`').
-      where(['memberships.user_id = ? and memberships.approved is true', id])
+    Series.where({ account_id: [approved_accounts] })
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,5 +66,4 @@ class User < BaseModel
       joins('LEFT OUTER JOIN `memberships` ON `memberships`.`account_id` = `series`.`account_id`').
       where(['memberships.user_id = ? and memberships.approved is true', id])
   end
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,14 +48,14 @@ class User < BaseModel
   end
 
   def approved_active_accounts
-    approved_accounts.active
+    approved_accounts.try(:active)
   end
 
   def approved_account_stories
-    Story.where({ account_id: [approved_accounts] })
+    !approved_accounts.nil? ? Story.where({ account_id: approved_accounts.try(:ids) }) : []
   end
 
   def approved_account_series
-    Series.where({ account_id: [approved_accounts] })
+    !approved_accounts.nil? ? Series.where({ account_id: approved_accounts.try(:ids) }) : []
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,10 +52,10 @@ class User < BaseModel
   end
 
   def approved_account_stories
-    !approved_accounts.nil? ? Story.where({ account_id: approved_accounts.try(:ids) }) : []
+    !approved_accounts.nil? ? Story.where(account_id: approved_accounts.try(:ids)) : []
   end
 
   def approved_account_series
-    !approved_accounts.nil? ? Series.where({ account_id: approved_accounts.try(:ids) }) : []
+    !approved_accounts.nil? ? Series.where(account_id: approved_accounts.try(:ids)) : []
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,8 +15,6 @@ class User < BaseModel
 
   after_commit :create_individual_account, on: [:create]
 
-  attr_accessor :approved_accounts
-
   def individual_account
     accounts.where('type = \'IndividualAccount\'').first
   end
@@ -47,15 +45,26 @@ class User < BaseModel
     "#{first_name} #{last_name}"
   end
 
+  def approved_accounts
+    Account.
+      joins('LEFT OUTER JOIN `memberships` ON `memberships`.`account_id` = `accounts`.`id`').
+      where(['memberships.user_id = ? and memberships.approved is true', id])
+  end
+
   def approved_active_accounts
-    approved_accounts.try(:active)
+    approved_accounts.active
   end
 
   def approved_account_stories
-    !approved_accounts.nil? ? Story.where(account_id: approved_accounts.try(:ids)) : []
+    Story.
+      joins('LEFT OUTER JOIN `memberships` ON `memberships`.`account_id` = `pieces`.`account_id`').
+      where(['memberships.user_id = ? and memberships.approved is true', id])
   end
 
   def approved_account_series
-    !approved_accounts.nil? ? Series.where(account_id: approved_accounts.try(:ids)) : []
+    Series.
+      joins('LEFT OUTER JOIN `memberships` ON `memberships`.`account_id` = `series`.`account_id`').
+      where(['memberships.user_id = ? and memberships.approved is true', id])
   end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,26 +44,4 @@ class User < BaseModel
   def name
     "#{first_name} #{last_name}"
   end
-
-  def approved_accounts
-    Account.
-      joins('LEFT OUTER JOIN `memberships` ON `memberships`.`account_id` = `accounts`.`id`').
-      where(['memberships.user_id = ? and memberships.approved is true', id])
-  end
-
-  def approved_active_accounts
-    approved_accounts.active
-  end
-
-  def approved_account_stories
-    Story.
-      joins('LEFT OUTER JOIN `memberships` ON `memberships`.`account_id` = `pieces`.`account_id`').
-      where(['memberships.user_id = ? and memberships.approved is true', id])
-  end
-
-  def approved_account_series
-    Series.
-      joins('LEFT OUTER JOIN `memberships` ON `memberships`.`account_id` = `series`.`account_id`').
-      where(['memberships.user_id = ? and memberships.approved is true', id])
-  end
 end

--- a/app/representers/api/authorization_representer.rb
+++ b/app/representers/api/authorization_representer.rb
@@ -2,7 +2,6 @@
 
 class Api::AuthorizationRepresenter < Api::BaseRepresenter
   property :id, writeable: false
-  property :name
 
   link :default_account do
     {
@@ -15,10 +14,10 @@ class Api::AuthorizationRepresenter < Api::BaseRepresenter
     {
       href: "#{api_authorization_accounts_path}#{index_url_params}",
       templated: true,
-      count: represented.accounts.count
+      count: represented.token_auth_accounts.count
     }
   end
-  embed :approved_active_accounts, as: :accounts, paged: true, per: :all, item_class: Account,
+  embed :token_auth_accounts, as: :accounts, paged: true, per: :all, item_class: Account,
                                    item_decorator: Api::Auth::AccountMinRepresenter,
                                    url: ->(_r) { api_authorization_accounts_path }
 
@@ -27,12 +26,12 @@ class Api::AuthorizationRepresenter < Api::BaseRepresenter
       {
         href: "#{api_authorization_series_path_template(id: '{id}')}#{show_url_params}",
         templated: true,
-        count: represented.approved_account_series.count
+        count: represented.token_auth_series.count
       },
       {
         href: "#{api_authorization_series_index_path}#{index_url_params}",
         templated: true,
-        count: represented.approved_account_series.count
+        count: represented.token_auth_series.count
       }
     ]
   end
@@ -41,7 +40,7 @@ class Api::AuthorizationRepresenter < Api::BaseRepresenter
     {
       href: "#{api_authorization_stories_path}#{index_url_params}",
       templated: true,
-      count: represented.approved_account_stories.count
+      count: represented.token_auth_stories.count
     }
   end
 

--- a/test/controllers/api/auth/accounts_controller_test.rb
+++ b/test/controllers/api/auth/accounts_controller_test.rb
@@ -3,12 +3,20 @@ require 'test_helper'
 describe Api::Auth::AccountsController do
 
   let (:user) { create(:user_with_accounts, group_accounts: 2) }
-  let (:token) { OpenStruct.new.tap { |t| t.user_id = user.id } }
+
   let (:individual_account) { user.individual_account }
-  let (:member_account) { user.accounts.member.first }
-  let (:unapproved_account) { user.accounts.member.last }
   let (:random_account) { create(:account) }
-  before { unapproved_account.memberships.first.update!(approved: false) }
+  let (:member_account) { create(:account) }
+  let (:unapproved_account) { create(:account)}
+
+  let (:token) { OpenStruct.new.tap { |t|
+    t.authorized_resources = {
+      member_account.id => "member",
+      individual_account.id => "admin"
+    }
+    t.user_id = user.id
+    }
+  }
 
   describe 'with a valid token' do
 
@@ -47,6 +55,12 @@ describe Api::Auth::AccountsController do
       ids.must_include member_account.id
       ids.wont_include unapproved_account.id
       ids.wont_include random_account.id
+    end
+
+    it 'gets list of approved accounts for a user from users token' do
+      get(:index, api_version: 'v1')
+      assert_response :success
+      user.reload.approved_accounts.wont_be_nil
     end
 
   end

--- a/test/controllers/api/auth/accounts_controller_test.rb
+++ b/test/controllers/api/auth/accounts_controller_test.rb
@@ -9,12 +9,11 @@ describe Api::Auth::AccountsController do
   let (:member_account) { create(:account) }
   let (:unapproved_account) { create(:account)}
 
-  let (:token) { OpenStruct.new.tap { |t|
-    t.authorized_resources = {
-      member_account.id => "member",
-      individual_account.id => "admin"
-    }
-    t.user_id = user.id
+  let (:token) { StubToken.new(nil, nil, user.id).tap { |t|
+      t.authorized_resources = {
+        member_account.id => "member",
+        individual_account.id => "admin"
+      }
     }
   }
 
@@ -55,12 +54,6 @@ describe Api::Auth::AccountsController do
       ids.must_include member_account.id
       ids.wont_include unapproved_account.id
       ids.wont_include random_account.id
-    end
-
-    it 'gets list of approved accounts for a user from users token' do
-      get(:index, api_version: 'v1')
-      assert_response :success
-      user.reload.approved_accounts.wont_be_nil
     end
 
   end

--- a/test/controllers/api/auth/accounts_controller_test.rb
+++ b/test/controllers/api/auth/accounts_controller_test.rb
@@ -7,15 +7,15 @@ describe Api::Auth::AccountsController do
   let (:individual_account) { user.individual_account }
   let (:random_account) { create(:account) }
   let (:member_account) { create(:account) }
-  let (:unapproved_account) { create(:account)}
+  let (:unapproved_account) { create(:account) }
+  let (:token) { StubToken.new(nil, nil, user.id) }
 
-  let (:token) { StubToken.new(nil, nil, user.id).tap { |t|
-      t.authorized_resources = {
-        member_account.id => "member",
-        individual_account.id => "admin"
-      }
+  before do
+    token.authorized_resources = {
+      member_account.id => 'member',
+      individual_account.id => 'admin'
     }
-  }
+  end
 
   describe 'with a valid token' do
 

--- a/test/controllers/api/auth/accounts_controller_test.rb
+++ b/test/controllers/api/auth/accounts_controller_test.rb
@@ -3,9 +3,7 @@ require 'test_helper'
 describe Api::Auth::AccountsController do
 
   let (:user) { create(:user_with_accounts, group_accounts: 2) }
-
   let (:individual_account) { user.individual_account }
-  let (:random_account) { create(:account) }
   let (:member_account) { create(:account) }
   let (:unapproved_account) { create(:account) }
   let (:token) { StubToken.new(nil, nil, user.id) }
@@ -38,11 +36,6 @@ describe Api::Auth::AccountsController do
       assert_response :not_found
     end
 
-    it 'does not show non-member accounts' do
-      get(:show, api_version: 'v1', id: random_account.id)
-      assert_response :not_found
-    end
-
     it 'indexes only member accounts' do
       get(:index, api_version: 'v1')
       assert_response :success
@@ -53,7 +46,6 @@ describe Api::Auth::AccountsController do
       ids.must_include individual_account.id
       ids.must_include member_account.id
       ids.wont_include unapproved_account.id
-      ids.wont_include random_account.id
     end
 
   end

--- a/test/controllers/api/authorizations_controller_test.rb
+++ b/test/controllers/api/authorizations_controller_test.rb
@@ -5,13 +5,6 @@ describe Api::AuthorizationsController do
   let (:user) { create(:user) }
   let (:token) { StubToken.new(user.individual_account.id, 'admin', user.id) }
 
-  it 'shows the user with a valid token' do
-    @controller.stub(:prx_auth_token, token) do
-      get(:show, api_version: 'v1')
-      assert_response :success
-    end
-  end
-
   it 'returns unauthorized with invalid token' do
     @controller.stub(:prx_auth_token, OpenStruct.new) do
       get(:show, api_version: 'v1')

--- a/test/controllers/api/authorizations_controller_test.rb
+++ b/test/controllers/api/authorizations_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe Api::AuthorizationsController do
 
   let (:user) { create(:user) }
-  let (:token) { OpenStruct.new.tap { |t| t.user_id = user.id } }
+  let (:token) { StubToken.new(user.individual_account.id, "admin", user.id) }
 
   it 'shows the user with a valid token' do
     @controller.stub(:prx_auth_token, token) do

--- a/test/controllers/api/authorizations_controller_test.rb
+++ b/test/controllers/api/authorizations_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe Api::AuthorizationsController do
 
   let (:user) { create(:user) }
-  let (:token) { StubToken.new(user.individual_account.id, "admin", user.id) }
+  let (:token) { StubToken.new(user.individual_account.id, 'admin', user.id) }
 
   it 'shows the user with a valid token' do
     @controller.stub(:prx_auth_token, token) do

--- a/test/controllers/concerns/api_authenticated_test.rb
+++ b/test/controllers/concerns/api_authenticated_test.rb
@@ -13,8 +13,7 @@ describe ApiAuthenticated do
       raise 'user_not_authorized'
     end
 
-    def prx_auth_token
-    end
+    def prx_auth_token; end
   end
 
   let(:controller) { ApiAuthenticatedTestController.new }

--- a/test/controllers/concerns/api_authenticated_test.rb
+++ b/test/controllers/concerns/api_authenticated_test.rb
@@ -12,6 +12,9 @@ describe ApiAuthenticated do
     def user_not_authorized
       raise 'user_not_authorized'
     end
+
+    def prx_auth_token
+    end
   end
 
   let(:controller) { ApiAuthenticatedTestController.new }
@@ -31,6 +34,14 @@ describe ApiAuthenticated do
   it 'calls user_not_authorized if there is no user' do
     err = assert_raises { controller.authenticate_user! }
     err.message.must_match /user_not_authorized/
+  end
+
+  it 'builds an authorization from token' do
+    controller.stub(:current_user, true) do
+      controller.stub(:prx_auth_token, StubToken.new(123, 'admin', nil)) do
+        controller.authorization.wont_be_nil
+      end
+    end
   end
 
 end

--- a/test/models/authorization_test.rb
+++ b/test/models/authorization_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+describe Authorization do
+  let(:account) { create(:account) }
+  let(:token) { StubToken.new(account.id, ['member'], 456) }
+  let(:authorization) { Authorization.new(token) }
+
+  it 'has a token' do
+    authorization.token.wont_be_nil
+  end
+
+  it 'has a list of accounts authorized on token' do
+    authorization.token_auth_accounts.must_include account
+  end
+
+  it 'has lists of stories and series belonging to accounts authorized on token' do
+    authorization.token_auth_stories.must_equal account.stories
+    authorization.token_auth_series.must_equal account.series
+  end
+end

--- a/test/models/authorization_test.rb
+++ b/test/models/authorization_test.rb
@@ -4,6 +4,7 @@ describe Authorization do
   let(:account) { create(:account) }
   let(:token) { StubToken.new(account.id, ['member'], 456) }
   let(:authorization) { Authorization.new(token) }
+  let(:unauth_account) { create(:account) }
 
   it 'has a token' do
     authorization.token.wont_be_nil
@@ -16,5 +17,10 @@ describe Authorization do
   it 'has lists of stories and series belonging to accounts authorized on token' do
     authorization.token_auth_stories.must_equal account.stories
     authorization.token_auth_series.must_equal account.series
+  end
+
+  it 'checks against token to see if accounts are authorized' do
+    authorization.authorized?(account).must_equal true
+    authorization.authorized?(unauth_account).must_equal false
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -6,6 +6,10 @@ describe User do
   let (:story) { create(:story, account: user.individual_account) }
   let (:series) { create(:series, account: user.individual_account) }
 
+  before do
+    user.approved_accounts = Account.where(id: [story.account_id, series.account_id])
+  end
+
   it 'has a table defined' do
     User.table_name.must_equal 'users'
   end
@@ -44,6 +48,5 @@ describe User do
   it 'has a list of stories and series for accounts approved on token' do
     user.approved_account_stories.must_include story
     user.approved_account_series.must_include series
-
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -3,8 +3,6 @@ require 'test_helper'
 describe User do
   let (:user) { create(:user) }
   let (:network) { create(:network, account: user.individual_account) }
-  let (:story) { create(:story, account: user.individual_account) }
-  let (:series) { create(:series, account: user.individual_account) }
 
   it 'has a table defined' do
     User.table_name.must_equal 'users'

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -3,6 +3,8 @@ require 'test_helper'
 describe User do
   let (:user) { create(:user) }
   let (:network) { create(:network, account: user.individual_account) }
+  let (:story) { create(:story, account: user.individual_account) }
+  let (:series) { create(:series, account: user.individual_account) }
 
   it 'has a table defined' do
     User.table_name.must_equal 'users'
@@ -39,9 +41,9 @@ describe User do
     user.networks.must_include network
   end
 
-  it 'has a list of stories for approved accounts' do
-    start_count = user.individual_account.stories.count
-    create(:account, user: user, stories_count: 2)
-    user.approved_account_stories.count.must_equal start_count + 2
+  it 'has a list of stories and series for accounts approved on token' do
+    user.approved_account_stories.must_include story
+    user.approved_account_series.must_include series
+
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -40,9 +40,4 @@ describe User do
   it 'has a list of networks' do
     user.networks.must_include network
   end
-
-  it 'has a list of stories and series' do
-    user.approved_account_stories.must_include story
-    user.approved_account_series.must_include series
-  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -6,10 +6,6 @@ describe User do
   let (:story) { create(:story, account: user.individual_account) }
   let (:series) { create(:series, account: user.individual_account) }
 
-  before do
-    user.approved_accounts = Account.where(id: [story.account_id, series.account_id])
-  end
-
   it 'has a table defined' do
     User.table_name.must_equal 'users'
   end
@@ -45,7 +41,7 @@ describe User do
     user.networks.must_include network
   end
 
-  it 'has a list of stories and series for accounts approved on token' do
+  it 'has a list of stories and series' do
     user.approved_account_stories.must_include story
     user.approved_account_series.must_include series
   end

--- a/test/representers/api/authorization_representer_test.rb
+++ b/test/representers/api/authorization_representer_test.rb
@@ -7,10 +7,6 @@ describe Api::AuthorizationRepresenter do
   let(:representer) { Api::AuthorizationRepresenter.new(user) }
   let(:json) { JSON.parse(representer.to_json) }
 
-  before do
-    user.approved_accounts = Account.where(id: account.id)
-  end
-
   def get_link(rel, key = 'href')
     json['_links'][rel] ? json['_links'][rel][key] : nil
   end

--- a/test/representers/api/authorization_representer_test.rb
+++ b/test/representers/api/authorization_representer_test.rb
@@ -4,7 +4,7 @@ describe Api::AuthorizationRepresenter do
 
   let(:user) { create(:user) }
   let(:account) { user.default_account }
-  let(:token) { StubToken.new(account.id, 'admin', user.id)}
+  let(:token) { StubToken.new(account.id, 'admin', user.id) }
   let(:authorization) { Authorization.new(token) }
   let(:representer) { Api::AuthorizationRepresenter.new(authorization) }
   let(:json) { JSON.parse(representer.to_json) }

--- a/test/representers/api/authorization_representer_test.rb
+++ b/test/representers/api/authorization_representer_test.rb
@@ -7,6 +7,10 @@ describe Api::AuthorizationRepresenter do
   let(:representer) { Api::AuthorizationRepresenter.new(user) }
   let(:json) { JSON.parse(representer.to_json) }
 
+  before do
+    user.approved_accounts = Account.where(id: account.id)
+  end
+
   def get_link(rel, key = 'href')
     json['_links'][rel] ? json['_links'][rel][key] : nil
   end

--- a/test/representers/api/authorization_representer_test.rb
+++ b/test/representers/api/authorization_representer_test.rb
@@ -4,7 +4,9 @@ describe Api::AuthorizationRepresenter do
 
   let(:user) { create(:user) }
   let(:account) { user.default_account }
-  let(:representer) { Api::AuthorizationRepresenter.new(user) }
+  let(:token) { StubToken.new(account.id, 'admin', user.id)}
+  let(:authorization) { Authorization.new(token) }
+  let(:representer) { Api::AuthorizationRepresenter.new(authorization) }
   let(:json) { JSON.parse(representer.to_json) }
 
   def get_link(rel, key = 'href')

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -63,9 +63,11 @@ reset_announce
 
 StubToken = Struct.new(:resource, :scopes, :user_id)
 class StubToken
+  attr_accessor :authorized_resources
   @@fake_user_id = 0
 
   def initialize(res, scopes, explicit_user_id = nil)
+    @authorized_resources = { res => scopes }
     if explicit_user_id
       super(res.to_s, scopes, explicit_user_id)
     else
@@ -74,7 +76,7 @@ class StubToken
   end
 
   def authorized?(r, s = nil)
-    resource == r.to_s && (s.nil? || scopes.include?(s.to_s))
+    authorized_resources.keys.include?(r) && (s.nil? || authorized_resources.values.flatten.include?(s.to_s))
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -76,7 +76,10 @@ class StubToken
   end
 
   def authorized?(r, s = nil)
-    authorized_resources.keys.include?(r) && (s.nil? || authorized_resources.values.flatten.include?(s.to_s))
+    res = authorized_resources.keys
+    roles = authorized_resources.values.flatten
+
+    res.include?(r) && (s.nil? || roles.include?(s.to_s))
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -78,7 +78,6 @@ class StubToken
   def authorized?(r, s = nil)
     res = authorized_resources.keys
     roles = authorized_resources.values.flatten
-
     res.include?(r) && (s.nil? || roles.include?(s.to_s))
   end
 end


### PR DESCRIPTION
 #216
- extracts account authorization information from the auth token in the ApiAuthenticated concern
- uses that list of account IDs instead of querying the memberships table to determine which accounts to use 
- updates StubToken class in `test_helper.rb` to more closely  mimic auth token behavior in terms of authorized_resources list 
