### PR TITLE
HOLD Feature/validate image dimensions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -331,7 +331,7 @@ GEM
     multi_json (1.12.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
-    mysql2 (0.4.5)
+    mysql2 (0.4.10)
     nenv (0.3.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)

--- a/app/models/concerns/validity_flag.rb
+++ b/app/models/concerns/validity_flag.rb
@@ -6,6 +6,7 @@ module ValidityFlag
   NOTFOUND         = 'not found'.freeze
   VALID            = 'valid'.freeze
   INVALID          = 'invalid'.freeze
+  INVALID_IMAGE_SIZE = 'invalid_image_size'.freeze
   FAILED           = 'failed'.freeze
   COMPLETE         = 'complete'.freeze
   VALIDATING       = 'validating'.freeze

--- a/app/representers/api/image_representer.rb
+++ b/app/representers/api/image_representer.rb
@@ -16,6 +16,7 @@ class Api::ImageRepresenter < Api::BaseRepresenter
   property :credit
   property :status, writeable: false
   property :purpose
+  property :dimension_errors
 
   # provide an accessible url to the image media file for upload
   property :upload, readable: false

--- a/app/workers/image_callback_worker.rb
+++ b/app/workers/image_callback_worker.rb
@@ -24,6 +24,8 @@ class ImageCallbackWorker
       image.status = INVALID
     elsif !job['resized']
       image.status = FAILED
+    elsif image.invalid_dimensions?
+      image.status = INVALID_IMAGE_SIZE
     else
       image.status = COMPLETE
     end

--- a/test/factories/series_image_factory.rb
+++ b/test/factories/series_image_factory.rb
@@ -3,6 +3,8 @@ FactoryGirl.define do
 
     series
     purpose 'profile'
+    height 1400
+    width 1400
 
     after(:create) { |af| af.update_file!('test.png') }
 

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -20,4 +20,72 @@ describe Image do
     TestImage.new(status: Image::COMPLETE).must_be :fixerable_final?
     TestImage.new(status: Image::FAILED).wont_be :fixerable_final?
   end
+
+  describe '#square?' do
+    it 'is not square if dims are missing' do
+      image.height.must_be_nil
+      image.width.must_be_nil
+      image.square?.must_equal false
+    end
+
+    it 'is not square if dims are unequal' do
+      image.height = 1
+      image.width = 2
+      image.square?.must_equal false
+    end
+
+    it 'is square if dims equal' do
+      image.height = 1
+      image.width = 1
+      image.square?.must_equal true
+    end
+  end
+
+  describe '#bounded?' do
+    it 'is not bounded if dims are missing' do
+      image.height.must_be_nil
+      image.width.must_be_nil
+      image.bounded?(99, 100).must_equal false
+    end
+
+    it 'is bounded if the height and width are within pixel range' do
+      image.height = 100
+      image.width = 100
+      image.bounded?(99, 100).must_equal true
+    end
+
+    it 'is not bounded if one an image dimension is outside the range' do
+      image.height = 100
+      image.width = 98
+      image.bounded?(99, 100).must_equal false
+    end
+  end
+
+  describe '#dimension_errors' do
+    before do
+      image.purpose = Image::THUMBNAIL
+    end
+
+    it 'has invalid dimensions if there are dimension errors' do
+      image.square?.must_equal false
+      image.dimension_errors.count.must_equal 2
+      image.invalid_dimensions?.must_equal true
+    end
+
+    it 'creates a list of error messages if there are dimension errors' do
+      # not square or bounded for thumbnail
+      image.height = 1000
+      image.width = 1500
+
+      image.dimension_errors.count.must_equal 2
+      image.dimension_errors.full_messages.first.must_equal 'Image must be square.'
+      image.dimension_errors.full_messages.second.must_equal 'Image dimensions 1500x1000 must be less than 300 pixels.'
+    end
+
+    it 'sets an appropriate error message if there are no dimensions' do
+      image.dimension_errors.count.must_equal 2
+      image.dimension_errors.full_messages.must_include 'Image dimensions must be less than 300 pixels.'
+    end
+  end
+
 end


### PR DESCRIPTION
Solution for #333.

This PR sets up a new set of validations on images.  After the image is processed by the  cms-image-lambda service, in the image callback worker we calculate some new validation properties.  As laid out in #333, this uses the image's `purpose` flag as a parameter to ensure the image is square and is of proper dimension.  Lastly, this modifies the image representer to expose the dimension validation errors as a JSON object. 