### PR TITLE
Set story or series account on create

### DIFF
--- a/app/controllers/api/auth/stories_controller.rb
+++ b/app/controllers/api/auth/stories_controller.rb
@@ -41,13 +41,4 @@ class Api::Auth::StoriesController < Api::StoriesController
       authorization.token_auth_stories
     end
   end
-
-  def create_resource
-    super.tap do |story|
-      story.creator_id = current_user.id
-      story.account_id ||= story.series.try(:account_id)
-      story.account_id ||= current_user.account_id if authorization.authorized?(current_user.default_account)
-      story.account_id ||= authorization.token_auth_accounts.first.try(:id)
-    end
-  end
 end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -63,6 +63,10 @@ class Api::BaseController < ApplicationController
     @current_user = user
   end
 
+  def authorization
+    Authorization.new(prx_auth_token) if prx_auth_token
+  end
+
   private
 
   def user_not_authorized(exception = nil)

--- a/app/controllers/api/series_controller.rb
+++ b/app/controllers/api/series_controller.rb
@@ -20,8 +20,14 @@ class Api::SeriesController < Api::BaseController
 
   def create_resource
     super.tap do |series|
-      series.account_id ||= account.id if account && authorization.authorized?(account)
-      series.account_id ||= current_user.account_id if authorization.authorized?(current_user.default_account)
+      if account && authorization.authorized?(account)
+        series.account_id ||= account.id
+      end
+
+      if authorization.authorized?(current_user.default_account)
+        series.account_id ||= current_user.account_id
+      end
+
       series.account_id ||= authorization.token_auth_accounts.first.try(:id)
     end
   end

--- a/app/controllers/api/series_controller.rb
+++ b/app/controllers/api/series_controller.rb
@@ -17,4 +17,16 @@ class Api::SeriesController < Api::BaseController
     resources = resources.match_text(filters.text) if filters.text?
     super
   end
+
+  def create_resource
+    super.tap do |series|
+      series.account_id ||= account.id if account && authorization.authorized?(account)
+      series.account_id ||= current_user.account_id if authorization.authorized?(current_user.default_account)
+      series.account_id ||= authorization.token_auth_accounts.first.try(:id)
+    end
+  end
+
+  def account
+    @account ||= Account.find(params[:account_id]) if params[:account_id]
+  end
 end

--- a/app/controllers/api/stories_controller.rb
+++ b/app/controllers/api/stories_controller.rb
@@ -46,6 +46,16 @@ class Api::StoriesController < Api::BaseController
     show
   end
 
+  def create_resource
+    super.tap do |story|
+      story.creator_id = current_user.id
+      story.account_id ||= story.series.try(:account_id)
+      story.account_id ||= account.id if account && authorization.authorized?(account)
+      story.account_id ||= current_user.account_id if authorization.authorized?(current_user.default_account)
+      story.account_id ||= authorization.token_auth_accounts.first.try(:id)
+    end
+  end
+
   private
 
   def resources_base

--- a/app/controllers/api/stories_controller.rb
+++ b/app/controllers/api/stories_controller.rb
@@ -50,8 +50,15 @@ class Api::StoriesController < Api::BaseController
     super.tap do |story|
       story.creator_id = current_user.id
       story.account_id ||= story.series.try(:account_id)
-      story.account_id ||= account.id if account && authorization.authorized?(account)
-      story.account_id ||= current_user.account_id if authorization.authorized?(current_user.default_account)
+
+      if account && authorization.authorized?(account)
+        story.account_id ||= account.id
+      end
+
+      if authorization.authorized?(current_user.default_account)
+        story.account_id ||= current_user.account_id
+      end
+
       story.account_id ||= authorization.token_auth_accounts.first.try(:id)
     end
   end

--- a/app/controllers/concerns/api_authenticated.rb
+++ b/app/controllers/concerns/api_authenticated.rb
@@ -14,10 +14,6 @@ module ApiAuthenticated
     user_not_authorized unless current_user
   end
 
-  def authorization
-    Authorization.new(prx_auth_token)
-  end
-
   def cache_show?
     false
   end
@@ -25,5 +21,4 @@ module ApiAuthenticated
   def cache_index?
     false
   end
-
 end

--- a/test/controllers/api/base_controller_test.rb
+++ b/test/controllers/api/base_controller_test.rb
@@ -7,13 +7,13 @@ describe Api::BaseController do
     assert_response :success
   end
 
-  it "determines show action options for roar" do
+  it 'determines show action options for roar' do
     @controller.class.resource_representer = 'rr'
     @controller.send(:show_options)[:represent_with].must_equal 'rr'
   end
 
-  it "can parse a zoom parameter" do
-    @controller.params[:zoom] = "a,test"
+  it 'can parse a zoom parameter' do
+    @controller.params[:zoom] = 'a,test'
     @controller.send(:zoom_param).must_equal ['a', 'test']
   end
 
@@ -22,20 +22,28 @@ describe Api::BaseController do
     response.status.must_equal 204
   end
 
-  describe "#current_user" do
-    it "returns nil if there is no current user" do
-      get(:entrypoint, api_version: "v1")
+  describe '#current_user' do
+    it 'returns nil if there is no current user' do
+      get(:entrypoint, api_version: 'v1')
 
       @controller.current_user.must_be_nil
     end
 
-    it "returns a user if there is one" do
+    it 'returns a user if there is one' do
       TokenData = Struct.new(:user_id)
       user = create(:user)
-      get(:entrypoint, api_version: "v1")
+      get(:entrypoint, api_version: 'v1')
       @request.env['prx.auth'] = TokenData.new(user.id)
 
       @controller.current_user.must_equal user
+    end
+
+    it 'builds an authorization from token' do
+      @controller.stub(:current_user, true) do
+        @controller.stub(:prx_auth_token, StubToken.new(123, 'admin', nil)) do
+          @controller.authorization.wont_be_nil
+        end
+      end
     end
   end
 end

--- a/test/controllers/api/series_controller_test.rb
+++ b/test/controllers/api/series_controller_test.rb
@@ -74,6 +74,28 @@ describe Api::SeriesController do
       new_series.account_id.must_equal account.id
     end
 
+    it 'creates a series with set account uri' do
+      series_params = {
+        title: 'foobar',
+        set_account_uri: "/api/v1/accounts/#{account.id}"
+      }
+      post :create, series_params.to_json, api_version: 'v1'
+      assert_response :success
+      new_series = Series.find(JSON.parse(response.body)['id'])
+      new_series.title.must_equal 'foobar'
+      new_series.must_be :v4?
+      new_series.account_id.must_equal account.id
+    end
+
+    it 'creates a series with no account specified' do
+      post :create, { title: 'foobar' }.to_json, api_version: 'v1'
+      assert_response :success
+      new_series = Series.find(JSON.parse(response.body)['id'])
+      new_series.title.must_equal 'foobar'
+      new_series.must_be :v4?
+      new_series.account_id.must_equal account.id
+    end
+
     it 'updates a series' do
       Series.find(series.id).title.wont_equal('foobar')
       put :update, { title: 'foobar' }.to_json, api_version: 'v1', id: series.id

--- a/test/controllers/api/stories_controller_test.rb
+++ b/test/controllers/api/stories_controller_test.rb
@@ -17,6 +17,9 @@ describe Api::StoriesController do
       class << @controller; attr_accessor :prx_auth_token; end
       @controller.prx_auth_token = token
       @request.env['CONTENT_TYPE'] = 'application/json'
+
+      # for `create`, feeder calls don't need to work, but webmock needs a response defined
+      stub_request(:post, 'https://id.prx.org/token').to_return(status: 500)
     end
 
     it 'can create a new story' do
@@ -36,8 +39,6 @@ describe Api::StoriesController do
     end
 
     it 'can create a new story for a series' do
-      stub_request(:post, 'https://id.prx.org/token').to_return(status: 500)
-
       post :create,
            { title: 'story' }.to_json,
            api_version: 'v1',
@@ -48,8 +49,6 @@ describe Api::StoriesController do
     end
 
     it 'can create a new story for a series' do
-      stub_request(:post, 'https://id.prx.org/token').to_return(status: 500)
-
       post :create,
            { title: 'story', set_series_uri: "/api/v1/series/#{series.id}" }.to_json,
            api_version: 'v1'
@@ -59,8 +58,6 @@ describe Api::StoriesController do
     end
 
     it 'can create a new story and distributions' do
-      stub_request(:post, 'https://id.prx.org/token').to_return(status: 500)
-
       series.wont_be_nil
       story_hash = {
         title: 'create story',

--- a/test/controllers/api/stories_controller_test.rb
+++ b/test/controllers/api/stories_controller_test.rb
@@ -3,15 +3,15 @@
 require 'test_helper'
 
 describe Api::StoriesController do
-  let(:series) { create(:series) }
+  let(:account) { create(:account) }
+  let(:series) { create(:series, account: account) }
   let(:story) { create(:story, series: series) }
 
   before { Story.delete_all }
 
   describe 'editing' do
-
-    let(:account) { create(:account) }
-    let(:token) { StubToken.new(account.id, ['member']) }
+    let (:user) { create(:user) }
+    let (:token) { StubToken.new(account.id, ['member'], user.id) }
 
     before(:each) do
       class << @controller; attr_accessor :prx_auth_token; end
@@ -35,8 +35,30 @@ describe Api::StoriesController do
       Story.find(id).account_id.must_equal account.id
     end
 
+    it 'can create a new story for a series' do
+      stub_request(:post, 'https://id.prx.org/token').to_return(status: 500)
+
+      post :create,
+           { title: 'story' }.to_json,
+           api_version: 'v1',
+           series_id: series.id
+      assert_response :success
+      id = JSON.parse(response.body)['id']
+      Story.find(id).account_id.must_equal account.id
+    end
+
+    it 'can create a new story for a series' do
+      stub_request(:post, 'https://id.prx.org/token').to_return(status: 500)
+
+      post :create,
+           { title: 'story', set_series_uri: "/api/v1/series/#{series.id}" }.to_json,
+           api_version: 'v1'
+      assert_response :success
+      id = JSON.parse(response.body)['id']
+      Story.find(id).account_id.must_equal account.id
+    end
+
     it 'can create a new story and distributions' do
-      # feeder calls do't need to work, but webmock needs a response defined
       stub_request(:post, 'https://id.prx.org/token').to_return(status: 500)
 
       series.wont_be_nil

--- a/test/controllers/concerns/api_authenticated_test.rb
+++ b/test/controllers/concerns/api_authenticated_test.rb
@@ -34,13 +34,4 @@ describe ApiAuthenticated do
     err = assert_raises { controller.authenticate_user! }
     err.message.must_match /user_not_authorized/
   end
-
-  it 'builds an authorization from token' do
-    controller.stub(:current_user, true) do
-      controller.stub(:prx_auth_token, StubToken.new(123, 'admin', nil)) do
-        controller.authorization.wont_be_nil
-      end
-    end
-  end
-
 end


### PR DESCRIPTION
We can call create and other authorized operations on the standard api controllers, not only the ones  under `\auth`.

This PR moves all the logic for setting accounts for stories and series on create to the standard api controllers, which also work for the child `auth` controllers.

It also moves the `authorization` method to the base controller, since that can be used on any api controller, not just under auth.
