### PR TITLE
Call save on parent objects instead of relying on touch to do it

### DIFF
--- a/app/models/audio_file.rb
+++ b/app/models/audio_file.rb
@@ -58,5 +58,6 @@ class AudioFile < BaseModel
       self.status = INVALID
       self.status_message = errors
     end
+    audio_version.try(:save!)
   end
 end

--- a/app/models/audio_version.rb
+++ b/app/models/audio_version.rb
@@ -52,5 +52,6 @@ class AudioVersion < BaseModel
       self.status = INVALID
       self.status_message = errors
     end
+    story.try(:save!)
   end
 end

--- a/test/models/audio_version_test.rb
+++ b/test/models/audio_version_test.rb
@@ -20,7 +20,7 @@ describe AudioVersion do
   describe 'with a template' do
 
     let(:audio_version_with_template) { create(:audio_version_with_template) }
-    let(:audio_file) { create(:audio_file, status_message: 'Foo bar') }
+    let(:audio_file) { create(:audio_file, status: 'invalid', status_message: 'Foo bar') }
 
     it 'can have a template' do
       audio_version_with_template.audio_version_template(true).wont_be_nil
@@ -35,7 +35,6 @@ describe AudioVersion do
     end
 
     it 'shows self as invalid if incompliant with template' do
-      audio_version_with_template.update_attributes(explicit: 'explicit')
       audio_version_with_template.status_message.must_include 'long, but must be'
       audio_version_with_template.status.must_equal 'invalid'
       audio_version_with_template.wont_be(:compliant_with_template?)

--- a/test/models/story_test.rb
+++ b/test/models/story_test.rb
@@ -27,7 +27,8 @@ describe Story do
   end
 
   describe 'checking audio versions' do
-    let(:story) { create(:story) }
+    let(:template) { create(:audio_version_template) }
+    let(:story) { create(:story, series: template.series) }
     let(:invalid_audio_versions) { create_list(:audio_version_with_template, 5) }
     let(:valid_audio_versions) { create_list(:audio_version, 5) }
 


### PR DESCRIPTION
Should fix the bug in import where the story status is "invalid" despite all children being "complete" 