### PR TITLE
Prevent simultaneous updates to status for audio files, versions, and stories

### DIFF
--- a/app/models/audio_file.rb
+++ b/app/models/audio_file.rb
@@ -21,7 +21,7 @@ class AudioFile < BaseModel
   fixerable_upload :upload, :file
 
   before_save :set_status, only: [:update, :create]
-  after_save :update_version_status, if: :status_changed?
+  after_commit :update_version_status, if: Proc.new { |af| af.previous_changes.key?(:status) }
   after_destroy :update_version_status
 
   before_validation do

--- a/app/models/audio_file.rb
+++ b/app/models/audio_file.rb
@@ -21,7 +21,7 @@ class AudioFile < BaseModel
   fixerable_upload :upload, :file
 
   before_save :set_status, only: [:update, :create]
-  after_commit :update_version_status, if: Proc.new { |af| af.previous_changes.key?(:status) }
+  after_commit :update_version_status
   after_destroy :update_version_status
 
   before_validation do
@@ -43,7 +43,10 @@ class AudioFile < BaseModel
   end
 
   def update_version_status
-    audio_version.try(:save!)
+    return unless audio_version
+    audio_version.with_lock do
+      audio_version.save!
+    end
   end
 
   def set_status

--- a/app/models/audio_version.rb
+++ b/app/models/audio_version.rb
@@ -12,7 +12,7 @@ class AudioVersion < BaseModel
   has_many :audio_files, -> { order :position }, dependent: :destroy
 
   before_save :set_status, only: [:update, :create]
-  after_save :update_story_status, if: :status_changed?
+  after_commit :update_story_status, if: Proc.new { |av| af.previous_changes.key?(:status) }
   after_destroy :update_story_status
 
   acts_as_paranoid

--- a/app/models/audio_version.rb
+++ b/app/models/audio_version.rb
@@ -12,7 +12,7 @@ class AudioVersion < BaseModel
   has_many :audio_files, -> { order :position }, dependent: :destroy
 
   before_save :set_status, only: [:update, :create]
-  after_commit :update_story_status, if: Proc.new { |av| af.previous_changes.key?(:status) }
+  after_commit :update_story_status, if: Proc.new { |av| av.previous_changes.key?(:status) }
   after_destroy :update_story_status
 
   acts_as_paranoid

--- a/app/models/audio_version.rb
+++ b/app/models/audio_version.rb
@@ -12,7 +12,7 @@ class AudioVersion < BaseModel
   has_many :audio_files, -> { order :position }, dependent: :destroy
 
   before_save :set_status, only: [:update, :create]
-  after_commit :update_story_status, if: Proc.new { |av| av.previous_changes.key?(:status) }
+  after_commit :update_story_status
   after_destroy :update_story_status
 
   acts_as_paranoid
@@ -42,7 +42,10 @@ class AudioVersion < BaseModel
   end
 
   def update_story_status
-    story.try(:save!)
+    return unless story
+    story.with_lock do
+      story.save!
+    end
   end
 
   def set_status

--- a/test/models/story_test.rb
+++ b/test/models/story_test.rb
@@ -38,6 +38,8 @@ describe Story do
       af.update_column(:status, 'mp3s created')
 
       af.save!
+      af.run_callbacks(:commit)
+      av.run_callbacks(:commit)
 
       [af, av, story].each { |m| m.reload.status.must_equal 'complete' }
     end
@@ -45,18 +47,17 @@ describe Story do
     it 'changes to valid when invalid audio file destroyed' do
       av = story.audio_versions(true).first
       af = av.audio_files(true).first
-
-      af.status.must_equal 'complete'
-      av.status.must_equal 'complete'
-      story.status.must_equal 'complete'
+      af.run_callbacks(:commit)
+      av.run_callbacks(:commit)
+      [af, av, story].each { |m| m.reload.status.must_equal 'complete' }
 
       af.update_columns(status: 'invalid', status_message: 'bad')
-      af.run_callbacks(:save)
-
+      af.run_callbacks(:commit)
+      av.run_callbacks(:commit)
       [af, av, story].each { |m| m.reload.status.must_equal 'invalid' }
 
       af.destroy
-
+      av.run_callbacks(:commit)
       [av, story].each { |m| m.reload.status.must_equal 'complete' }
     end
   end


### PR DESCRIPTION
- [x] Change `after_save` to `after_commit`
- [x] Lock the story and version records so multiple changes can't happen simultaneously