### PR TITLE
Feature/upgrade docker compose yml

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -30,7 +30,6 @@ makara: &makara
 
 development:
   <<: *default
-  database: cms_development
 
 test:
   <<: *default

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -56,3 +56,5 @@ services:
       - esdata1:/usr/share/elasticsearch/data
     ports:
       - 9200:9200
+volumes:
+  esdata1:

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -5,6 +5,7 @@ services:
     links:
       - db
       - pg
+      - elasticsearch
     ports:
       - 3000:3000
     command: test
@@ -43,6 +44,7 @@ services:
       - ./test/db/:/docker-entrypoint-initdb.d/
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.3.0
+    container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -1,57 +1,58 @@
-cms:
-  build: .
-  links:
-    - db
-    - pg
-    - elasticsearch
-  ports:
-    - 3000:3000
-  command: test
-  env_file:
-    - env-example
-  environment:
-    VIRTUAL_HOST: cms.prx.docker
-    LOCAL_ENV: "true"
-    DB_ENV_MYSQL_USER: root
-    DB_ENV_MYSQL_PASSWORD: password
-    DB_PORT_3306_TCP_ADDR: db
-    DB_PORT_3306_TCP_PORT: "3306"
-    FEEDER_DB_HOST: pg
-    FEEDER_DB_DATABASE: feeder
-    FEEDER_DB_PASSWORD: password
-    ELASTICSEARCH_URL: http://elasticsearch:9200
-db:
-  image: mysql:8.0.12
-  environment:
-    MYSQL_DATABASE: cms_test
-    MYSQL_ROOT_PASSWORD: password
-  ports:
-    - 3306:3306
-  command: mysqld --log_error_verbosity=1 --default-authentication-plugin=mysql_native_password
-pg:
-  image: postgres
-  env_file:
-    - env-example
-  environment:
-    POSTGRES_USER: feeder
-    POSTGRES_PASSWORD: password
-    POSTGRES_DB: feeder
-  ports:
-    - 5432:5432
-  volumes:
-    - ./test/db/:/docker-entrypoint-initdb.d/
-elasticsearch:
-  image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.3.0
-  environment:
-    - cluster.name=docker-cluster
-    - bootstrap.memory_lock=true
-    - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-    - discovery.type=single-node
-  ulimits:
-    memlock:
-      soft: -1
-      hard: -1
-  volumes:
-    - esdata1:/usr/share/elasticsearch/data
-  ports:
-    - 9200:9200
+version: '2'
+services:
+  cms:
+    build: .
+    links:
+      - db
+      - pg
+    ports:
+      - 3000:3000
+    command: test
+    env_file:
+      - env-example
+    environment:
+      VIRTUAL_HOST: cms.prx.docker
+      LOCAL_ENV: "true"
+      DB_ENV_MYSQL_USER: root
+      DB_ENV_MYSQL_PASSWORD: password
+      DB_PORT_3306_TCP_ADDR: db
+      DB_PORT_3306_TCP_PORT: "3306"
+      FEEDER_DB_HOST: pg
+      FEEDER_DB_DATABASE: feeder
+      FEEDER_DB_PASSWORD: password
+      ELASTICSEARCH_URL: http://elasticsearch:9200
+  db:
+    image: mysql:8.0.2
+    environment:
+      MYSQL_DATABASE: cms_test
+      MYSQL_ROOT_PASSWORD: password
+    ports:
+      - 3306:3306
+    command: mysqld --log_error_verbosity=1 --default-authentication-plugin=mysql_native_password
+  pg:
+    image: postgres
+    env_file:
+      - env-example
+    environment:
+      POSTGRES_USER: feeder
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: feeder
+    ports:
+      - 5432:5432
+    volumes:
+      - ./test/db/:/docker-entrypoint-initdb.d/
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.3.0
+    environment:
+      - cluster.name=docker-cluster
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - discovery.type=single-node
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - esdata1:/usr/share/elasticsearch/data
+    ports:
+      - 9200:9200

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - pg
       - elasticsearch
     ports:
-      - "3000:3000"
+      - "3002:3000"
     command: web
     environment:
       VIRTUAL_HOST: cms.prx.docker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,77 +1,81 @@
-cms:
-  build: .
-  volumes:
-    - .:/app
-  env_file:
-    - .env
-  links:
-    - db
-    - pg
-    - elasticsearch
-  ports:
-    - "3000:3000"
-  command: web
-  environment:
-    VIRTUAL_HOST: cms.prx.docker
-    LOCAL_ENV: "true"
-    DB_ENV_MYSQL_USER: root
-    DB_ENV_MYSQL_PASSWORD: password
-    DB_PORT_3306_TCP_ADDR: db
-    DB_PORT_3306_TCP_PORT: "3306"
-    FEEDER_DB_HOST: pg
-    FEEDER_DB_DATABASE: feeder
-    FEEDER_DB_PASSWORD: password
-worker:
-  image: cmsprxorg_cms
-  volumes:
-    - .:/app
-  env_file:
-    - .env
-  environment:
-    LOCAL_ENV: "true"
-    DB_ENV_MYSQL_USER: root
-    DB_ENV_MYSQL_PASSWORD: password
-    DB_PORT_3306_TCP_ADDR: db
-    DB_PORT_3306_TCP_PORT: "3306"
-  links:
-    - db
-    - elasticsearch
-  command: worker
-db:
-  image: mysql:8.0.12
-  env_file:
-    - .env
-  environment:
-    MYSQL_DATABASE: cms_development
-    MYSQL_ROOT_PASSWORD: password
-  expose:
-    - "3306"
-  command: mysqld --log_error_verbosity=1 --default-authentication-plugin=mysql_native_password
-pg:
-  image: postgres
-  env_file:
-    - .env
-  environment:
-    POSTGRES_USER: feeder
-    POSTGRES_PASSWORD: password
-    POSTGRES_DB: feeder
-  expose:
-    - "5432"
-  volumes:
-    - ./test/db/:/docker-entrypoint-initdb.d/
-elasticsearch:
-  image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.3.0
-  container_name: elasticsearch
-  environment:
-    - cluster.name=docker-cluster
-    - bootstrap.memory_lock=true
-    - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-    - discovery.type=single-node
-  ulimits:
-    memlock:
-      soft: -1
-      hard: -1
-  volumes:
-    - esdata1:/usr/share/elasticsearch/data
-  ports:
-    - 9200:9200
+version: '2'
+services:
+  cms:
+    build: .
+    volumes:
+      - .:/app
+    env_file:
+      - .env
+    links:
+      - db
+      - pg
+      - elasticsearch
+    ports:
+      - "3000:3000"
+    command: web
+    environment:
+      VIRTUAL_HOST: cms.prx.docker
+      LOCAL_ENV: "true"
+      DB_ENV_MYSQL_USER: root
+      DB_ENV_MYSQL_PASSWORD: password
+      DB_PORT_3306_TCP_ADDR: db
+      DB_PORT_3306_TCP_PORT: "3306"
+      FEEDER_DB_HOST: pg
+      FEEDER_DB_DATABASE: feeder
+      FEEDER_DB_PASSWORD: password
+  worker:
+    image: cmsprxorg_cms
+    volumes:
+      - .:/app
+    env_file:
+      - .env
+    environment:
+      LOCAL_ENV: "true"
+      DB_ENV_MYSQL_USER: root
+      DB_ENV_MYSQL_PASSWORD: password
+      DB_PORT_3306_TCP_ADDR: db
+      DB_PORT_3306_TCP_PORT: "3306"
+    links:
+      - db
+      - elasticsearch
+    command: worker
+  db:
+    image: mysql:8.0.2
+    env_file:
+      - .env
+    environment:
+      MYSQL_DATABASE: cms_development
+      MYSQL_ROOT_PASSWORD: password
+    expose:
+      - "3306"
+    command: mysqld --log_error_verbosity=1 --default-authentication-plugin=mysql_native_password
+  pg:
+    image: postgres
+    env_file:
+      - .env
+    environment:
+      POSTGRES_USER: feeder
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: feeder
+    expose:
+      - "5432"
+    volumes:
+      - ./test/db/:/docker-entrypoint-initdb.d/
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.3.0
+    container_name: elasticsearch
+    environment:
+      - cluster.name=docker-cluster
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - discovery.type=single-node
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - esdata1:/usr/share/elasticsearch/data
+    ports:
+      - 9200:9200
+volumes:
+  esdata1:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       FEEDER_DB_HOST: pg
       FEEDER_DB_DATABASE: feeder
       FEEDER_DB_PASSWORD: password
+      ELASTICSEARCH_URL: http://elasticsearch:9200
   worker:
     image: cmsprxorg_cms
     volumes:


### PR DESCRIPTION
This PR bumps the major version of the docker-compose.yml file to "2" which allows the addition of a `networks` top-level key.  Based on this updated version I was able to get a dev environment running in a WIP over here, where cms, id, and exchange all talk to each other: https://github.com/PRX/cms.prx.org/compare/feature/cms-id-exchange-shared-database

Also, this changes the port exposed on the docker host from 3000 to 3001.  This allows multiple docker-compose rails apps to boot up at the same time. If this PR is merged, I'll open similar PRs over in id, exchange etc, bumping those ports as well (3002, 3003, etc.). The effect of this should be pretty minimal, since the dinghy proxy hides these ports under the virtual host (e.g. cms.prx.docker)

