### PR TITLE
check for blank instead of nil

### DIFF
--- a/app/models/podcast_import.rb
+++ b/app/models/podcast_import.rb
@@ -356,7 +356,7 @@ class PodcastImport < BaseModel
 
   def short_desc(item)
     [item.itunes_subtitle, item.description, item.title].find do |field|
-      !field.nil? && field.split.length < 50
+      !field.blank? && field.split.length < 50
     end
   end
 

--- a/test/models/podcast_import_test.rb
+++ b/test/models/podcast_import_test.rb
@@ -143,8 +143,13 @@ describe PodcastImport do
     it 'can substitute for a missing short description' do
       item = feed.entries.first
       importer.short_desc(item).must_equal 'An astronomer has turned the night sky into a symphony.'
+
+      item.itunes_subtitle = ''
+      importer.short_desc(item).wont_equal ''
+
       item.itunes_subtitle = nil
       importer.short_desc(item).must_equal 'Sidedoor from the Smithsonian: Shake it Up'
+
       item.description = 'Some text that\'s under 50 words'
       importer.short_desc(item).must_equal 'Some text that\'s under 50 words'
 


### PR DESCRIPTION
Check for blank instead of nil to avoid setting description fields to empty string. 