### PR TITLE
Prefer "explicit" to "yes" on import to match Publish

### DIFF
--- a/app/models/podcast_import.rb
+++ b/app/models/podcast_import.rb
@@ -364,8 +364,8 @@ class PodcastImport < BaseModel
   def explicit(str)
     return nil if str.blank?
     explicit = clean_string(str).downcase
-    if %w(true explicit).include?(explicit)
-      explicit = 'yes'
+    if %w(true yes).include?(explicit)
+      explicit = 'explicit'
     elsif %w(no false).include?(explicit)
       explicit = 'clean'
     end

--- a/test/models/podcast_import_test.rb
+++ b/test/models/podcast_import_test.rb
@@ -193,7 +193,7 @@ describe PodcastImport do
     end
 
     it 'can interpret explicit values' do
-      %w(Yes TRUE Explicit).each { |x| importer.explicit(x).must_equal 'yes' }
+      %w(Yes TRUE Explicit).each { |x| importer.explicit(x).must_equal 'explicit' }
       %w(NO False Clean).each { |x| importer.explicit(x).must_equal 'clean' }
       %w(UnClean y N 1 0).each { |x| importer.explicit(x).must_equal x.downcase }
     end


### PR DESCRIPTION
Publish expects iTunes Explicit value to be “explicit” or “clean”. So we should set that value accordingly on import (currently we’re setting to either “yes” or “clean”). 