### PR TITLE
Use a specific cert file path for excon requests

### DIFF
--- a/config/initializers/excon.rb
+++ b/config/initializers/excon.rb
@@ -1,3 +1,4 @@
 require 'excon'
 
 Excon.defaults[:omit_default_port] = true
+Excon.defaults[:ssl_ca_path] = ENV['CERT_PATH'] if ENV['CERT_PATH']


### PR DESCRIPTION
I have the env var `CERT_FILE` set in production already.