### PR TITLE
bump mysql2 gem for compatibility with latest mysql 8.0.12

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,7 +333,7 @@ GEM
     multi_json (1.12.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
-    mysql2 (0.4.5)
+    mysql2 (0.4.10)
     nenv (0.3.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -19,7 +19,7 @@ cms:
     FEEDER_DB_DATABASE: feeder
     FEEDER_DB_PASSWORD: password
 db:
-  image: mysql:8.0.2
+  image: mysql:8.0.12
   environment:
     MYSQL_DATABASE: cms_test
     MYSQL_ROOT_PASSWORD: password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ worker:
     - db
   command: worker
 db:
-  image: mysql:8.0.2
+  image: mysql:8.0.12
   env_file:
     - .env
   environment:


### PR DESCRIPTION
Splitting this out of #425, this allows the mysql gem to compile with mysql 8.0.3

per: https://github.com/brianmario/mysql2/pull/892
