### PR TITLE
Fix announcing story destroy events

### DIFF
--- a/app/controllers/api/auth/stories_controller.rb
+++ b/app/controllers/api/auth/stories_controller.rb
@@ -13,7 +13,7 @@ class Api::Auth::StoriesController < Api::StoriesController
               allowed: [:id, :created_at, :updated_at, :published_at, :title,
                         :episode_number, :position]
 
-  announce_actions :create, :update, :delete, :publish, :unpublish
+  announce_actions :create, :update, :destroy, :publish, :unpublish
 
   represent_with Api::Auth::StoryRepresenter
 

--- a/app/controllers/api/stories_controller.rb
+++ b/app/controllers/api/stories_controller.rb
@@ -11,7 +11,7 @@ class Api::StoriesController < Api::BaseController
               allowed: [:id, :created_at, :updated_at, :published_at, :title,
                         :episode_number, :position]
 
-  announce_actions :create, :update, :delete, :publish, :unpublish
+  announce_actions :create, :update, :destroy, :publish, :unpublish
 
   def after_create_resource(res)
     res.create_story_distributions

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -40,17 +40,17 @@ class Story < BaseModel
   belongs_to :network
 
   has_many :images,
-    -> { where(parent_id: nil).order(:position) },
-    class_name: 'StoryImage',
-    foreign_key: :piece_id,
-    dependent: :destroy
+           -> { where(parent_id: nil).order(:position) },
+           class_name: 'StoryImage',
+           foreign_key: :piece_id,
+           dependent: :destroy
   has_many :audio_versions, -> { where(promos: false).includes(:audio_files) }, foreign_key: :piece_id
   has_many :audio_files, through: :audio_versions
   has_many :producers, foreign_key: :piece_id, dependent: :destroy
   has_many :musical_works,
-    -> { order(:position) },
-    foreign_key: :piece_id,
-    dependent: :destroy
+           -> { order(:position) },
+           foreign_key: :piece_id,
+           dependent: :destroy
   has_many :topics, foreign_key: :piece_id, dependent: :destroy
   has_many :tones, foreign_key: :piece_id, dependent: :destroy
   has_many :formats, foreign_key: :piece_id, dependent: :destroy
@@ -60,9 +60,9 @@ class Story < BaseModel
   has_many :playlists, through: :picks
   has_many :purchases, foreign_key: :purchased_id
   has_many :distributions,
-    class_name: StoryDistribution,
-    foreign_key: :piece_id,
-    dependent: :destroy
+           class_name: StoryDistribution,
+           foreign_key: :piece_id,
+           dependent: :destroy
 
   has_one :promos, -> { where(promos: true).includes(:audio_files) }, class_name: 'AudioVersion', foreign_key: :piece_id
   has_one :license, foreign_key: :piece_id, dependent: :destroy

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -60,7 +60,7 @@ class Story < BaseModel
   has_many :playlists, through: :picks
   has_many :purchases, foreign_key: :purchased_id
   has_many :distributions,
-           class_name: StoryDistribution,
+           class_name: 'StoryDistribution',
            foreign_key: :piece_id,
            dependent: :destroy
 

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -64,7 +64,10 @@ class Story < BaseModel
            foreign_key: :piece_id,
            dependent: :destroy
 
-  has_one :promos, -> { where(promos: true).includes(:audio_files) }, class_name: 'AudioVersion', foreign_key: :piece_id
+  has_one :promos,
+          -> { where(promos: true).includes(:audio_files) },
+          class_name: 'AudioVersion',
+          foreign_key: :piece_id
   has_one :license, foreign_key: :piece_id, dependent: :destroy
 
   before_validation :set_app_version, on: :create

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -39,23 +39,33 @@ class Story < BaseModel
   belongs_to :series, touch: true
   belongs_to :network
 
-  has_many :images, -> { where(parent_id: nil).order(:position) }, class_name: 'StoryImage', foreign_key: :piece_id
+  has_many :images,
+    -> { where(parent_id: nil).order(:position) },
+    class_name: 'StoryImage',
+    foreign_key: :piece_id,
+    dependent: :destroy
   has_many :audio_versions, -> { where(promos: false).includes(:audio_files) }, foreign_key: :piece_id
   has_many :audio_files, through: :audio_versions
-  has_many :producers
-  has_many :musical_works, -> { order(:position) }, foreign_key: :piece_id
-  has_many :topics, foreign_key: :piece_id
-  has_many :tones, foreign_key: :piece_id
-  has_many :formats, foreign_key: :piece_id
-  has_many :taggings, as: :taggable
+  has_many :producers, foreign_key: :piece_id, dependent: :destroy
+  has_many :musical_works,
+    -> { order(:position) },
+    foreign_key: :piece_id,
+    dependent: :destroy
+  has_many :topics, foreign_key: :piece_id, dependent: :destroy
+  has_many :tones, foreign_key: :piece_id, dependent: :destroy
+  has_many :formats, foreign_key: :piece_id, dependent: :destroy
+  has_many :taggings, as: :taggable, dependent: :destroy
   has_many :user_tags, through: :taggings
-  has_many :picks, foreign_key: 'playlistable_id'
+  has_many :picks, foreign_key: 'playlistable_id', dependent: :destroy
   has_many :playlists, through: :picks
   has_many :purchases, foreign_key: :purchased_id
-  has_many :distributions, class_name: StoryDistribution, foreign_key: :piece_id
+  has_many :distributions,
+    class_name: StoryDistribution,
+    foreign_key: :piece_id,
+    dependent: :destroy
 
-  has_one :promos, -> { where(promos: true) }, class_name: 'AudioVersion', foreign_key: :piece_id
-  has_one :license, foreign_key: :piece_id
+  has_one :promos, -> { where(promos: true).includes(:audio_files) }, class_name: 'AudioVersion', foreign_key: :piece_id
+  has_one :license, foreign_key: :piece_id, dependent: :destroy
 
   before_validation :set_app_version, on: :create
   before_validation :update_published_to_released

--- a/app/representers/concerns/nested_image.rb
+++ b/app/representers/concerns/nested_image.rb
@@ -7,13 +7,13 @@ module NestedImage
 
   def nested_image_path(represented)
     if represented.is_a?(StoryImage)
-      api_story_story_image_path(represented.story, represented)
+      api_story_story_image_path(represented.piece_id, represented.id)
     elsif represented.is_a?(SeriesImage)
-      api_series_series_image_path(represented.series, represented)
+      api_series_series_image_path(represented.series_id, represented.id)
     elsif represented.is_a?(AccountImage)
-      api_account_account_image_path(represented.account)
+      api_account_account_image_path(represented.account_id)
     elsif represented.is_a?(UserImage)
-      api_user_user_image_path(represented.user)
+      api_user_user_image_path(represented.user_id)
     end
   end
 end


### PR DESCRIPTION
- [x] Change `delete` to `destroy` in announce actions config
- [x] Also destroy dependencies for the story
- [x] Do not try to retrieve relations when getting the url for a nested (e.g. story) image, they may be deleted
- [x] Fix bug where `producer` relation on story had wrong foreign key