### PR TITLE
Import Fixes III: Many fixes. One PR. #dealwithit

### DIFF
--- a/app/models/distributions/podcast_distribution.rb
+++ b/app/models/distributions/podcast_distribution.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+
 require 'prx_access'
 
 class Distributions::PodcastDistribution < Distribution
@@ -39,7 +40,6 @@ class Distributions::PodcastDistribution < Distribution
       attrs[:title] = owner.title
       attrs[:subtitle] = owner.short_description
       attrs[:description] = owner.description
-      attrs[:summary] = owner.description
     end
 
     attrs

--- a/app/models/podcast_import.rb
+++ b/app/models/podcast_import.rb
@@ -299,7 +299,7 @@ class PodcastImport < BaseModel
     create_attributes[:block] = (clean_string(entry[:itunes_block]) == 'yes')
     create_attributes[:explicit] = explicit(entry[:itunes_explicit])
     create_attributes[:guid] = clean_string(entry.entry_id)
-    create_attributes[:is_closed_captioned] = (clean_string(entry[:itunes_is_closed_captioned]) == 'yes')
+    create_attributes[:is_closed_captioned] = is_closed_captioned(entry)
     create_attributes[:is_perma_link] = entry[:is_perma_link]
     create_attributes[:keywords] = (entry[:itunes_keywords] || '').split(',').map(&:strip)
     create_attributes[:position] = entry[:itunes_order]
@@ -314,6 +314,10 @@ class PodcastImport < BaseModel
       url = nil
     end
     url
+  end
+
+  def is_closed_captioned(entry)
+    (clean_string(entry[:itunes_is_closed_captioned]) == 'yes')
   end
 
   def explicit(str)

--- a/app/models/podcast_import.rb
+++ b/app/models/podcast_import.rb
@@ -341,8 +341,8 @@ class PodcastImport < BaseModel
 
   def remove_feedburner_tracker(str)
     return nil if str.blank?
-    feedburner_tag_regex = /<img src="http:\/\/feeds\.feedburner\.com.+" height="1" width="1" alt=""\/>/
-    str.sub(feedburner_tag_regex, '').strip
+    regex = /<img src="http:\/\/feeds\.feedburner\.com.+" height="1" width="1" alt=""\/>/
+    str.sub(regex, '').strip
   end
 
   def sanitize_html(text)

--- a/app/models/podcast_import.rb
+++ b/app/models/podcast_import.rb
@@ -299,7 +299,7 @@ class PodcastImport < BaseModel
     create_attributes[:block] = (clean_string(entry[:itunes_block]) == 'yes')
     create_attributes[:explicit] = explicit(entry[:itunes_explicit])
     create_attributes[:guid] = clean_string(entry.entry_id)
-    create_attributes[:is_closed_captioned] = is_closed_captioned(entry)
+    create_attributes[:is_closed_captioned] = closed_captioned?(entry)
     create_attributes[:is_perma_link] = entry[:is_perma_link]
     create_attributes[:keywords] = (entry[:itunes_keywords] || '').split(',').map(&:strip)
     create_attributes[:position] = entry[:itunes_order]
@@ -316,7 +316,7 @@ class PodcastImport < BaseModel
     url
   end
 
-  def is_closed_captioned(entry)
+  def closed_captioned?(entry)
     (clean_string(entry[:itunes_is_closed_captioned]) == 'yes')
   end
 

--- a/app/models/podcast_import.rb
+++ b/app/models/podcast_import.rb
@@ -318,10 +318,10 @@ class PodcastImport < BaseModel
 
   def explicit(str)
     return nil if str.blank?
-    explicit = clean_string(str)
-    if %w(yes true explicit).include?(explicit)
+    explicit = clean_string(str).downcase
+    if %w(true explicit).include?(explicit)
       explicit = 'yes'
-    elsif %w(no false clean).include?(explicit)
+    elsif %w(no false).include?(explicit)
       explicit = 'clean'
     end
     explicit

--- a/app/models/story_distributions/episode_distribution.rb
+++ b/app/models/story_distributions/episode_distribution.rb
@@ -36,10 +36,9 @@ class StoryDistributions::EpisodeDistribution < StoryDistribution
     {
       prx_uri: api_story_path(story),
       title: story.title,
-      subtitle: Sanitize.fragment(story.short_description || '').strip,
-      description: Sanitize.fragment(story.description_html || '').strip,
-      summary: story.description,
-      content: story.description,
+      subtitle: story.short_description,
+      description: story.description_html,
+      content: story.description_html,
       categories: story.tags,
       published_at: story.published_at,
       updated_at: story.updated_at

--- a/test/fixtures/transistor_two.xml
+++ b/test/fixtures/transistor_two.xml
@@ -99,8 +99,6 @@
 <img src="http://feeds.feedburner.com/~r/transistor_stem/~4/NHnLCsjtdQM" height="1" width="1" alt=""/>]]>
 			</content:encoded>
 			<itunes:subtitle>An astronomer has turned the night sky into a symphony.</itunes:subtitle>
-			<itunes:summary>For the next few episodes, we’re featuring the Smithsonian’s new series, Sidedoor, about where science, art, history, and humanity unexpectedly overlap — just like in their museums. In this episode: an astronomer who has turned the
-				night sky into a symphony.</itunes:summary>
 			<itunes:author>PRX</itunes:author>
 			<itunes:duration>24:46</itunes:duration>
 			<post-id xmlns="com-wordpress:feed-additions:1">1286</post-id>

--- a/test/models/distributions/podcast_distribution_test.rb
+++ b/test/models/distributions/podcast_distribution_test.rb
@@ -59,7 +59,7 @@ describe Distributions::PodcastDistribution do
 
   it 'returns attributes for creating the podcast' do
     attrs = distribution.podcast_attributes
-    attrs.keys.count.must_equal 7
+    attrs.keys.count.must_equal 6
     attrs[:prx_uri].must_equal "/api/v1/series/#{distribution.owner.id}"
     attrs[:prx_account_uri].must_equal "/api/v1/accounts/#{distribution.account.id}"
     attrs[:published_at].wont_be_nil

--- a/test/models/podcast_import_test.rb
+++ b/test/models/podcast_import_test.rb
@@ -140,6 +140,12 @@ describe PodcastImport do
       desc = 'desc <iframe src="/"></iframe><script src="/"></script>'
       importer.sanitize_html(desc).must_equal 'desc'
     end
+
+    it 'can interpret explicit values' do
+      %w(Yes TRUE Explicit).each { |x| importer.explicit(x).must_equal 'yes' }
+      %w(NO False Clean).each { |x| importer.explicit(x).must_equal 'clean' }
+      %w(UnClean y N 1 0).each { |x| importer.explicit(x).must_equal x.downcase }
+    end
   end
 end
 

--- a/test/models/podcast_import_test.rb
+++ b/test/models/podcast_import_test.rb
@@ -133,19 +133,19 @@ describe PodcastImport do
     it 'can remove feedburner tracking pixels' do
       desc = 'desc <img src="http://feeds.feedburner.com/~r/transistor_stem/~4/NHnLCsjtdQM" ' +
              'height="1" width="1" alt=""/>'
-      importer.remove_feedburner_tracker(desc).must_equal 'desc '
+      importer.remove_feedburner_tracker(desc).must_equal 'desc'
     end
 
     it 'can remove unsafe tags' do
       desc = 'desc <iframe src="/"></iframe><script src="/"></script>'
-      importer.sanitize_html(desc).must_equal 'desc '
+      importer.sanitize_html(desc).must_equal 'desc'
     end
   end
 end
 
 def stub_requests
   stub_request(:get, 'http://feeds.prx.org/transistor_stem').
-    to_return(status: 200, body: test_file('/fixtures/transistor.xml'), headers: {})
+    to_return(status: 200, body: test_file('/fixtures/transistor_two.xml'), headers: {})
 
   stub_request(:get, 'https://www.prx.org/search/all.atom?q=radio').
     to_return(status: 200, body: test_file('/fixtures/prx-atom.xml'), headers: {})


### PR DESCRIPTION
An important fix, many small improvements, one PR.

- [x] #296 Do not set the podcast summary, unless the user fills out a summary
- [x] #296 Do not set the episode summary, unless blah blah blah
- [x] And hey, don't sanitize data in the episode distribution, do that when data comes in and gets saved
- [x] Clean all the text - yeah, feeder will clean it too, but we need it clean in CMS
- [x] #295 Interpret and set explicit values

![deal-with-it-audrey-hepburn-reaction-gif](https://cloud.githubusercontent.com/assets/46439/23827452/d4acf9b4-0681-11e7-8942-8c89cd99635c.gif)

