### PR TITLE
Add Makefile, ignore my-docker-compose.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ pickle-email-*.html
 
 # Ignore .capistrano config
 .capistrano
+
+# local docker compose config
+my-docker-compose.yml

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+DOCKER_COMPOSE_FILE := my-docker-compose.yml
+
+all: build startdb setup
+
+run:
+	docker-compose -f ${DOCKER_COMPOSE_FILE} up
+
+setup:
+	docker-compose -f ${DOCKER_COMPOSE_FILE} run cms setup
+
+startdb:
+	docker-compose -f ${DOCKER_COMPOSE_FILE} start db
+
+build:
+	docker-compose -f ${DOCKER_COMPOSE_FILE} build
+
+buildclean:
+	docker-compose -f ${DOCKER_COMPOSE_FILE} build --no-cache
+
+test: clean
+	docker-compose -f ${DOCKER_COMPOSE_FILE} run cms testsetup test
+
+check:
+	rubocop
+
+clean:
+	sudo rm -rf log/*log && chmod 777 log
+	sudo rm -rf tmp/ && mkdir tmp && chmod -R 777 tmp
+	sudo rm -rf coverage/ && mkdir coverage && chmod 777 coverage
+
+LOCAL_POSTGRES_USER := ${USER}
+onetest: clean
+	FEEDER_DB_DATABASE=feeder_test FEEDER_DB_USER=${LOCAL_POSTGRES_USER} FEEDER_DB_HOST=/var/run/postgresql bundle exec rake test RAILS_ENV=test TESTOPTS='--name /${TESTNAME}/'
+
+stop:
+	docker-compose -f ${DOCKER_COMPOSE_FILE} stop
+
+console:
+	docker-compose -f ${DOCKER_COMPOSE_FILE} run cms console
+
+
+.PHONY: test clean check all setup startdb build stop


### PR DESCRIPTION
I've been using this Makefile locally for several months to help ease my cognitive overload moving between Rails and Angular-based repos.

The `my-docker-compose.yml` file is from:
```bash
% cp docker-compose.yml my-docker-compose.yml
```
and then customized if I want to run an app on a different host port.

```diff
--- docker-compose.yml	2018-04-26 18:15:50.587152772 -0500
+++ my-docker-compose.yml	2018-04-24 14:42:36.376435969 -0500
@@ -7,7 +7,7 @@
   links:
    - db
   ports:
-    - 3000:3000
+    - 4205:3000
   command: web
   environment:
     VIRTUAL_HOST: id.prx.docker
```