### PR TITLE
test relation presence before serializing

### DIFF
--- a/app/representers/api/episode_import_representer.rb
+++ b/app/representers/api/episode_import_representer.rb
@@ -13,10 +13,16 @@ class Api::EpisodeImportRepresenter < Api::BaseRepresenter
     api_authorization_podcast_import_episode_import_path(represented.podcast_import, represented)
   end
 
+  def series_title(represented)
+    return nil unless represented.podcast_import.series.present?
+
+    represented.podcast_import.series.title
+  end
+
   link :podcast_import do
     {
       href: api_authorization_podcast_import_path(represented.podcast_import),
-      title: represented.podcast_import.series.title
+      title: series_title(represented)
     } if represented.podcast_import_id
   end
   embed :series, class: Series, decorator: Api::Min::SeriesRepresenter, zoom: false

--- a/app/representers/api/podcast_import_representer.rb
+++ b/app/representers/api/podcast_import_representer.rb
@@ -24,7 +24,7 @@ class Api::PodcastImportRepresenter < Api::BaseRepresenter
     {
       href: api_series_path(represented.series),
       title: represented.series.title
-    } if represented.series_id
+    } if represented.series
   end
   embed :series, class: Series, decorator: Api::Min::SeriesRepresenter
 

--- a/test/representers/api/podcast_import_repesenter_test.rb
+++ b/test/representers/api/podcast_import_repesenter_test.rb
@@ -11,6 +11,12 @@ describe Api::PodcastImportRepresenter do
     json['_links'][name] ? json['_links'][name]['href'] : nil
   end
 
+  it 'handles a deleted series' do
+    podcast_import.series.destroy
+    podcast_import.reload
+    get_link_href('prx:series').must_equal nil
+  end
+
   it 'create representer' do
     representer.wont_be_nil
   end


### PR DESCRIPTION
Discovered this in pursuit of https://github.com/PRX/cms.prx.org/issues/437

This PR follows the series relation to ensure that if a user deletes a series, the podcast import representer will still render.