### PR TITLE
Account for file processing failures in audio version and story status

### DIFF
--- a/app/models/audio_file.rb
+++ b/app/models/audio_file.rb
@@ -48,7 +48,15 @@ class AudioFile < BaseModel
 
   def set_status
     # only do template validations once the audio callback worker has succeeded
-    return if [UPLOADED, NOTFOUND, FAILED].include? status
+    if status == UPLOADED
+      return
+    elsif status == NOTFOUND
+      self.status_message = "Audio file #{label} not found."
+      return
+    elsif status == FAILED
+      self.status_message = "Audio file #{label} failed to process."
+      return
+    end
 
     template = audio_version.
                try(:audio_version_template).

--- a/app/representers/api/min/story_representer.rb
+++ b/app/representers/api/min/story_representer.rb
@@ -11,6 +11,9 @@ class Api::Min::StoryRepresenter < Api::BaseRepresenter
   property :published_at, writeable: false
   property :produced_on
 
+  property :status, writeable: false
+  property :status_message, writeable: false
+
   property :duration, writeable: false
   property :points, writeable: false
   property :app_version, writeable: false

--- a/test/models/audio_file_test.rb
+++ b/test/models/audio_file_test.rb
@@ -75,9 +75,15 @@ describe AudioFile do
     audio_file.must_be(:compliant_with_template?)
   end
 
-  it 'doesnt validate on template unless audio has processed' do
+  it 'doesnt validate on template unless audio has processed successfully' do
     audio_file.update(status: 'failed')
     audio_file.update_attributes(position: 1, label: 'Main Segment')
     audio_file.status.must_equal 'failed'
+    audio_file.status_message.must_include 'Audio file Main Segment failed to process'
+
+    audio_file.update(status: 'not found')
+    audio_file.update_attributes(position: 1, label: 'Main Segment2')
+    audio_file.status.must_equal 'not found'
+    audio_file.status_message.must_include 'Audio file Main Segment2 not found'
   end
 end

--- a/test/models/audio_version_test.rb
+++ b/test/models/audio_version_test.rb
@@ -48,5 +48,21 @@ describe AudioVersion do
       audio_version_with_template.status.must_equal 'invalid'
       audio_version_with_template.wont_be(:compliant_with_template?)
     end
+
+    it 'shows self as invalid if any audio file is not found or failed' do
+      audio_file.update(status: 'not found')
+      audio_version_with_template.audio_files << audio_file
+      audio_version_with_template.update_attributes(explicit: 'explicit')
+      audio_version_with_template.status_message.must_include 'not found'
+      audio_version_with_template.status.must_equal 'invalid'
+      audio_version_with_template.wont_be(:compliant_with_template?)
+
+      audio_file.update(status: 'failed')
+      audio_version_with_template.audio_files << audio_file
+      audio_version_with_template.update_attributes(explicit: 'explicit')
+      audio_version_with_template.status_message.must_include 'failed to process'
+      audio_version_with_template.status.must_equal 'invalid'
+      audio_version_with_template.wont_be(:compliant_with_template?)
+    end
   end
 end

--- a/test/representers/api/min/story_representer_test.rb
+++ b/test/representers/api/min/story_representer_test.rb
@@ -26,4 +26,8 @@ describe Api::Min::StoryRepresenter do
       json['duration'].must_equal 212
     end
   end
+
+  it 'includes story status' do
+    json['status'].wont_be_nil
+  end
 end


### PR DESCRIPTION
- #300 adds story and audio version `status` and `status_message` handling for NOTFOUND or FAILED audio file after processing (should fix error we just saw on import where a NOTFOUND audio file was in a COMPLETE audio version / story)
- #301 adds `status` and `status_message` to Story Min Representer