### PR TITLE
Only add an episode image when it differs from the series image

### DIFF
--- a/app/models/podcast_import.rb
+++ b/app/models/podcast_import.rb
@@ -275,7 +275,7 @@ class PodcastImport < BaseModel
     end
 
     # add the image if it is different from the channel itunes_image
-    if entry.itunes_image && self.feed.itunes_image != entry.itunes_image
+    if entry.itunes_image && feed.itunes_image != entry.itunes_image
       image = story.images.create!(upload: entry.itunes_image)
       announce_image(image)
     end

--- a/app/models/podcast_import.rb
+++ b/app/models/podcast_import.rb
@@ -274,8 +274,8 @@ class PodcastImport < BaseModel
       announce_audio(audio)
     end
 
-    # add the image
-    if entry.itunes_image
+    # add the image if it is different from the channel itunes_image
+    if entry.itunes_image && self.feed.itunes_image != entry.itunes_image
       image = story.images.create!(upload: entry.itunes_image)
       announce_image(image)
     end

--- a/test/fixtures/transistor.xml
+++ b/test/fixtures/transistor.xml
@@ -58,7 +58,9 @@
 			<wfw:commentRss>https://transistor.prx.org/2017/01/sidedoor-from-the-smithsonian-shake-it-up/feed/</wfw:commentRss>
 			<slash:comments>0</slash:comments>
 			<category><![CDATA[Indie Features]]></category>
-			<description>For the next few episodes, we’re featuring the Smithsonian’s new series, Sidedoor, about where science, art, history, and humanity unexpectedly overlap — just like in their museums. In this episode: an astronomer has turned the night sky into a symphony; an architecture firm has radically re-thought police stations; and an audiophile builds a successful record … &lt;a href="https://transistor.prx.org/2017/01/sidedoor-from-the-smithsonian-shake-it-up/" class="more-link"&gt;Continue reading &lt;span class="screen-reader-text"&gt;Sidedoor from the Smithsonian: Shake it Up&lt;/span&gt;&lt;/a&gt;</description>
+			<description>For the next few episodes, we’re featuring the Smithsonian’s new series, Sidedoor, about where science, art, history, and humanity unexpectedly overlap — just like in their museums. In this episode: an astronomer has turned the night sky
+				into a symphony; an architecture firm has radically re-thought police stations; and an audiophile builds a successful record … &lt;a href="https://transistor.prx.org/2017/01/sidedoor-from-the-smithsonian-shake-it-up/" class="more-link"&gt;Continue
+				reading &lt;span class="screen-reader-text"&gt;Sidedoor from the Smithsonian: Shake it Up&lt;/span&gt;&lt;/a&gt;</description>
 			<content:encoded>
 				<![CDATA[<p>For the next few episodes, we’re featuring the Smithsonian’s new series, <em>Sidedoor</em>, about where science, art, history, and humanity unexpectedly overlap — just like in their museums.</p>
 <p>In this episode: an astronomer has turned the night sky into a symphony; an architecture firm has radically re-thought police stations; and an audiophile builds a successful record company on under-appreciated sounds.</p>
@@ -67,7 +69,6 @@
 <p><em>Music credits under backannounce: &#8220;Candy&#8221; by Jahzzar.</em></p>
 <img src="http://feeds.feedburner.com/~r/transistor_stem/~4/NHnLCsjtdQM" height="1" width="1" alt=""/>]]>
 			</content:encoded>
-
 			<itunes:subtitle>An astronomer has turned the night sky into a symphony.</itunes:subtitle>
 			<itunes:summary>For the next few episodes, we’re featuring the Smithsonian’s new series, Sidedoor, about where science, art, history, and humanity unexpectedly overlap — just like in their museums. In this episode: an astronomer who has turned the
 				night sky into a symphony.</itunes:summary>
@@ -77,6 +78,35 @@
 			<feedburner:origLink>https://transistor.prx.org/2017/01/sidedoor-from-the-smithsonian-shake-it-up/</feedburner:origLink><enclosure url="http://feeds.prx.org/~r/transistor_stem/~5/7X0iW0LgXWg/Smithsonian3_Transistor.mp3" length="29714854" type="audio/mpeg"/>
 			<feedburner:origEnclosureLink>https://dts.podtrac.com/redirect.mp3/media.blubrry.com/transistor/cdn-transistor.prx.org/wp-content/uploads/Smithsonian3_Transistor.mp3</feedburner:origEnclosureLink>
 			<itunes:image href="https://cdn-transistor.prx.org/shake.jpg"/>
+		</item>
+		<item>
+			<title>Sidedoor from the Smithsonian: Butting Heads</title>
+			<link>http://feeds.prx.org/~r/transistor_stem/~3/aQtd2G_vSXA/</link>
+			<pubDate>Fri, 09 Dec 2016 21:41:18 +0000</pubDate>
+			<guid isPermaLink="false">https://transistor.prx.org/?p=1276</guid>
+			<comments>https://transistor.prx.org/2016/12/sidedoor-from-the-smithsonian-butting-heads/#respond</comments>
+			<wfw:commentRss>https://transistor.prx.org/2016/12/sidedoor-from-the-smithsonian-butting-heads/feed/</wfw:commentRss>
+			<slash:comments>0</slash:comments>
+			<category><![CDATA[Indie Features]]></category>
+			<description>For the next few episodes, we’re featuring the Smithsonian’s new series, Sidedoor, about where science, art, history, and humanity unexpectedly overlap — just like in their museums. In this episode: two besties turn into lifelong enemies
+				over a dining room; a researcher embraces the panda craze; and why some dinosaur skulls were built to take … &lt;a href="https://transistor.prx.org/2016/12/sidedoor-from-the-smithsonian-butting-heads/" class="more-link"&gt;Continue reading &lt;span
+				class="screen-reader-text"&gt;Sidedoor from the Smithsonian: Butting Heads&lt;/span&gt;&lt;/a&gt;</description>
+			<content:encoded>
+				<![CDATA[<p>For the next few episodes, we&#8217;re featuring the Smithsonian&#8217;s new series, <em>Sidedoor</em>, about where science, art, history, and humanity  unexpectedly overlap &#8212; just like in their museums. </p>
+	<p>In this episode: two besties turn into lifelong enemies over a dining room; a researcher embraces the panda craze; and why some dinosaur skulls were built to take a beating.</p>
+	<p><script id='prx-p193105-embed' src='https://www.prx.org/p/193105/embed.js?size=small'></script> </p>
+	<p>For even more from <a href="https://itunes.apple.com/us/podcast/sidedoor/id1168154281?mt=2" target="_blank">Sidedoor</a>, subscribe in iTunes or wherever you get your podcasts.</p>
+	<p><em>Music credits under backannounce: &#8220;Walking Barefoot On Grass&#8221; by Kai Engel.</em></p>
+	<img src="http://feeds.feedburner.com/~r/transistor_stem/~4/aQtd2G_vSXA" height="1" width="1" alt=""/>]]>
+			</content:encoded>
+			<itunes:subtitle>Besties, enemies, or frenemies? The Smithsonian finds out.</itunes:subtitle>
+			<itunes:summary>For the next few episodes, we're featuring the Smithsonian's new series, Sidedoor. This time, two besties turn into lifelong enemies over a dining room; a researcher embraces the panda craze; and why some dinosaur skulls were built to take a beating.</itunes:summary>
+			<itunes:author>PRX</itunes:author>
+			<itunes:duration>19:19</itunes:duration>
+			<post-id xmlns="com-wordpress:feed-additions:1">1276</post-id>
+			<feedburner:origLink>https://transistor.prx.org/2016/12/sidedoor-from-the-smithsonian-butting-heads/</feedburner:origLink><enclosure url="http://feeds.prx.org/~r/transistor_stem/~5/VXWv6c5BMag/SmithsonianSquabbles_Transistor.mp3" length="23185817" type="audio/mpeg"/>
+			<feedburner:origEnclosureLink>https://dts.podtrac.com/redirect.mp3/media.blubrry.com/transistor/cdn-transistor.prx.org/wp-content/uploads/SmithsonianSquabbles_Transistor.mp3</feedburner:origEnclosureLink>
+			<itunes:image href="https://cdn-transistor.prx.org/transistor1400.jpg"/>
 		</item>
 	</channel>
 </rss>

--- a/test/fixtures/transistor_two.xml
+++ b/test/fixtures/transistor_two.xml
@@ -78,5 +78,35 @@
 			<feedburner:origEnclosureLink>https://dts.podtrac.com/redirect.mp3/media.blubrry.com/transistor/cdn-transistor.prx.org/wp-content/uploads/Smithsonian3_Transistor.mp3</feedburner:origEnclosureLink>
 			<itunes:image href="https://cdn-transistor.prx.org/shake.jpg"/>
 		</item>
+		<item>
+			<title>Sidedoor from the Smithsonian: Shake it Up</title>
+			<link>http://feeds.prx.org/~r/transistor_stem/~3/NHnLCsjtdQM/</link>
+			<pubDate>Fri, 20 Jan 2017 03:04:12 +0000</pubDate>
+			<guid isPermaLink="false">https://transistor.prx.org/?p=1286</guid>
+			<comments>https://transistor.prx.org/2017/01/sidedoor-from-the-smithsonian-shake-it-up/#respond</comments>
+			<wfw:commentRss>https://transistor.prx.org/2017/01/sidedoor-from-the-smithsonian-shake-it-up/feed/</wfw:commentRss>
+			<slash:comments>0</slash:comments>
+			<category><![CDATA[Indie Features]]></category>
+			<description>For the next few episodes, we’re featuring the Smithsonian’s new series, Sidedoor, about where science, art, history, and humanity unexpectedly overlap — just like in their museums. In this episode: an astronomer has turned the night sky
+				into a symphony; an architecture firm has radically re-thought police stations; and an audiophile builds a successful record … &lt;a href="https://transistor.prx.org/2017/01/sidedoor-from-the-smithsonian-shake-it-up/" class="more-link"&gt;Continue
+				reading &lt;span class="screen-reader-text"&gt;Sidedoor from the Smithsonian: Shake it Up&lt;/span&gt;&lt;/a&gt;</description>
+			<content:encoded>
+				<![CDATA[<p>For the next few episodes, we’re featuring the Smithsonian’s new series, <em>Sidedoor</em>, about where science, art, history, and humanity unexpectedly overlap — just like in their museums.</p>
+<p>In this episode: an astronomer has turned the night sky into a symphony; an architecture firm has radically re-thought police stations; and an audiophile builds a successful record company on under-appreciated sounds.</p>
+<p><script id='prx-p195778-embed' src='https://www.prx.org/p/195778/embed.js?size=small'></script> </p>
+<p>For even more from <a href="https://itunes.apple.com/us/podcast/sidedoor/id1168154281?mt=2" target="_blank">Sidedoor</a>, subscribe in iTunes or wherever you get your podcasts.</p>
+<p><em>Music credits under backannounce: &#8220;Candy&#8221; by Jahzzar.</em></p>
+<img src="http://feeds.feedburner.com/~r/transistor_stem/~4/NHnLCsjtdQM" height="1" width="1" alt=""/>]]>
+			</content:encoded>
+			<itunes:subtitle>An astronomer has turned the night sky into a symphony.</itunes:subtitle>
+			<itunes:summary>For the next few episodes, we’re featuring the Smithsonian’s new series, Sidedoor, about where science, art, history, and humanity unexpectedly overlap — just like in their museums. In this episode: an astronomer who has turned the
+				night sky into a symphony.</itunes:summary>
+			<itunes:author>PRX</itunes:author>
+			<itunes:duration>24:46</itunes:duration>
+			<post-id xmlns="com-wordpress:feed-additions:1">1286</post-id>
+			<feedburner:origLink>https://transistor.prx.org/2017/01/sidedoor-from-the-smithsonian-shake-it-up/</feedburner:origLink><enclosure url="http://feeds.prx.org/~r/transistor_stem/~5/7X0iW0LgXWg/Smithsonian3_Transistor.mp3" length="29714854" type="audio/mpeg"/>
+			<feedburner:origEnclosureLink>https://dts.podtrac.com/redirect.mp3/media.blubrry.com/transistor/cdn-transistor.prx.org/wp-content/uploads/Smithsonian3_Transistor.mp3</feedburner:origEnclosureLink>
+			<itunes:image href="https://cdn-transistor.prx.org/transistor1400.jpg"/>
+		</item>
 	</channel>
 </rss>

--- a/test/models/podcast_import_test.rb
+++ b/test/models/podcast_import_test.rb
@@ -77,20 +77,23 @@ describe PodcastImport do
     importer.distribution = distribution
     importer.podcast = podcast
     stories = importer.create_stories
-    s = stories.first
-    s.description.must_match /^For the next few episodes/
-    s.description.wont_match /<script/
-    s.description.wont_match /<iframe/
-    s.description.wont_match /feedburner/
-    s.account_id.wont_be_nil
-    s.creator_id.wont_be_nil
-    s.series_id.wont_be_nil
-    s.published_at.wont_be_nil
-    s.audio_versions.count.must_equal 1
-    version = s.audio_versions.first
+    f = stories.first
+    f.description.must_match /^For the next few episodes/
+    f.description.wont_match /<script/
+    f.description.wont_match /<iframe/
+    f.description.wont_match /feedburner/
+    f.account_id.wont_be_nil
+    f.creator_id.wont_be_nil
+    f.series_id.wont_be_nil
+    f.published_at.wont_be_nil
+    f.images.count.must_equal 1
+    f.audio_versions.count.must_equal 1
+    version = f.audio_versions.first
     version.audio_version_template_id.wont_be_nil
     version.label.must_equal 'Podcast Audio'
     version.explicit.must_be_nil
+    l = stories.last
+    l.images.count.must_equal 0
   end
 
   it 'imports a feed' do

--- a/test/models/podcast_import_test.rb
+++ b/test/models/podcast_import_test.rb
@@ -13,7 +13,7 @@ describe PodcastImport do
     stub_requests
   end
 
-  let(:feed) { Feedjira::Feed.parse(test_file('/fixtures/transistor.xml')) }
+  let(:feed) { Feedjira::Feed.parse(test_file('/fixtures/transistor_two.xml')) }
   let(:series) { create(:series) }
   let(:template) { create(:audio_version_template, series: series) }
   let(:distribution) do


### PR DESCRIPTION
fixes #291 
- [x] On import, check the episode image against feed image, only add when different