### PR TITLE
Strip tags on import

### DIFF
--- a/app/models/podcast_import.rb
+++ b/app/models/podcast_import.rb
@@ -250,7 +250,7 @@ class PodcastImport < BaseModel
       title: clean_string(entry[:title]),
       short_description: clean_string(short_desc(entry)),
       description_html: entry_description(entry),
-      tags: Array(entry[:categories]).map(&:strip),
+      tags: Array(entry[:categories]).map(&:strip).reject(&:blank?),
       published_at: entry[:published]
     )
 

--- a/app/models/podcast_import.rb
+++ b/app/models/podcast_import.rb
@@ -250,7 +250,7 @@ class PodcastImport < BaseModel
       title: clean_string(entry[:title]),
       short_description: clean_string(short_desc(entry)),
       description_html: entry_description(entry),
-      tags: entry[:categories],
+      tags: Array(entry[:categories]).map(&:strip),
       published_at: entry[:published]
     )
 

--- a/test/fixtures/transistor_two.xml
+++ b/test/fixtures/transistor_two.xml
@@ -66,6 +66,8 @@
 			<category>
 				<![CDATA[architecture]]>
 			</category>
+			<category>
+			</category>
 			<description>For the next few episodes, we’re featuring the Smithsonian’s new series, Sidedoor, about where science, art, history, and humanity unexpectedly overlap — just like in their museums. In this episode: an astronomer has turned the night sky into a symphony; an architecture firm has radically re-thought police stations; and an audiophile builds a successful record … &lt;a href="https://transistor.prx.org/2017/01/sidedoor-from-the-smithsonian-shake-it-up/" class="more-link"&gt;Continue reading &lt;span class="screen-reader-text"&gt;Sidedoor from the Smithsonian: Shake it Up&lt;/span&gt;&lt;/a&gt;</description>
 			<content:encoded>
 				<![CDATA[<p>For the next few episodes, we’re featuring the Smithsonian’s new series, <em>Sidedoor</em>, about where science, art, history, and humanity unexpectedly overlap — just like in their museums.</p>

--- a/test/fixtures/transistor_two.xml
+++ b/test/fixtures/transistor_two.xml
@@ -57,7 +57,15 @@
 			<comments>https://transistor.prx.org/2017/01/sidedoor-from-the-smithsonian-shake-it-up/#respond</comments>
 			<wfw:commentRss>https://transistor.prx.org/2017/01/sidedoor-from-the-smithsonian-shake-it-up/feed/</wfw:commentRss>
 			<slash:comments>0</slash:comments>
-			<category><![CDATA[Indie Features]]></category>
+			<category>
+				<![CDATA[Indie Features]]>
+			</category>
+			<category>
+				<![CDATA[science]]>
+			</category>
+			<category>
+				<![CDATA[architecture]]>
+			</category>
 			<description>For the next few episodes, we’re featuring the Smithsonian’s new series, Sidedoor, about where science, art, history, and humanity unexpectedly overlap — just like in their museums. In this episode: an astronomer has turned the night sky into a symphony; an architecture firm has radically re-thought police stations; and an audiophile builds a successful record … &lt;a href="https://transistor.prx.org/2017/01/sidedoor-from-the-smithsonian-shake-it-up/" class="more-link"&gt;Continue reading &lt;span class="screen-reader-text"&gt;Sidedoor from the Smithsonian: Shake it Up&lt;/span&gt;&lt;/a&gt;</description>
 			<content:encoded>
 				<![CDATA[<p>For the next few episodes, we’re featuring the Smithsonian’s new series, <em>Sidedoor</em>, about where science, art, history, and humanity unexpectedly overlap — just like in their museums.</p>

--- a/test/models/podcast_import_test.rb
+++ b/test/models/podcast_import_test.rb
@@ -84,8 +84,8 @@ describe PodcastImport do
     f.description.wont_match /<script/
     f.description.wont_match /<iframe/
     f.description.wont_match /feedburner/
-    f.tags.must_equal ['Indie Features', 'science', 'architecture']
-    f.tags.wont_include '\n'
+    f.tags.must_include 'Indie Features'
+    f.tags.each {|tag| tag.wont_match /\n/}
     f.tags.wont_include '\t'
     f.account_id.wont_be_nil
     f.creator_id.wont_be_nil

--- a/test/models/podcast_import_test.rb
+++ b/test/models/podcast_import_test.rb
@@ -84,6 +84,9 @@ describe PodcastImport do
     f.description.wont_match /<script/
     f.description.wont_match /<iframe/
     f.description.wont_match /feedburner/
+    f.tags.must_equal ['Indie Features', 'science', 'architecture']
+    f.tags.wont_include '\n'
+    f.tags.wont_include '\t'
     f.account_id.wont_be_nil
     f.creator_id.wont_be_nil
     f.series_id.wont_be_nil

--- a/test/models/podcast_import_test.rb
+++ b/test/models/podcast_import_test.rb
@@ -85,7 +85,10 @@ describe PodcastImport do
     f.description.wont_match /<iframe/
     f.description.wont_match /feedburner/
     f.tags.must_include 'Indie Features'
-    f.tags.each {|tag| tag.wont_match /\n/}
+    f.tags.each do |tag|
+      tag.wont_match /\n/
+      tag.wont_be :blank?
+    end
     f.tags.wont_include '\t'
     f.account_id.wont_be_nil
     f.creator_id.wont_be_nil


### PR DESCRIPTION
When a feed had categories like so: 
```RSS
<category>
  Something
</category>
<category>
  Something else
</category>
```
the tags were getting saved with newlines. Which looks pretty weird on Publish! 