### PR TITLE
Handle changing series accounts

### DIFF
--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -153,6 +153,6 @@ class Series < BaseModel
   end
 
   def update_account_for_stories
-    stories.each {|s| s.update_attributes!(account_id: account_id)} if account_id_changed?
+    stories.each { |s| s.update_attributes!(account_id: account_id) } if account_id_changed?
   end
 end

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -37,6 +37,7 @@ class Series < BaseModel
   has_many :images, -> { where(parent_id: nil) }, class_name: 'SeriesImage', dependent: :destroy
 
   before_validation :set_app_version, on: :create
+  before_validation :update_account_for_stories, on: :update
 
   event_attribute :subscriber_only_at
 
@@ -149,5 +150,9 @@ class Series < BaseModel
   def set_app_version
     return unless new_record?
     self.app_version = PRX::APP_VERSION
+  end
+
+  def update_account_for_stories
+    stories.each {|s| s.update_attributes!(account_id: account_id)} if account_id_changed?
   end
 end

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -37,7 +37,7 @@ class Series < BaseModel
   has_many :images, -> { where(parent_id: nil) }, class_name: 'SeriesImage', dependent: :destroy
 
   before_validation :set_app_version, on: :create
-  before_validation :update_account_for_stories, on: :update
+  after_save :update_account_for_stories, on: :update
 
   event_attribute :subscriber_only_at
 

--- a/app/representers/api/series_representer.rb
+++ b/app/representers/api/series_representer.rb
@@ -41,7 +41,7 @@ class Api::SeriesRepresenter < Api::BaseRepresenter
   end
   embed :images, paged: true, item_class: SeriesImage, item_decorator: Api::ImageRepresenter
 
-  link :account do
+  link rel: :account, writeable: true do
     {
       href: api_account_path(represented.account),
       title: represented.account.name,

--- a/test/models/series_test.rb
+++ b/test/models/series_test.rb
@@ -24,6 +24,13 @@ describe Series do
     Series.where(id: v3_series.id).with_deleted.count.must_equal 1
   end
 
+  it 'changes account_id for stories when own account changes' do
+    series.update_attributes!(account_id: 123)
+    series.stories.each do |story|
+      story.account_id.must_equal 123
+    end
+  end
+
   describe '#images' do
     let(:series) { create(:series, images_count: 0) }
     let(:image_none) { create(:series_image, series: series, purpose: '') }

--- a/test/representers/api/series_representer_test.rb
+++ b/test/representers/api/series_representer_test.rb
@@ -21,4 +21,13 @@ describe Api::SeriesRepresenter do
   it 'includes templates' do
     json['_links']['prx:audio-version-templates'].wont_be_nil
   end
+
+  it 'can set the account' do
+    series.account_id.wont_be_nil
+    series_hash = { title: 'Title', set_account_uri: 'api/v1/accounts/123' }
+    s_representer = Api::SeriesRepresenter.new(Series.new)
+    s_series = s_representer.from_json(series_hash.to_json)
+    s_series.title.must_equal 'Title'
+    s_series.account_id.must_equal 123
+  end
 end


### PR DESCRIPTION
Fixes #252 (allowing series account to be changed) and fixes #247 (updating episodes in a series when series account changes)