### PR TITLE
default to title if missing every description field

### DIFF
--- a/app/models/podcast_import.rb
+++ b/app/models/podcast_import.rb
@@ -239,7 +239,7 @@ class PodcastImport < BaseModel
   end
 
   def entry_description_attribute(entry)
-    [:content, :itunes_summary, :description].find { |d| !entry[d].blank? }
+    [:content, :itunes_summary, :description, :title].find { |d| !entry[d].blank? }
   end
 
   def create_story(entry, series)

--- a/test/models/podcast_import_test.rb
+++ b/test/models/podcast_import_test.rb
@@ -168,6 +168,14 @@ describe PodcastImport do
       importer.short_desc(feed).must_equal 'Transistor'
     end
 
+    it 'can substitute for a missing description' do
+      item = feed.entries.first
+      item.description = nil
+      item.itunes_summary = nil
+      item.content = nil
+      importer.entry_description(item).wont_be :blank?
+    end
+
     it 'can remove feedburner tracking pixels' do
       desc = 'desc <img src="http://feeds.feedburner.com/~r/transistor_stem/~4/NHnLCsjtdQM" ' +
              'height="1" width="1" alt=""/>'


### PR DESCRIPTION
Discovered on most recent import that if an item in the feed has no description, itunes summary, OR content, we'll error out with `NameError: @ is not allowed as an instance variable name`
Now, we'll just use the title as an absolute last resort.