### PR TITLE
Replace audio on podcast import

### DIFF
--- a/app/models/podcast_import.rb
+++ b/app/models/podcast_import.rb
@@ -118,7 +118,7 @@ class PodcastImport < BaseModel
       length_maximum: 0
     )
 
-    num_segments = [config[:segments].to_i, 1 ].max
+    num_segments = [config[:segments].to_i, 1].max
     num_segments.times do |x|
       num = x + 1
       template.audio_file_templates.create!(
@@ -382,8 +382,8 @@ class PodcastImport < BaseModel
     @uri ||= Addressable::URI.parse(url)
   end
 
-  def connection(uri = uri)
-    conn_uri = "#{uri.scheme}://#{uri.host}:#{uri.port}"
+  def connection(u = self.uri)
+    conn_uri = "#{u.scheme}://#{u.host}:#{u.port}"
     Faraday.new(conn_uri) { |stack| stack.adapter :excon }.tap do |c|
       c.headers[:user_agent] = 'PRX CMS FeedValidator'
     end

--- a/app/models/podcast_import.rb
+++ b/app/models/podcast_import.rb
@@ -382,7 +382,7 @@ class PodcastImport < BaseModel
     @uri ||= Addressable::URI.parse(url)
   end
 
-  def connection(u = self.uri)
+  def connection(u = uri)
     conn_uri = "#{u.scheme}://#{u.host}:#{u.port}"
     Faraday.new(conn_uri) { |stack| stack.adapter :excon }.tap do |c|
       c.headers[:user_agent] = 'PRX CMS FeedValidator'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -198,6 +198,7 @@ ActiveRecord::Schema.define(version: 6) do
     t.integer  "account_id", limit: 4
     t.integer  "series_id",  limit: 4
     t.string   "url",        limit: 255
+    t.text     "config",     limit: 65535
     t.string   "status",     limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"

--- a/test/fixtures/transistor_import_config.json
+++ b/test/fixtures/transistor_import_config.json
@@ -1,0 +1,9 @@
+{
+  "segments" : 1,
+  "program" : "transistor_stem",
+  "audio" : {
+    "https://transistor.prx.org/?p=1286" : [
+      "https://cdn-transistor.prx.org/wp-content/uploads/Smithsonian3_Transistor.mp3"
+    ]
+  }
+}

--- a/test/models/podcast_import_test.rb
+++ b/test/models/podcast_import_test.rb
@@ -96,6 +96,8 @@ describe PodcastImport do
     f.published_at.wont_be_nil
     f.images.count.must_equal 1
     f.audio_versions.count.must_equal 1
+    config_audio = 'https://cdn-transistor.prx.org/wp-content/uploads/Smithsonian3_Transistor.mp3'
+    f.audio_versions.first.audio_files.first.upload.must_equal config_audio
     version = f.audio_versions.first
     version.audio_version_template_id.wont_be_nil
     version.label.must_equal 'Podcast Audio'

--- a/test/models/podcast_import_test.rb
+++ b/test/models/podcast_import_test.rb
@@ -33,6 +33,13 @@ describe PodcastImport do
     importer.feed.wont_be_nil
   end
 
+  it 'retrieves a config' do
+    importer.set_config_url('http://test.prx.org/transistor_import_config.json')
+    importer.config[:segments].must_equal 1
+    importer.config[:program].must_equal 'transistor_stem'
+    importer.config[:audio]['https://transistor.prx.org/?p=1286'].count.must_equal 1
+  end
+
   it 'fails when feed is invalid' do
     importer.url = 'https://www.prx.org/search/all.atom?q=radio'
     -> { importer.get_feed }.must_raise(RuntimeError)
@@ -71,6 +78,7 @@ describe PodcastImport do
   end
 
   it 'creates stories' do
+    importer.set_config_url('http://test.prx.org/transistor_import_config.json')
     importer.feed = feed
     importer.series = series
     importer.template = template
@@ -152,6 +160,9 @@ end
 def stub_requests
   stub_request(:get, 'http://feeds.prx.org/transistor_stem').
     to_return(status: 200, body: test_file('/fixtures/transistor_two.xml'), headers: {})
+
+  stub_request(:get, 'http://test.prx.org/transistor_import_config.json').
+    to_return(status: 200, body: json_file('transistor_import_config'), headers: {})
 
   stub_request(:get, 'https://www.prx.org/search/all.atom?q=radio').
     to_return(status: 200, body: test_file('/fixtures/prx-atom.xml'), headers: {})


### PR DESCRIPTION

- [x] Add `config` for a `PodcastImport`, use for # of segments and replacement audio
- [x] Use this config to setup audio template, and set audio files, when available