### PR TITLE
Filter out 4 byte utf 8 before saving import entry

### DIFF
--- a/app/models/concerns/import_utils.rb
+++ b/app/models/concerns/import_utils.rb
@@ -62,7 +62,11 @@ module ImportUtils
     return nil if text.blank?
     result = remove_feedburner_tracker(text)
     result = sanitize_html(result)
-    result.each_char.select { |char| char.bytesize < 4 }.join('')
+    remove_utf8_4byte(result)
+  end
+
+  def remove_utf8_4byte(str)
+    str.each_char.select { |char| char.bytesize < 4 }.join('')
   end
 
   def remove_feedburner_tracker(str)

--- a/app/models/podcast_import.rb
+++ b/app/models/podcast_import.rb
@@ -87,12 +87,19 @@ class PodcastImport < BaseModel
 
   def create_or_update_episode_imports!
     feed.entries.map do |entry|
-      entry_hash = entry.to_h.with_indifferent_access
+      entry_hash = feed_entry_to_hash(entry)
       audio_files = entry_audio_files(entry_hash)
       get_or_create_template(audio_files[:files].count)
       episode_import = create_or_update_episode_import!(entry_hash, audio_files)
       episode_import.import_later
     end
+  end
+
+  def feed_entry_to_hash(entry)
+    entry
+      .to_h
+      .with_indifferent_access
+      .transform_values { |x| x.is_a?(String) ? remove_utf8_4byte(x) : x }
   end
 
   def create_or_update_episode_import!(entry, audio_files)

--- a/test/fixtures/transistor_two.xml
+++ b/test/fixtures/transistor_two.xml
@@ -105,7 +105,7 @@
 			<category><![CDATA[Indie Features]]></category>
 			<description>For the next few episodes, we’re featuring the Smithsonian’s new series, Sidedoor, about where science, art, history, and humanity unexpectedly overlap — just like in their museums. In this episode: an astronomer has turned the night sky
 				into a symphony; an architecture firm has radically re-thought police stations; and an audiophile builds a successful record … &lt;a href="https://transistor.prx.org/2017/01/sidedoor-from-the-smithsonian-shake-it-up/" class="more-link"&gt;Continue
-				reading &lt;span class="screen-reader-text"&gt;Sidedoor from the Smithsonian: Shake it Up&lt;/span&gt;&lt;/a&gt;</description>
+				reading &lt;span class="screen-reader-text"&gt;Sidedoor from the Smithsonian: Shake it Up&lt;/span&gt;&lt;/a&gt;🌈</description>
 			<content:encoded>
 				<![CDATA[<p>For the next few episodes, we’re featuring the Smithsonian’s new series, <em>Sidedoor</em>, about where science, art, history, and humanity unexpectedly overlap — just like in their museums.</p>
 <p>In this episode: an astronomer has turned the night sky into a symphony; an architecture firm has radically re-thought police stations; and an audiophile builds a successful record company on under-appreciated sounds.</p>


### PR DESCRIPTION
Prior changes correctly filter out values saved to story models, but did not filter out the 4byte values before saving serialized hash of feed entry to the import