### PR TITLE
Correctly remember distribution_id param for cache key and query

### DIFF
--- a/app/controllers/api/audio_version_templates_controller.rb
+++ b/app/controllers/api/audio_version_templates_controller.rb
@@ -7,12 +7,16 @@ class Api::AudioVersionTemplatesController < Api::BaseController
 
   sort_params default: { label: :asc }, allowed: [:id, :label]
 
+  attr_accessor :distribution_id
+
   def filtered(arel)
-    if params[:distribution_id]
-      distribution_id = params.delete(:distribution_id)
+    self.distribution_id = params.delete(:distribution_id).to_i if params[:distribution_id]
+
+    if distribution_id
       arel = arel.joins(:distribution_templates)
       arel = arel.where('distribution_templates.distribution_id = ?', distribution_id)
     end
+
     super(arel)
   end
 end


### PR DESCRIPTION
The param was being deleted, so it was not there to be correctly used in the query if it was already used in the cache key