### PR TITLE
Filter templates by distribution

### DIFF
--- a/app/controllers/api/audio_version_templates_controller.rb
+++ b/app/controllers/api/audio_version_templates_controller.rb
@@ -8,8 +8,8 @@ class Api::AudioVersionTemplatesController < Api::BaseController
   sort_params default: { label: :asc }, allowed: [:id, :label]
 
   def filtered(arel)
-    if params['distribution_id']
-      distribution_id = params.delete('distribution_id')
+    if params[:distribution_id]
+      distribution_id = params.delete(:distribution_id)
       arel = arel.joins(:distribution_templates)
       arel = arel.where('distribution_templates.distribution_id = ?', distribution_id)
     end

--- a/test/controllers/api/audio_version_templates_controller_test.rb
+++ b/test/controllers/api/audio_version_templates_controller_test.rb
@@ -38,4 +38,13 @@ describe Api::AudioVersionTemplatesController do
     ids.must_equal [template2.id]
     assert_response :success
   end
+
+  it 'should list by distribution' do
+    distribution_template.id.wont_be_nil
+    get(:index, api_request_opts(distribution_id: 'anything'))
+    body = JSON.parse(response.body)
+    ids = body['_embedded']['prx:items'].map { |item| item['id'] }
+    ids.must_equal []
+    assert_response :success
+  end
 end


### PR DESCRIPTION
- [x] Change to use a symbol to access params, but honestly it shouldn't matter (should have indifferent access)
- [x] Add a test for if the distribution id does not exist