### PR TITLE
Better descriptions

### DIFF
--- a/app/models/podcast_import.rb
+++ b/app/models/podcast_import.rb
@@ -126,10 +126,7 @@ class PodcastImport < BaseModel
       podcast_attributes[atr.to_sym] = feed.send(atr)
     end
 
-    if feed.itunes_summary && feed.itunes_summary != feed_description(feed)
-      podcast_attributes[:summary] = feed.itunes_summary
-    end
-
+    podcast_attributes[:summary] = feed.itunes_summary
     podcast_attributes[:link] = feed.url
     podcast_attributes[:explicit] = feed.itunes_explicit
     podcast_attributes[:new_feed_url] = feed.itunes_new_feed_url

--- a/app/models/podcast_import.rb
+++ b/app/models/podcast_import.rb
@@ -66,18 +66,17 @@ class PodcastImport < BaseModel
     end
   end
 
-  def create_series_from_podcast(feed = self.feed)
-    description = feed.description
-    if feed.itunes_summary
-      description = feed.itunes_summary if feed.itunes_summary.length > feed.description.length
-    end
+  def feed_description(feed)
+    [feed.itunes_summary, feed.description].find { |d| !d.blank? }
+  end
 
+  def create_series_from_podcast(feed = self.feed)
     # create the series
     self.series = create_series!(
       account: account,
       title: feed.title,
       short_description: feed.itunes_subtitle,
-      description: description
+      description: feed_description(feed)
     )
     save!
 
@@ -125,6 +124,10 @@ class PodcastImport < BaseModel
     podcast_attributes = {}
     %w(copyright language update_frequency update_period).each do |atr|
       podcast_attributes[atr.to_sym] = feed.send(atr)
+    end
+
+    if feed.itunes_summary && feed.itunes_summary != feed_description(feed)
+      podcast_attributes[:summary] = feed.itunes_summary
     end
 
     podcast_attributes[:link] = feed.url
@@ -212,13 +215,18 @@ class PodcastImport < BaseModel
     end
   end
 
+  def entry_description(entry)
+    atr = [:content, :itunes_summary, :description].find { |d| !entry[d].blank? }
+    entry[atr] if atr
+  end
+
   def create_story(entry, series)
     story = series.stories.create!(
       creator_id: user_id,
       account_id: series.account_id,
       title: entry[:title],
       short_description: entry[:itunes_subtitle],
-      description: entry[:description],
+      description_html: entry_description(entry),
       tags: entry[:categories],
       published_at: entry[:published]
     )
@@ -258,6 +266,9 @@ class PodcastImport < BaseModel
     )
 
     create_attributes = {}
+    if entry[:itunes_summary] && entry[:itunes_summary] != entry_description(entry)
+      create_attributes[:summary] = entry[:itunes_summary]
+    end
     create_attributes[:author] = person(entry[:itunes_author] || entry[:author] || entry[:creator])
     create_attributes[:block] = (entry[:itunes_block] == 'yes')
     create_attributes[:explicit] = entry[:itunes_explicit]

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -12,6 +12,10 @@ class Series < BaseModel
   include Storied
   include RenderMarkdown
 
+  def description_html=(html)
+    self.description = v4? ? html_to_markdown(html) : html
+  end
+
   def description_html
     v4? ? markdown_to_html(description) : description
   end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -8,6 +8,10 @@ class Story < BaseModel
   include RenderMarkdown
   include ValidityFlag
 
+  def description_html=(html)
+    self.description = v4? ? html_to_markdown(html) : html
+  end
+
   def description_html
     v4? ? markdown_to_html(description) : description
   end

--- a/app/representers/api/series_representer.rb
+++ b/app/representers/api/series_representer.rb
@@ -4,7 +4,7 @@ class Api::SeriesRepresenter < Api::BaseRepresenter
   property :id, writeable: false
   property :title
   property :short_description
-  property :description, getter: ->(_o) { description_html }
+  property :description_html, as: :description
   property :description_md
   property :created_at, writeable: false
   property :updated_at, writeable: false

--- a/app/representers/api/story_representer.rb
+++ b/app/representers/api/story_representer.rb
@@ -18,7 +18,7 @@ class Api::StoryRepresenter < Api::BaseRepresenter
   property :status, writeable: false
   property :status_message, writeable: false
 
-  property :description, getter: ->(_o) { description_html }
+  property :description_html, as: :description
   property :description_md
   property :related_website
   property :broadcast_history


### PR DESCRIPTION
- [x] On import, set the html into the story and series using `description_html`, model changes -> md
- [x] On story import, use content:encoded, itunes:summary, or description as the description, whichever of those is non blank, in that order
- [x] On series import, use itunes:summary, or description as the description, whichever of those is non blank, in that order
- [x] Only set the episode or podcast summary in feeder if it is different from the description