### PR TITLE
Also send story announcements for version changes

### DIFF
--- a/app/controllers/api/audio_versions_controller.rb
+++ b/app/controllers/api/audio_versions_controller.rb
@@ -5,7 +5,7 @@ class Api::AudioVersionsController < Api::BaseController
 
   filter_resources_by :story_id
 
-  announce_actions resource: :story_resource
+  announce_actions resource: :story_resource, action: :update
 
   def story_resource
     resource.try(:story)

--- a/app/controllers/api/audio_versions_controller.rb
+++ b/app/controllers/api/audio_versions_controller.rb
@@ -4,4 +4,10 @@ class Api::AudioVersionsController < Api::BaseController
   api_versions :v1
 
   filter_resources_by :story_id
+
+  announce_actions resource: :story_resource
+
+  def story_resource
+    resource.try(:story)
+  end
 end

--- a/app/controllers/api/distributions_controller.rb
+++ b/app/controllers/api/distributions_controller.rb
@@ -11,7 +11,7 @@ class Api::DistributionsController < Api::BaseController
 
   filter_resources_by :series_id
 
-  announce_actions resource: :owner_resource
+  announce_actions resource: :owner_resource, action: :update
 
   around_action :wrap_in_transaction, only: :create
 

--- a/app/controllers/api/story_distributions_controller.rb
+++ b/app/controllers/api/story_distributions_controller.rb
@@ -11,7 +11,7 @@ class Api::StoryDistributionsController < Api::BaseController
 
   filter_resources_by :story_id
 
-  announce_actions resource: :story_resource
+  announce_actions resource: :story_resource, action: :update
 
   around_action :wrap_in_transaction, only: :create
 

--- a/test/controllers/concerns/announce_actions_test.rb
+++ b/test/controllers/concerns/announce_actions_test.rb
@@ -4,7 +4,7 @@ require 'announce_actions'
 
 Api::TestObjectsController.class_eval do
   include AnnounceActions
-  announce_actions(:update, resource: :parent)
+  announce_actions(:update, resource: :parent, action: :change)
   announce_actions(:create, :destroy)
 end
 
@@ -42,12 +42,12 @@ describe Api::TestObjectsController do
       last_message['action'].to_s.must_equal 'delete'
     end
 
-    it 'will call announce on a different resource' do
+    it 'will call announce on a different resource and action' do
       put :update, id: 1
 
       response.must_be :success?
       last_message['subject'].to_s.must_equal 'test_parent'
-      last_message['action'].to_s.must_equal 'update'
+      last_message['action'].to_s.must_equal 'change'
     end
   end
 


### PR DESCRIPTION
- [x] Make the version controller send story update announcements
- [x] Fix the distro controllers to send parent update announcements

The reason for specifying the action is you don't want to send the child action for the parent resource.
e.g. if I delete a version, I don't want to send a story delete, I want to send a story update.
