### PR TITLE
Send s3 audio urls in announce message for feeder

### DIFF
--- a/app/controllers/concerns/announce_actions/announce_filter.rb
+++ b/app/controllers/concerns/announce_actions/announce_filter.rb
@@ -65,6 +65,7 @@ module AnnounceActions
 
     def decorator_class(name)
       "Api::Msg::#{name}Representer".safe_constantize ||
+        "Api::Auth::#{name}Representer".safe_constantize ||
         "Api::#{name}Representer".safe_constantize ||
         "Api::Min::#{name}Representer".safe_constantize
     end

--- a/app/models/concerns/fixerable.rb
+++ b/app/models/concerns/fixerable.rb
@@ -120,6 +120,17 @@ module Fixerable
     end
   end
 
+  def fixerable_final_storage_url
+    return unless fixerable_final?
+    scheme = self.class.fixerable_storage.invert[fixfinal.fog_credentials[:provider]]
+    options = {
+      scheme: scheme,
+      host: fixfinal.fog_directory,
+      path: "/#{fixfinal.path}",
+    }
+    URI::Generic.build(options).to_s
+  end
+
   def fixerable_final_path
     fixfinal.store_dir
   end

--- a/app/representers/api/auth/audio_file_representer.rb
+++ b/app/representers/api/auth/audio_file_representer.rb
@@ -1,8 +1,6 @@
 # encoding: utf-8
 
 class Api::Auth::AudioFileRepresenter < Api::AudioFileRepresenter
-  # make sure "self" stays under authorization, because unpublished
-  # stories won't exist under the public stories path
   def self_url(r)
     api_authorization_audio_file_path(r)
   end

--- a/app/representers/api/auth/audio_file_representer.rb
+++ b/app/representers/api/auth/audio_file_representer.rb
@@ -1,0 +1,16 @@
+# encoding: utf-8
+
+class Api::Auth::AudioFileRepresenter < Api::AudioFileRepresenter
+  # make sure "self" stays under authorization, because unpublished
+  # stories won't exist under the public stories path
+  def self_url(r)
+    api_authorization_audio_file_path(r)
+  end
+
+  link :storage do
+    {
+      href: represented.fixerable_final_storage_url,
+      type: represented.content_type
+    } if represented.id
+  end
+end

--- a/app/representers/api/auth/story_representer.rb
+++ b/app/representers/api/auth/story_representer.rb
@@ -18,4 +18,17 @@ class Api::Auth::StoryRepresenter < Api::StoryRepresenter
       href: unpublish_api_authorization_story_path(represented)
     } if !represented.published_at.nil?
   end
+
+  link :audio do
+    {
+      href: api_authorization_audio_files_path(represented.id),
+      count: represented.default_audio.count
+    } if represented.id
+  end
+  embed :default_audio,
+        as: :audio,
+        paged: true,
+        item_class: AudioFile,
+        item_decorator: Api::Auth::AudioFileRepresenter,
+        per: :all
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,10 @@ PRX::Application.routes.draw do
           resources :podcast_imports, except: [:new, :edit]
         end
 
+        resources :audio_files do
+          get 'original', on: :member
+        end
+
         resources :series, except: [:new, :edit, :create], module: :auth do
           resources :stories, only: [:index, :create]
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,9 +71,7 @@ PRX::Application.routes.draw do
           resources :podcast_imports, except: [:new, :edit]
         end
 
-        resources :audio_files do
-          get 'original', on: :member
-        end
+        resources :audio_files, except: [:new, :edit]
 
         resources :series, except: [:new, :edit, :create], module: :auth do
           resources :stories, only: [:index, :create]

--- a/test/models/audio_file_test.rb
+++ b/test/models/audio_file_test.rb
@@ -32,6 +32,12 @@ describe AudioFile do
     audio_file_uploaded.public_asset_filename.must_equal 'test.mp3'
   end
 
+  it 'complete audio has a storage url' do
+    s3_file = "s3://#{ENV['AWS_BUCKET']}/public/audio_files/#{audio_file.id}/test.mp2"
+    audio_file.fixerable_final_storage_url.must_equal s3_file
+    audio_file_uploaded.fixerable_final_storage_url.must_equal nil
+  end
+
   it 'updates story and version timestamps' do
     story = create(:story)
     version = create(:audio_version, story: story)

--- a/test/models/concerns/fixerable_test.rb
+++ b/test/models/concerns/fixerable_test.rb
@@ -53,6 +53,15 @@ describe Fixerable do
     end
   end
 
+  it 'can get the final storage url' do
+    model.stub(:fixerable_final?, true) do
+      model.fixerable_final_storage_url.must_equal "s3://#{ENV['AWS_BUCKET']}/"
+    end
+
+    model.the_temp_field = 'https://s3.aws.amazon.com/prx-development/another.mp3'
+    model.fixerable_final_storage_url.must_equal nil
+  end
+
   it 'signs HEAD requests for temp aws uploads' do
     fake_store = Fog::Storage::AWS.new(aws_access_key_id: 'foo', aws_secret_access_key: 'bar')
     Fog::Storage::AWS.stub(:new, fake_store) do

--- a/test/representers/api/auth/audio_file_representer_test.rb
+++ b/test/representers/api/auth/audio_file_representer_test.rb
@@ -1,0 +1,24 @@
+# encoding: utf-8
+
+require 'test_helper'
+require 'audio_file' if !defined?(AudioFile)
+
+describe Api::Auth::AudioFileRepresenter do
+
+  let(:audio_file)  { create(:audio_file) }
+  let(:representer) { Api::Auth::AudioFileRepresenter.new(audio_file) }
+  let(:json)        { JSON.parse(representer.to_json) }
+
+  it 'create representer' do
+    representer.wont_be_nil
+  end
+
+  it 'use representer to create json' do
+    json['id'].must_equal audio_file.id
+  end
+
+  it 'links to the s3 storage' do
+    store = json['_links']['prx:storage']['href']
+    store.must_equal "s3://#{ENV['AWS_BUCKET']}/public/audio_files/#{audio_file.id}/test.mp2"
+  end
+end

--- a/test/representers/api/auth/story_representer_test.rb
+++ b/test/representers/api/auth/story_representer_test.rb
@@ -25,4 +25,9 @@ describe Api::Auth::StoryRepresenter do
   it 'keeps the publish link in the authorization namespace' do
     get_link_href(draft_json, 'prx:publish').must_match /authorization\/stories\/\d+/
   end
+
+  it 'has audio with storage urls' do
+    af = pub_json['_embedded']['prx:audio']['_embedded']['prx:items'].first
+    get_link_href(af, 'prx:storage').must_match /s3:\/\//
+  end
 end


### PR DESCRIPTION
This will allow feeder to use these s3://bucket/path/file.ext style urls for sending to fixer.