### PR TITLE
Fix use of auth story and series announcements

### DIFF
--- a/app/workers/audio_callback_worker.rb
+++ b/app/workers/audio_callback_worker.rb
@@ -43,7 +43,7 @@ class AudioCallbackWorker
     Shoryuken.logger.info("Updating #{job['type']}[#{audio.id}]: status => #{audio.status}")
     audio.save!
     # announce the audio changes on its story.
-    announce(:story, :update, Api::StoryRepresenter.new(audio.story).to_json)
+    announce(:story, :update, Api::Auth::StoryRepresenter.new(audio.story).to_json)
 
   rescue ActiveRecord::RecordNotFound
     Shoryuken.logger.error("Record #{job['type']}[#{job['id']}] not found")

--- a/app/workers/image_callback_worker.rb
+++ b/app/workers/image_callback_worker.rb
@@ -34,9 +34,9 @@ class ImageCallbackWorker
 
     # announce the image changes on its story or series
     if image.is_a?(StoryImage)
-      announce(:story, :update, Api::StoryRepresenter.new(image.story).to_json)
+      announce(:story, :update, Api::Auth::StoryRepresenter.new(image.story).to_json)
     elsif image.is_a?(SeriesImage)
-      announce(:series, :update, Api::SeriesRepresenter.new(image.series).to_json)
+      announce(:series, :update, Api::Auth::SeriesRepresenter.new(image.series).to_json)
     end
 
   rescue ActiveRecord::RecordNotFound


### PR DESCRIPTION
The auth representer is now used, when present, for announcements.
This is working for controller triggered announcements, need to also have this working for async jobs.