### PR TITLE
Check audio files match on channel, bit rate, freq

### DIFF
--- a/app/models/audio_version.rb
+++ b/app/models/audio_version.rb
@@ -35,7 +35,7 @@ class AudioVersion < BaseModel
   private
 
   def audio_formats_match?
-    [:frequency, :bit_rate, :channel_mode].each do |format|
+    %i(frequency bit_rate channel_mode).each do |format|
       return false if audio_files.map(&format).compact.uniq.length > 1
     end
     true

--- a/app/models/audio_version.rb
+++ b/app/models/audio_version.rb
@@ -34,6 +34,13 @@ class AudioVersion < BaseModel
 
   private
 
+  def audio_formats_match?
+    [:frequency, :bit_rate, :channel_mode].each do |format|
+      return false if audio_files.map(&format).compact.uniq.length > 1
+    end
+    true
+  end
+
   def update_story_status
     story.try(:save!)
   end
@@ -45,6 +52,12 @@ class AudioVersion < BaseModel
     if !noncompliant_files.empty?
       self.status = INVALID
       self.status_message = noncompliant_files.map(&:status_message).join(', ')
+      return
+    end
+
+    if !audio_formats_match?
+      self.status = INVALID
+      self.status_message = 'Mismatch in audio formats between audio files'
       return
     end
 

--- a/app/models/audio_version.rb
+++ b/app/models/audio_version.rb
@@ -35,7 +35,7 @@ class AudioVersion < BaseModel
   private
 
   def audio_formats_match?
-    %i(frequency bit_rate channel_mode).each do |format|
+    %i(content_type layer frequency bit_rate channel_mode).each do |format|
       return false if audio_files.map(&format).compact.uniq.length > 1
     end
     true
@@ -57,7 +57,7 @@ class AudioVersion < BaseModel
 
     if !audio_formats_match?
       self.status = INVALID
-      self.status_message = 'Mismatch in audio formats between audio files'
+      self.status_message = 'Audio file formats do not match'
       return
     end
 

--- a/app/representers/api/auth/audio_file_representer.rb
+++ b/app/representers/api/auth/audio_file_representer.rb
@@ -1,6 +1,12 @@
 # encoding: utf-8
 
 class Api::Auth::AudioFileRepresenter < Api::AudioFileRepresenter
+  property :content_type, writeable: false
+  property :layer, writeable: false
+  property :frequency, writeable: false
+  property :bit_rate, writeable: false
+  property :channel_mode, writeable: false
+
   def self_url(r)
     api_authorization_audio_file_path(r)
   end

--- a/test/factories/audio_file_factory.rb
+++ b/test/factories/audio_file_factory.rb
@@ -4,6 +4,11 @@ FactoryGirl.define do
     audio_version
 
     length 60
+    content_type 'audio/mpeg'
+    layer 2
+    frequency 44.1
+    bit_rate 128
+    channel_mode 'Single Channel'
 
     status 'complete'
 

--- a/test/models/audio_version_test.rb
+++ b/test/models/audio_version_test.rb
@@ -47,6 +47,22 @@ describe AudioVersion do
       av.status_message.wont_be_nil
       av.status.must_equal 'invalid'
     end
+
+    it 'validates audio files match on content type' do
+      av.audio_files.first.update_column(:content_type, 'audio/mpeg')
+      av.audio_files.last.update_column(:content_type, 'audio/x-wav')
+      av.send(:set_status)
+      av.status_message.wont_be_nil
+      av.status.must_equal 'invalid'
+    end
+
+    it 'validates audio files match on layer' do
+      av.audio_files.first.update_column(:layer, 2)
+      av.audio_files.last.update_column(:layer, 3)
+      av.send(:set_status)
+      av.status_message.wont_be_nil
+      av.status.must_equal 'invalid'
+    end
   end
 
   describe 'with a template' do

--- a/test/representers/api/auth/audio_file_representer_test.rb
+++ b/test/representers/api/auth/audio_file_representer_test.rb
@@ -21,4 +21,12 @@ describe Api::Auth::AudioFileRepresenter do
     store = json['_links']['prx:storage']['href']
     store.must_equal "s3://#{ENV['AWS_BUCKET']}/public/audio_files/#{audio_file.id}/test.mp2"
   end
+
+  it 'reveals the analyzed audio format' do
+    json['contentType'].must_equal 'audio/mpeg'
+    json['layer'].must_equal 2
+    json['frequency'].must_equal '44.1'
+    json['bitRate'].must_equal 128
+    json['channelMode'].must_equal 'Single Channel'
+  end
 end


### PR DESCRIPTION
Dovetail needs audio files to match on channels, bitrate, and frequency to stitch them together without possibility of error in playback. This checks to make sure all audio files for a given audio version match each other on those three attributes. (first half of https://github.com/PRX/publish.prx.org/issues/432)

The chain of methods to make this happen is:
- audio file gets uploaded, with `status: 'uploaded'`
- audio lambda kicks in and determines length, size, bit rate, frequency, channel etc 
- AudioCallbackWorker adds those attributes to the audio file, sets the file's status to `'mp3s created'` (aka `TRANSFORMED`) and calls `save!`
- before_save hook calls `set_status` on the file and validates it against its own audio file template, and sets the status to `complete` if no error
- after_save hook calls `update_version_status` since the status of the audio file has changed, which calls `save!` on the audio version the file belongs to 
- before_save hook on the audio version calls `set_status`, which will now check for file format mismatches in addition to validating against template

I'm thinking that we can rely on this chain of callbacks to work as expected -- are there any times that an audio file's status would _not_ change, but we'd still fear a new file format mismatch? 