### PR TITLE
Validate max against min for version and file tempalets

### DIFF
--- a/app/models/audio_file_template.rb
+++ b/app/models/audio_file_template.rb
@@ -12,11 +12,14 @@ class AudioFileTemplate < BaseModel
 
   validates :length_minimum,
             presence: true,
-            numericality: { less_than_or_equal_to: :length_maximum }
+            numericality: true
 
   validates :length_maximum,
             presence: true,
-            numericality: { greater_than_or_equal_to: :length_minimum }
+            numericality: true
+
+  validate :max_is_greater_than_min_if_set
+
 
   def set_defaults
     self.label ||= 'segment'
@@ -45,4 +48,11 @@ class AudioFileTemplate < BaseModel
     end
     length_errors
   end
+
+  def max_is_greater_than_min_if_set
+    if length_maximum != 0 && length_minimum > length_maximum
+      errors.add(:length_mininum, 'must be less than or equal to length maximum')
+    end
+  end
+
 end

--- a/app/models/audio_version_template.rb
+++ b/app/models/audio_version_template.rb
@@ -21,11 +21,13 @@ class AudioVersionTemplate < BaseModel
 
   validates :length_minimum,
             presence: true,
-            numericality: { less_than_or_equal_to: :length_maximum }
+            numericality: true
 
   validates :length_maximum,
             presence: true,
-            numericality: { greater_than_or_equal_to: :length_minimum }
+            numericality: true
+
+  validate :max_is_greater_than_min_if_set
 
   def self.policy_class
     SeriesAttributePolicy
@@ -68,5 +70,11 @@ class AudioVersionTemplate < BaseModel
                        "- #{length_maximum.to_time_string} long."
     end
     length_errors
+  end
+
+  def max_is_greater_than_min_if_set
+    if length_maximum != 0 && length_minimum > length_maximum
+      errors.add(:length_mininum, 'must be less than or equal to length maximum')
+    end
   end
 end

--- a/test/models/audio_file_template_test.rb
+++ b/test/models/audio_file_template_test.rb
@@ -21,4 +21,16 @@ describe AudioFileTemplate do
     audio_file.update(length: 5)
     audio_file_template.validate_audio_file(audio_file).must_be(:empty?)
   end
+
+  it 'checks template min against max' do
+    audio_file_template.length_minimum = 20
+    audio_file_template.length_maximum = 10
+    audio_file_template.wont_be :valid?
+  end
+
+  it 'allows template max to be unset' do
+    audio_file_template.length_minimum = 20
+    audio_file_template.length_maximum = 0
+    audio_file_template.must_be :valid?
+  end
 end

--- a/test/models/audio_version_template_test.rb
+++ b/test/models/audio_version_template_test.rb
@@ -33,4 +33,16 @@ describe AudioVersionTemplate do
     audio_version_template.validate_audio_version(audio_version).must_be(:empty?)
   end
 
+  it 'checks template min against max' do
+    audio_version_template.length_minimum = 20
+    audio_version_template.length_maximum = 10
+    audio_version_template.wont_be :valid?
+  end
+
+  it 'allows template max to be unset' do
+    audio_version_template.length_minimum = 20
+    audio_version_template.length_maximum = 0
+    audio_version_template.must_be :valid?
+  end
+
 end


### PR DESCRIPTION
Allows length maximum to be unset for version and file templates; validates it against min if it's there. fixes #322 