### PR TITLE
Apply same description logic as episode_import model

### DIFF
--- a/lib/feeder_importer.rb
+++ b/lib/feeder_importer.rb
@@ -213,7 +213,7 @@ class FeederImporter
   end
 
   def episode_description(episode)
-    attrname = %i(:content :summary :description :subtitle :title).find { |d| !episode[d].blank? }
+    attrname = %i(content summary description subtitle title).find { |d| !episode[d].blank? }
     episode[attrname]
   end
 

--- a/lib/feeder_importer.rb
+++ b/lib/feeder_importer.rb
@@ -212,6 +212,11 @@ class FeederImporter
     episode.contains_video? ? video_template : audio_template
   end
 
+  def episode_description(episode)
+    attr = [:content, :summary, :description, :subtitle, :title].find { |d| !episode[d].blank? }
+    episode[attr]
+  end
+
   def create_story(episode)
     # puts "episode.categories: #{episode.categories.inspect}"
     attrs = {
@@ -220,7 +225,7 @@ class FeederImporter
       account_id: account_id,
       title: episode.title,
       short_description: episode.subtitle,
-      description_html: episode.description,
+      description_html: episode_description(episode),
       tags: episode.categories,
       published_at: episode.published_at,
       released_at: episode.published_at,

--- a/lib/feeder_importer.rb
+++ b/lib/feeder_importer.rb
@@ -213,8 +213,8 @@ class FeederImporter
   end
 
   def episode_description(episode)
-    attr = [:content, :summary, :description, :subtitle, :title].find { |d| !episode[d].blank? }
-    episode[attr]
+    attrname = %i(:content :summary :description :subtitle :title).find { |d| !episode[d].blank? }
+    episode[attrname]
   end
 
   def create_story(episode)

--- a/test/lib/feeder_importer_test.rb
+++ b/test/lib/feeder_importer_test.rb
@@ -61,6 +61,9 @@ describe FeederImporter do
     now = Time.now
     episode.published_at = now
 
+    # tweek description so we verify we get content
+    episode.description = 'this is the description'
+
     story = importer.create_story(episode)
     story.wont_be_nil
 
@@ -70,7 +73,8 @@ describe FeederImporter do
 
     story.title.must_equal episode.title
     story.short_description.must_equal episode.subtitle
-    story.description_html[0..32].must_equal episode.description[0..32]
+    story.description_html[0..32].must_equal episode.content[0..32]
+    story.description_html[0..32].wont_equal episode.description[0..32]
     story.tags.must_equal episode.categories
     story.published_at.must_equal now
     story.released_at.must_equal now

--- a/test/lib/feeder_importer_test.rb
+++ b/test/lib/feeder_importer_test.rb
@@ -61,7 +61,7 @@ describe FeederImporter do
     now = Time.now
     episode.published_at = now
 
-    # tweek description so we verify we get content
+    # tweak description so we verify we get content
     episode.description = 'this is the description'
 
     story = importer.create_story(episode)


### PR DESCRIPTION
The `EpisodeImport` model uses an array of "description" fields to populate the Episode.description on import. Apply the same logic to the `FeederImporter`.