### PR TITLE
Handle when public asset has no file name extension

### DIFF
--- a/app/models/concerns/public_asset.rb
+++ b/app/models/concerns/public_asset.rb
@@ -24,6 +24,11 @@ module PublicAsset
     n = o[:name]
     x = o[:extension]
 
+    if x.blank? && n.include?('.')
+      n = get_basename(o[:name])
+      x = get_extension(o[:name])
+    end
+
     str = [t,e,u,c,i,v,n,x].join("|")
 
     OpenSSL::Digest::MD5.hexdigest(str)
@@ -78,12 +83,18 @@ module PublicAsset
   end
 
   def filename_base
-    fn = public_asset_filename || 'asset'
+    get_basename(public_asset_filename || 'asset')
+  end
+
+  def get_basename(fn)
     File.basename(fn, File.extname(fn))
   end
 
   def filename_extension
-    fn = public_asset_filename || ''
+    get_extension(public_asset_filename || '')
+  end
+
+  def get_extension(fn)
     ext = File.extname(fn)
     (!ext.blank? && (ext.first == '.')) ? ext[1..-1] : ''
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,11 +103,10 @@ PRX::Application.routes.draw do
   match '/api', via: [:get], to: redirect("/api/v1")
   match '/', via: [:get], to: redirect("/api/v1")
 
-  public_asset = 'pub/:token/:expires/:use/:class/:id/:version/:name.:extension'
+  public_asset = 'pub/:token/:expires/:use/:class/:id/:version/:name(.:extension)'
   public_name = { name: /[^\/]+/ }
   match public_asset, to: 'public_assets#show_head', via: :head, constraints: public_name
   match public_asset, to: 'public_assets#show_options', via: :options, constraints: public_name
   match public_asset, to: 'public_assets#show', via: :get, constraints: public_name,
                       as: :public_asset
-
 end

--- a/test/controllers/public_assets_controller_test.rb
+++ b/test/controllers/public_assets_controller_test.rb
@@ -4,6 +4,16 @@ describe PublicAssetsController do
 
   let(:audio_file) { FactoryGirl.create(:audio_file) }
 
+  it 'should recognize an asset path' do
+    path = "https://cms.prx.org/pub/key/0/web/audio_file/123/original/stream.mp3"
+    options = Rails.application.routes.recognize_path path
+    options[:name].must_equal 'stream.mp3'
+
+    path = "https://cms.prx.org/pub/key/0/web/audio_file/123/original/stream"
+    options = Rails.application.routes.recognize_path path
+    options[:name].must_equal 'stream'
+  end
+
   it 'should get unauthorized for invalid request' do
     get(:show,
       {


### PR DESCRIPTION
Found this problem importing `/stream` urls from soundcloud.
Need to handle when there is no extension, and so make that an optional part of the route matcher.

However, for incoming requests, parse out the extension as there is not a good regex way to have the router differentiate between the extension and the base filename.