### PR TITLE
Announce story and series with public self uri

### DIFF
--- a/app/controllers/concerns/announce_actions/announce_filter.rb
+++ b/app/controllers/concerns/announce_actions/announce_filter.rb
@@ -65,7 +65,6 @@ module AnnounceActions
 
     def decorator_class(name)
       "Api::Msg::#{name}Representer".safe_constantize ||
-        "Api::Auth::#{name}Representer".safe_constantize ||
         "Api::#{name}Representer".safe_constantize ||
         "Api::Min::#{name}Representer".safe_constantize
     end

--- a/app/representers/api/msg/series_representer.rb
+++ b/app/representers/api/msg/series_representer.rb
@@ -1,0 +1,11 @@
+# encoding: utf-8
+
+class Api::Msg::SeriesRepresenter < Api::SeriesRepresenter
+  # don't embed the stories, makes this a much smaller message
+  embed :public_stories,
+        as: :stories,
+        paged: true,
+        item_class: Story,
+        item_decorator: Api::Min::StoryRepresenter,
+        zoom: false
+end

--- a/app/representers/api/msg/story_representer.rb
+++ b/app/representers/api/msg/story_representer.rb
@@ -1,0 +1,17 @@
+# encoding: utf-8
+
+class Api::Msg::StoryRepresenter < Api::StoryRepresenter
+  # main thing needed here is the audio with the s3 notifications
+  link :audio do
+    {
+      href: api_authorization_audio_files_path(represented.id),
+      count: represented.default_audio.count
+    } if represented.id
+  end
+  embed :default_audio,
+        as: :audio,
+        paged: true,
+        item_class: AudioFile,
+        item_decorator: Api::Auth::AudioFileRepresenter,
+        per: :all
+end

--- a/app/workers/audio_callback_worker.rb
+++ b/app/workers/audio_callback_worker.rb
@@ -43,7 +43,7 @@ class AudioCallbackWorker
     Shoryuken.logger.info("Updating #{job['type']}[#{audio.id}]: status => #{audio.status}")
     audio.save!
     # announce the audio changes on its story.
-    announce(:story, :update, Api::Auth::StoryRepresenter.new(audio.story).to_json)
+    announce(:story, :update, Api::Msg::StoryRepresenter.new(audio.story).to_json)
 
   rescue ActiveRecord::RecordNotFound
     Shoryuken.logger.error("Record #{job['type']}[#{job['id']}] not found")

--- a/app/workers/image_callback_worker.rb
+++ b/app/workers/image_callback_worker.rb
@@ -34,9 +34,9 @@ class ImageCallbackWorker
 
     # announce the image changes on its story or series
     if image.is_a?(StoryImage)
-      announce(:story, :update, Api::Auth::StoryRepresenter.new(image.story).to_json)
+      announce(:story, :update, Api::Msg::StoryRepresenter.new(image.story).to_json)
     elsif image.is_a?(SeriesImage)
-      announce(:series, :update, Api::Auth::SeriesRepresenter.new(image.series).to_json)
+      announce(:series, :update, Api::Msg::SeriesRepresenter.new(image.series).to_json)
     end
 
   rescue ActiveRecord::RecordNotFound

--- a/test/representers/api/msg/series_representer_test.rb
+++ b/test/representers/api/msg/series_representer_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+describe Api::Msg::SeriesRepresenter do
+  let(:series)      { FactoryGirl.create(:series) }
+  let(:representer) { Api::Msg::SeriesRepresenter.new(series) }
+  let(:json)        { JSON.parse(representer.to_json) }
+
+  def get_link_href(name)
+    json['_links'][name] ? json['_links'][name]['href'] : nil
+  end
+
+  it 'keeps the public self url' do
+    get_link_href('self').must_match /api\/v1\/series\/\d+/
+  end
+
+  it 'does not embed stories' do
+    json['_embedded']['prx:stories'].must_be_nil
+  end
+end

--- a/test/representers/api/msg/story_representer_test.rb
+++ b/test/representers/api/msg/story_representer_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+describe Api::Msg::StoryRepresenter do
+
+  let(:story) { create(:story, audio_versions_count: 1) }
+  let(:representer) { Api::Msg::StoryRepresenter.new(story) }
+  let(:json) { JSON.parse(representer.to_json) }
+
+  def get_link_href(json, name)
+    json['_links'][name] ? json['_links'][name]['href'] : nil
+  end
+
+  it 'keeps the public self url' do
+    get_link_href(json, 'self').must_match /api\/v1\/stories\/\d+/
+  end
+
+  it 'has audio with storage urls' do
+    af = json['_embedded']['prx:audio']['_embedded']['prx:items'].first
+    get_link_href(af, 'prx:storage').must_match /s3:\/\//
+  end
+end


### PR DESCRIPTION
fixes #288 
- [x] Make new msg representers for series and story
- [x] On both, send the public self link
- [x] Don't send the stories embedded in the series - long & redundant with story announcements
- [x] Revert announce filter, no longer try to use auth representers
- [x] Update jobs to use msg not auth representers