### PR TITLE
Embed auth audio files

### DIFF
--- a/app/models/audio_file_template.rb
+++ b/app/models/audio_file_template.rb
@@ -42,9 +42,13 @@ class AudioFileTemplate < BaseModel
 
     if shorter_than_min || longer_than_max
       length_errors << "Audio file '#{file.label}' is " +
-                       "#{file.length.to_time_string} long, but " +
-                       "must be #{length_minimum.to_time_string} " +
-                       "- #{length_maximum.to_time_string} long."
+                       "#{file.length.to_time_string} long but must be "
+      if length_maximum != 0
+        length_errors << "#{length_minimum.to_time_string} - " +
+                         "#{length_maximum.to_time_string} long."
+      else
+        length_errors << "more than #{length_minimum.to_time_string} long."
+      end
     end
     length_errors
   end

--- a/app/models/audio_file_template.rb
+++ b/app/models/audio_file_template.rb
@@ -43,12 +43,12 @@ class AudioFileTemplate < BaseModel
     if shorter_than_min || longer_than_max
       length_errors << "Audio file '#{file.label}' is " +
                        "#{file.length.to_time_string} long but must be "
-      if length_maximum != 0
-        length_errors << "#{length_minimum.to_time_string} - " +
+      length_errors << if length_maximum != 0
+                         "#{length_minimum.to_time_string} - " +
                          "#{length_maximum.to_time_string} long."
-      else
-        length_errors << "more than #{length_minimum.to_time_string} long."
-      end
+                       else
+                         "more than #{length_minimum.to_time_string} long."
+                       end
     end
     length_errors
   end

--- a/app/models/audio_version_template.rb
+++ b/app/models/audio_version_template.rb
@@ -54,7 +54,7 @@ class AudioVersionTemplate < BaseModel
     num_audio_files = audio_version.audio_files.count
     if !segment_count.nil? && audio_version.audio_files.count != segment_count
       file_count_errors << "Audio version #{audio_version.label} has #{num_audio_files} " +
-                           "audio files, but must have #{segment_count} segments."
+                           "audio files but must have #{segment_count} segments."
     end
     file_count_errors
   end
@@ -65,9 +65,13 @@ class AudioVersionTemplate < BaseModel
     longer_than_max = length_maximum != 0 && audio_version.length > length_maximum
     if shorter_than_min || longer_than_max
       length_errors << "Audio version '#{audio_version.label}' is " +
-                       "#{audio_version.length.to_time_string} long, but " +
-                       "must be #{length_minimum.to_time_string} " +
-                       "- #{length_maximum.to_time_string} long."
+                       "#{audio_version.length.to_time_string} long but must be " +
+      length_errors << if length_maximum != 0
+                         "#{length_minimum.to_time_string} - " +
+                         "#{length_maximum.to_time_string} long."
+                       else
+                         "more than #{length_minimum.to_time_string} long."
+                       end
     end
     length_errors
   end

--- a/app/models/audio_version_template.rb
+++ b/app/models/audio_version_template.rb
@@ -65,7 +65,7 @@ class AudioVersionTemplate < BaseModel
     longer_than_max = length_maximum != 0 && audio_version.length > length_maximum
     if shorter_than_min || longer_than_max
       length_errors << "Audio version '#{audio_version.label}' is " +
-                       "#{audio_version.length.to_time_string} long but must be " +
+                       "#{audio_version.length.to_time_string} long but must be "
       length_errors << if length_maximum != 0
                          "#{length_minimum.to_time_string} - " +
                          "#{length_maximum.to_time_string} long."

--- a/app/representers/api/auth/audio_version_representer.rb
+++ b/app/representers/api/auth/audio_version_representer.rb
@@ -1,0 +1,6 @@
+# encoding: utf-8
+
+class Api::Auth::AudioVersionRepresenter < Api::AudioVersionRepresenter
+  # embed with authorized representer
+  embeds :audio_files, as: :audio, class: AudioFile, decorator: Api::Auth::AudioFileRepresenter
+end

--- a/app/representers/api/auth/story_representer.rb
+++ b/app/representers/api/auth/story_representer.rb
@@ -31,4 +31,10 @@ class Api::Auth::StoryRepresenter < Api::StoryRepresenter
         item_class: AudioFile,
         item_decorator: Api::Auth::AudioFileRepresenter,
         per: :all
+
+  # use authorized representer
+  embed :audio_versions,
+        paged: true,
+        item_class: AudioVersion,
+        item_decorator: Api::Auth::AudioVersionRepresenter
 end

--- a/test/models/audio_file_template_test.rb
+++ b/test/models/audio_file_template_test.rb
@@ -14,7 +14,19 @@ describe AudioFileTemplate do
   end
 
   it 'can tell if file length doesnt match template' do
-    audio_file_template.validate_audio_file(audio_file).must_include 'long, but must be'
+    msg = audio_file_template.validate_audio_file(audio_file)
+    msg.must_include 'long but must be 1 second - 10 seconds'
+  end
+
+  it 'validates with just a minimum' do
+    audio_file_template.update(length_minimum: 120, length_maximum: 0)
+    msg = audio_file_template.validate_audio_file(audio_file)
+    msg.must_include 'but must be more than 2 minutes'
+  end
+
+  it 'does not validate anything if all 0s' do
+    audio_file_template.update(length_minimum: 0, length_maximum: 0)
+    audio_file_template.validate_audio_file(audio_file).must_equal ''
   end
 
   it 'leaves a file alone if file complies with template' do

--- a/test/models/audio_file_test.rb
+++ b/test/models/audio_file_test.rb
@@ -65,7 +65,7 @@ describe AudioFile do
     audio_version.audio_version_template.audio_file_templates = file_templates
 
     audio_file.update_attributes(position: 1, label: 'Main Segment')
-    audio_file.status_message.must_include 'long, but must be'
+    audio_file.status_message.must_include 'long but must be'
     audio_file.wont_be(:compliant_with_template?)
     audio_file.status.must_equal 'invalid'
 

--- a/test/models/audio_version_template_test.rb
+++ b/test/models/audio_version_template_test.rb
@@ -20,12 +20,23 @@ describe AudioVersionTemplate do
   it 'can tell if version doesnt have enough segments' do
     audio_version_template.segment_count = 2
     error_results = audio_version_template.validate_audio_version(audio_version)
-    error_results.must_include 'has 1 audio files, but must have'
+    error_results.must_include 'has 1 audio files but must have 2'
   end
 
   it 'can tell if version length doesnt match template' do
     error_results = audio_version_template.validate_audio_version(audio_version)
-    error_results.must_include 'long, but must be'
+    error_results.must_include 'long but must be 10 seconds - 1 minute and'
+  end
+
+  it 'validates with just a minimum' do
+    audio_version_template.update(length_minimum: 120, length_maximum: 0)
+    error_results = audio_version_template.validate_audio_version(audio_version)
+    error_results.must_include 'long but must be more than 2 minutes'
+  end
+
+  it 'does not validate anything if all 0s' do
+    audio_version_template.update(length_minimum: 0, length_maximum: 0)
+    audio_version_template.validate_audio_version(audio_version).must_equal ''
   end
 
   it 'leaves a file alone if file complies with template' do

--- a/test/models/audio_version_test.rb
+++ b/test/models/audio_version_test.rb
@@ -84,7 +84,7 @@ describe AudioVersion do
 
     it 'shows self as invalid if incompliant with template' do
       audio_version_with_template.update_attributes(explicit: 'explicit')
-      audio_version_with_template.status_message.must_include 'long, but must be'
+      audio_version_with_template.status_message.must_include 'long but must be'
       audio_version_with_template.status.must_equal 'invalid'
       audio_version_with_template.wont_be(:compliant_with_template?)
     end

--- a/test/representers/api/auth/story_representer_test.rb
+++ b/test/representers/api/auth/story_representer_test.rb
@@ -30,4 +30,13 @@ describe Api::Auth::StoryRepresenter do
     af = pub_json['_embedded']['prx:audio']['_embedded']['prx:items'].first
     get_link_href(af, 'prx:storage').must_match /s3:\/\//
   end
+
+  it 'has auth audio versions' do
+    av = pub_json['_embedded']['prx:audio-versions']['_embedded']['prx:items'].first
+    af = av['_embedded']['prx:audio'].first
+    af.keys.must_include 'frequency'
+    af.keys.must_include 'bitRate'
+    af.keys.must_include 'channelMode'
+    get_link_href(af, 'self').must_match /authorization\/audio_files\/\d+/
+  end
 end


### PR DESCRIPTION
Validation updates.  Will allow Publish to get the audio file frequency/bitrate/etc, and validate itself.

- [x] Embed auth-audio-files into auth-stories (through the audio-versions, which is what Publish looks at)
- [x] Slightly better validation messaging