### PR TITLE
Add default account link

### DIFF
--- a/app/representers/api/user_representer.rb
+++ b/app/representers/api/user_representer.rb
@@ -6,6 +6,13 @@ class Api::UserRepresenter < Api::BaseRepresenter
   property :last_name
   property :login
 
+  link :default_account do
+    {
+      href: api_account_path(represented.default_account)
+    }
+  end
+  embed :default_account, decorator: Api::Min::AccountRepresenter, zoom: false
+
   link :accounts do
     {
       href: "#{api_user_accounts_path(represented)}#{index_url_params}",

--- a/test/representers/api/user_representer_test.rb
+++ b/test/representers/api/user_representer_test.rb
@@ -18,4 +18,8 @@ describe Api::UserRepresenter do
     json['id'].must_equal user.id
   end
 
+  it 'includes the default account' do
+    json['_links']['prx:default-account']['href'].must_match /accounts\/#{user.default_account.id}/
+  end
+
 end


### PR DESCRIPTION
Need some way to get from the user to their ~individual~ default account.  (Which isn't included under `/users/1234/accounts`).