### PR TITLE
Update around_perform syntax for ApplicationJob

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,15 +1,14 @@
 require 'newrelic_rpm'
 
 class ApplicationJob < ActiveJob::Base
-  around_perform :use_db_pool
 
   rescue_from(StandardError) do |e|
     NewRelic::Agent.notice_error(e)
   end
 
-  def use_db_pool(job)
+  around_perform do |job, block|
     ActiveRecord::Base.connection_pool.with_connection do
-      yield
+      block.call
     end
   end
 end


### PR DESCRIPTION
copying syntax from https://github.com/PRX/feeder.prx.org/pull/283 (though we haven't yet seen the similar error -- 0 arguments for 1 -- pop up for cms yet) 