### PR TITLE
Handle escaped newlines

### DIFF
--- a/app/models/concerns/render_markdown.rb
+++ b/app/models/concerns/render_markdown.rb
@@ -15,7 +15,12 @@ module RenderMarkdown
   def markdown_to_html(str)
     return nil unless str
     md = Redcarpet::Markdown.new(markdown_html_renderer, markdown_extensions)
-    md.render(str || '').strip
+    str = md.render(str || '').strip
+    str = convert_escaped_newlines(str || '')
+  end
+
+  def convert_escaped_newlines(str)
+    str.gsub(/\\<br>/, "<br>")
   end
 
   def markdown_extensions

--- a/app/models/concerns/render_markdown.rb
+++ b/app/models/concerns/render_markdown.rb
@@ -16,11 +16,11 @@ module RenderMarkdown
     return nil unless str
     md = Redcarpet::Markdown.new(markdown_html_renderer, markdown_extensions)
     str = md.render(str || '').strip
-    str = convert_escaped_newlines(str || '')
+    convert_escaped_newlines(str)
   end
 
   def convert_escaped_newlines(str)
-    str.gsub(/\\<br>/, "<br>")
+    str.gsub(/\\<br>/, '<br>')
   end
 
   def markdown_extensions

--- a/test/models/concerns/render_markdown_test.rb
+++ b/test/models/concerns/render_markdown_test.rb
@@ -17,4 +17,10 @@ describe TestMarkdownModel do
   it 'converts html to markdown ' do
     model.html_to_markdown("\n<p><em>This is markdown</em></p>\n").must_equal "_This is markdown_"
   end
+
+  it 'converts escaped new lines without slashes' do
+    model.markdown_to_html("one\n\n\\\nanother\n").must_equal "<p>one</p>\n\n<p><br>\nanother</p>"
+    model.markdown_to_html("one\n\\\n\\\n\\\nanother\n").must_equal "<p>one<br>\n<br>\n<br>\n<br>\nanother</p>"
+    model.markdown_to_html("one\n\\\n\\\nanother\n").must_equal "<p>one<br>\n<br>\n<br>\nanother</p>"
+  end
 end

--- a/test/models/concerns/render_markdown_test.rb
+++ b/test/models/concerns/render_markdown_test.rb
@@ -19,8 +19,8 @@ describe TestMarkdownModel do
   end
 
   it 'converts escaped new lines without slashes' do
-    model.markdown_to_html("one\n\n\\\nanother\n").must_equal "<p>one</p>\n\n<p><br>\nanother</p>"
-    model.markdown_to_html("one\n\\\n\\\n\\\nanother\n").must_equal "<p>one<br>\n<br>\n<br>\n<br>\nanother</p>"
-    model.markdown_to_html("one\n\\\n\\\nanother\n").must_equal "<p>one<br>\n<br>\n<br>\nanother</p>"
+    model.markdown_to_html("o\n\n\\\na\n").must_equal "<p>o</p>\n\n<p><br>\na</p>"
+    model.markdown_to_html("o\n\\\n\\\n\\\na\n").must_equal "<p>o<br>\n<br>\n<br>\n<br>\na</p>"
+    model.markdown_to_html("o\n\\\n\\\na\n").must_equal "<p>o<br>\n<br>\n<br>\na</p>"
   end
 end


### PR DESCRIPTION
The convention for hard breaks in markdown is `space-space-newline`
proseMirror uses escaped newlines, with means a backslash as the last thing on a line.
have cms recognize these backslashes as breaks, and remove them from the html.

