### PR TITLE
Fix 500 errors on distribution when its a-v template is destroyed

### DIFF
--- a/app/models/audio_version_template.rb
+++ b/app/models/audio_version_template.rb
@@ -6,6 +6,7 @@ class AudioVersionTemplate < BaseModel
   has_many :audio_file_templates, -> { order :position }, dependent: :destroy
 
   has_many :audio_versions, dependent: :nullify
+  has_many :distributions, dependent: :nullify
 
   after_save :touch_audio_versions
 

--- a/test/representers/api/distribution_representer_test.rb
+++ b/test/representers/api/distribution_representer_test.rb
@@ -5,7 +5,9 @@ require 'distribution' if !defined?(Distribution)
 
 describe Api::DistributionRepresenter do
   let(:audio_version_template) { create(:audio_version_template) }
-  let(:distribution) { FactoryGirl.create(:distribution, audio_version_template: audio_version_template) }
+  let(:distribution) do
+    FactoryGirl.create(:distribution, audio_version_template: audio_version_template)
+  end
   let(:representer)   { Api::DistributionRepresenter.new(distribution) }
   let(:json)          { JSON.parse(representer.to_json) }
 

--- a/test/representers/api/distribution_representer_test.rb
+++ b/test/representers/api/distribution_representer_test.rb
@@ -4,8 +4,8 @@ require 'test_helper'
 require 'distribution' if !defined?(Distribution)
 
 describe Api::DistributionRepresenter do
-
-  let(:distribution) { FactoryGirl.create(:distribution) }
+  let(:audio_version_template) { create(:audio_version_template) }
+  let(:distribution) { FactoryGirl.create(:distribution, audio_version_template: audio_version_template) }
   let(:representer)   { Api::DistributionRepresenter.new(distribution) }
   let(:json)          { JSON.parse(representer.to_json) }
 
@@ -16,5 +16,11 @@ describe Api::DistributionRepresenter do
   it 'use representer to create json' do
     json['id'].must_equal distribution.id
     json['properties']['explicit'].must_equal 'clean'
+  end
+
+  it 'doesnt link to the template if the template has been destroyed' do
+    representer.represented.audio_version_template.destroy!
+    representer.represented.reload
+    json['_links']['prx:audio-version-template'].must_be_nil
   end
 end


### PR DESCRIPTION
Nils out `audio_version_template_id` on distribution when template is destroyed (fixes 500 error in #245) 