### PR TITLE
Elasticsearch authorization filters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ clean:
 	sudo rm -rf coverage/ && mkdir coverage && chmod 777 coverage
 
 onetest: clean
-	docker-compose -f ${DOCKER_COMPOSE_FILE} run cms -- bundle exec rake test RAILS_ENV=test TEST=${TEST} TESTOPTS='--name /${TESTNAME}/'
+	docker-compose -f ${DOCKER_COMPOSE_FILE} run cms -- bundle exec rake test RAILS_ENV=test TEST=${TEST}
 
 stop:
 	docker-compose -f ${DOCKER_COMPOSE_FILE} stop

--- a/app/controllers/api/auth/stories_controller.rb
+++ b/app/controllers/api/auth/stories_controller.rb
@@ -2,6 +2,7 @@
 
 class Api::Auth::StoriesController < Api::StoriesController
   include ApiAuthenticated
+  include ApiSearchable
 
   api_versions :v1
 
@@ -51,5 +52,25 @@ class Api::Auth::StoriesController < Api::StoriesController
     else
       authorization.token_auth_stories
     end
+  end
+
+  def search
+    @stories = Story.text_search(search_query, search_params, authorization)
+    index
+  end
+
+  def search_params
+    sparams = super
+    sparams['fq'] ||= {}
+    [:network_id, :series_id].each do |p|
+      if params[p]
+        sparams['fq'][p.to_s] = params[p]
+      end
+    end
+    sparams
+  end
+
+  def searchable_fields
+    Story.searchable_fields
   end
 end

--- a/app/controllers/api/auth/stories_controller.rb
+++ b/app/controllers/api/auth/stories_controller.rb
@@ -46,7 +46,8 @@ class Api::Auth::StoriesController < Api::StoriesController
   end
 
   def resources_base
-    # If there is a network_id specified, use that network
+    # If there is a network_id specified, use that network.
+    # The authz is performed in check_user_network().
     @stories ||= if params[:network_id]
       super.published
     else
@@ -55,7 +56,12 @@ class Api::Auth::StoriesController < Api::StoriesController
   end
 
   def search
-    @stories = Story.text_search(search_query, search_params, authorization)
+    # same logic as resources_base above
+    @stories ||= if params[:network_id]
+      Story.text_search(search_query, search_params)
+    else
+      Story.text_search(search_query, search_params, authorization)
+    end
     index
   end
 

--- a/app/controllers/api/auth/stories_controller.rb
+++ b/app/controllers/api/auth/stories_controller.rb
@@ -67,10 +67,10 @@ class Api::Auth::StoriesController < Api::StoriesController
 
   def search_params
     sparams = super
-    sparams['fq'] ||= {}
-    [:network_id, :series_id, :account_id].each do |p|
+    sparams[:fq] ||= {}
+    [:network_id, :series_id, :account_id, :app_version].each do |p|
       if params[p]
-        sparams['fq'][p.to_s] = params[p]
+        sparams[:fq][p.to_s] = params[p]
       end
     end
     sparams

--- a/app/controllers/api/auth/stories_controller.rb
+++ b/app/controllers/api/auth/stories_controller.rb
@@ -62,7 +62,7 @@ class Api::Auth::StoriesController < Api::StoriesController
   def search_params
     sparams = super
     sparams['fq'] ||= {}
-    [:network_id, :series_id].each do |p|
+    [:network_id, :series_id, :account_id].each do |p|
       if params[p]
         sparams['fq'][p.to_s] = params[p]
       end

--- a/app/controllers/api/stories_controller.rb
+++ b/app/controllers/api/stories_controller.rb
@@ -1,6 +1,8 @@
 # encoding: utf-8
 
 class Api::StoriesController < Api::BaseController
+  include ApiSearchable
+
   api_versions :v1
 
   filter_resources_by :series_id, :account_id, :network_id
@@ -14,10 +16,12 @@ class Api::StoriesController < Api::BaseController
   announce_actions :create, :update, :destroy, :publish, :unpublish
 
   def search
-    query = params.permit(:q)[:q]
-    search_params = params.permit(:page, :size, :sort, fields: {}, fq: Story.searchable_fields).to_h
-    @stories = Story.text_search(query, search_params, current_user)
+    @stories = Story.text_search(search_query, search_params)
     index
+  end
+
+  def searchable_fields
+    Story.searchable_fields
   end
 
   def after_create_resource(res)

--- a/app/controllers/concerns/api_searchable.rb
+++ b/app/controllers/concerns/api_searchable.rb
@@ -1,0 +1,19 @@
+# encoding: utf-8
+
+require 'active_support/concern'
+
+module ApiSearchable
+  extend ActiveSupport::Concern
+
+  def search_query
+    params.permit(:q)[:q]
+  end
+
+  def search_params
+    params.permit(:page, :size, :sort, fields: {}, fq: searchable_fields).to_h
+  end
+
+  def searchable_fields
+    []
+  end
+end

--- a/app/controllers/concerns/api_searchable.rb
+++ b/app/controllers/concerns/api_searchable.rb
@@ -10,7 +10,7 @@ module ApiSearchable
   end
 
   def search_params
-    params.permit(:page, :size, :sort, fields: {}, fq: searchable_fields).to_h
+    params.permit(:page, :size, :sort, fq: searchable_fields).to_h
   end
 
   def searchable_fields

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -154,17 +154,17 @@ class Story < BaseModel
 
   scope :public_stories, -> { published.network_visible.series_visible }
 
-  def self.build_query_dsl(query_text, params, current_user)
+  def self.build_query_dsl(query_text, params, authorization)
     StoryQueryBuilder.new(
       query: query_text,
       params: params,
-      current_user: current_user,
+      authorization: authorization,
       fielded_query: params ? params['fq'] : nil,
     ).as_dsl
   end
 
-  def self.text_search(text, params=nil, current_user=nil)
-    search(build_query_dsl(text, params, current_user)).records
+  def self.text_search(text, params=nil, authorization=nil)
+    search(build_query_dsl(text, params, authorization)).records
   end
 
   def self.searchable_fields

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -42,6 +42,7 @@ class Story < BaseModel
       }
     })).tap do |json|
       # any custom index-time munging here
+      json[:published_released_at] = published_at || released_at
     end
   end
 
@@ -159,12 +160,12 @@ class Story < BaseModel
       query: query_text,
       params: params,
       authorization: authorization,
-      fielded_query: params ? params['fq'] : nil,
+      fielded_query: params[:fq],
     ).as_dsl
   end
 
-  def self.text_search(text, params=nil, authorization=nil)
-    search(build_query_dsl(text, params, authorization)).records
+  def self.text_search(text, params={}, authorization=nil)
+    search(build_query_dsl(text, params.with_indifferent_access, authorization)).records
   end
 
   def self.searchable_fields

--- a/app/services/es_query_builder.rb
+++ b/app/services/es_query_builder.rb
@@ -3,12 +3,12 @@ require 'elasticsearch/dsl'
 class ESQueryBuilder
   include Elasticsearch::DSL
 
-  attr_reader :current_user, :params, :query_str, :fields, :fielded_query
+  attr_reader :authorization, :params, :query_str, :fields, :fielded_query
 
   def initialize(args)
     @query_str = args[:query]
     @fields = args[:fields] || default_fields
-    @current_user = args[:current_user]
+    @authorization = args[:authorization]
     @params = args[:params]
     @fielded_query = args[:fielded_query]
 

--- a/app/services/es_query_builder.rb
+++ b/app/services/es_query_builder.rb
@@ -107,6 +107,7 @@ class ESQueryBuilder
   def add_query
     searchdsl = self
     bools = build_filters
+    nils = structured_query.fields_with_nil_values
     @dsl.query = Query.new
     @dsl.query do
       bool do
@@ -123,6 +124,13 @@ class ESQueryBuilder
             # this block magic is to make it easy for subclasses to define Filters
             filter_block = must_filter.instance_variable_get(:@block)
             filter(&filter_block)
+          end
+        end
+        if nils.any?
+          nils.each do |field_name|
+            must_not do
+              exists field: field_name
+            end
           end
         end
       end

--- a/app/services/fielded_search_query.rb
+++ b/app/services/fielded_search_query.rb
@@ -1,6 +1,8 @@
 class FieldedSearchQuery
   attr_reader :field_pairs
 
+  NULL_STRING = 'NULL'
+
   def initialize(field_pairs)
     @field_pairs = field_pairs
   end
@@ -16,13 +18,25 @@ class FieldedSearchQuery
     end
   end
 
+  def fields_with_nil_values
+    nils = []
+    if field_pairs
+      field_pairs.each do |k, v|
+        nils << k if v.nil?
+        nils << k if v == NULL_STRING
+      end
+    end
+    nils
+  end
+
   def to_s
     clauses = []
     if field_pairs
       field_pairs.each do |k, v|
         next if v.nil?
         next if v.blank?
-        next if v == "*"
+        next if v == '*' 
+        next if v == NULL_STRING
         clauses << clause_to_s(k, v)
       end
     end
@@ -35,7 +49,8 @@ class FieldedSearchQuery
       field_pairs.each do |k, v|
         next if v.nil?
         next if v.blank?
-        next if v == "*"
+        next if v == '*'
+        next if v == NULL_STRING
         hash[k] = v
       end
     end

--- a/app/services/story_query_builder.rb
+++ b/app/services/story_query_builder.rb
@@ -17,6 +17,10 @@ class StoryQueryBuilder < ESQueryBuilder
   end
 
   def apply_published_filter?
+    false # TODO
+  end
+
+  def apply_public_filter?
     !apply_authz?
   end
 
@@ -30,20 +34,74 @@ class StoryQueryBuilder < ESQueryBuilder
     if apply_authz?
       bools.push authz_filter
     end
+    if apply_public_filter?
+      bools.push published_filter
+      bools.push v4_or_deleted_at_null_filter
+      bools.push network_visible_filter
+      bools.push series_visible_filter
+    end
     bools
   end
 
   def published_filter
     searchdsl = self
     Filter.new do
-      range published_at: { lte: 'now' }
+      range published_at: { lte: 'now', _name: :published }
     end
   end
 
   def authz_filter
     searchdsl = self
     Filter.new do
-      terms account_id: searchdsl.authorization.token_auth_accounts.try(:ids)
+      terms account_id: { value: searchdsl.authorization.token_auth_accounts.try(:ids), _name: :authz }
+    end
+  end
+
+  def v4_or_deleted_at_null_filter
+    Filter.new do
+      bool do
+        should do
+          bool do
+            must_not do
+              exists field: :deleted_at, _name: :deleted_at_null
+            end
+          end
+        end
+        should do
+          term app_version: { value: 'v4', _name: :app_version_v4 }
+        end
+      end
+    end
+  end
+
+  def network_visible_filter
+    Filter.new do
+      bool do
+        must_not do
+          exists field: :network_only_at, _name: :network_visible
+        end
+      end
+    end
+  end
+
+  def series_visible_filter
+    Filter.new do
+      bool do
+        should do
+          bool do
+            must_not do
+              term 'series.subscription_approval_status' => { value: 'PRX Approved', _name: :prx_series_approved }
+            end
+          end
+        end
+        should do
+          bool do
+            must_not do
+              exists field: 'series.subscriber_only_at', _name: :series_subscriber_only_at
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/app/services/story_query_builder.rb
+++ b/app/services/story_query_builder.rb
@@ -13,7 +13,7 @@ class StoryQueryBuilder < ESQueryBuilder
   end
 
   def apply_authz?
-    authorization
+    authorization.present?
   end
 
   def apply_published_filter?

--- a/app/services/story_query_builder.rb
+++ b/app/services/story_query_builder.rb
@@ -17,11 +17,15 @@ class StoryQueryBuilder < ESQueryBuilder
   end
 
   def apply_published_filter?
-    false # TODO
+    !apply_authz? && has_network_query?
+  end
+
+  def has_network_query?
+    structured_query.present? && structured_query.value_for(:network_id)
   end
 
   def apply_public_filter?
-    !apply_authz?
+    !apply_authz? && !has_network_query?
   end
 
   private
@@ -53,7 +57,7 @@ class StoryQueryBuilder < ESQueryBuilder
   def authz_filter
     searchdsl = self
     Filter.new do
-      terms account_id: { value: searchdsl.authorization.token_auth_accounts.try(:ids), _name: :authz }
+      terms account_id: searchdsl.authorization.token_auth_accounts.try(:ids), _name: :authz
     end
   end
 

--- a/app/services/story_query_builder.rb
+++ b/app/services/story_query_builder.rb
@@ -13,11 +13,11 @@ class StoryQueryBuilder < ESQueryBuilder
   end
 
   def apply_authz?
-    current_user
+    authorization
   end
 
   def apply_published_filter?
-    !apply_authz? # TODO what else should trigger this?
+    !apply_authz?
   end
 
   private
@@ -43,7 +43,7 @@ class StoryQueryBuilder < ESQueryBuilder
   def authz_filter
     searchdsl = self
     Filter.new do
-      term account_id: searchdsl.current_user.account_ids
+      terms account_id: searchdsl.authorization.token_auth_accounts.try(:ids)
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,16 +87,21 @@ PRX::Application.routes.draw do
         end
 
         resources :series, except: [:new, :edit, :create], module: :auth do
-          resources :stories, only: [:index, :create]
+          resources :stories, only: [:index, :create] do
+            get 'search', on: :collection
+          end
         end
 
         resources :stories, except: [:new, :edit, :create], module: :auth do
           post 'publish', on: :member
           post 'unpublish', on: :member
+          get 'search', on: :collection
         end
 
         resources :networks, only: [:index, :show], module: :auth do
-          resources :stories, only: [:index]
+          resources :stories, only: [:index] do
+            get 'search', on: :collection
+          end
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,7 +75,9 @@ PRX::Application.routes.draw do
         resources :audio_files, except: [:new, :edit]
 
         resources :accounts, only: [:index, :show], module: :auth do
-          resources :stories, only: [:index, :create, :update]
+          resources :stories, only: [:index, :create, :update] do
+            get 'search', on: :collection
+          end
         end
 
         resources :podcast_imports, except: [:new, :edit], module: :auth do

--- a/test/controllers/api/auth/stories_controller_test.rb
+++ b/test/controllers/api/auth/stories_controller_test.rb
@@ -6,23 +6,22 @@ describe Api::Auth::StoriesController do
   let (:token) { StubToken.new(account.id, ['member'], user.id) }
   let (:account) { user.individual_account }
   let (:published_story) { account.stories.last }
-  let (:latest_story) { create(:story, account: account, description: 'latest') }
+  let (:latest_story) { create(:story, account: account) }
   let (:unpublished_story) { account.stories.first }
-  let (:random_story) { create(:story, published_at: nil, description: 'random') }
+  let (:random_story) { create(:story, published_at: nil) }
   let (:network) { create(:network, account: account) }
-  let (:network_story) { create(:story, network_id: network.id, network_only_at: Time.now, description: 'network') }
-  let (:v3_story) { create(:story_v3, account: account, description: 'v3_story') }
+  let (:network_story) { create(:story, network_id: network.id, network_only_at: Time.now) }
+  let (:v3_story) { create(:story_v3, account: account) }
   let (:released_story) { create(:story, account: account, released_at: Time.now + 1.day) }
 
   before do
     account.stories.each { |s| s }
-    network.stories.each { |s| s.update!(short_description:"network #{s.id}") }
-    network_story.update!(short_description: "network")
-    v3_story.update!(short_description: "v3 story")
-    unpublished_story.update!(published_at: nil, short_description: 'unpublished')
-    published_story.update_attributes!(published_at: 2.days.ago, short_description: 'published')
-    latest_story.update_attributes!(published_at: 1.day.ago, short_description: 'latest')
-    released_story.update!(published_at: nil, short_description: 'released')
+    network_story.update!(short_description: "network") # to trigger creation/indexing
+    v3_story.update!(short_description: "v3 story") # to trigger creation/indexing
+    unpublished_story.update!(published_at: nil)
+    published_story.update_attributes!(published_at: 2.days.ago)
+    latest_story.update_attributes!(published_at: 1.day.ago)
+    released_story.update!(published_at: nil)
   end
 
   describe 'with a valid token' do

--- a/test/controllers/api/auth/stories_controller_test.rb
+++ b/test/controllers/api/auth/stories_controller_test.rb
@@ -155,7 +155,7 @@ describe Api::Auth::StoriesController do
       it 'filters v4 stories' do
         unpublished_story.must_be :v4?
         v3_story.wont_be :v4?
-        get(:search, api_version: 'v1', format: 'json', fq: { app_version: 'v4' }, q: search_term)
+        get(:search, api_version: 'v1', format: 'json', app_version: 'v4', q: search_term)
         assert_response :success
         assert_not_nil assigns[:stories]
         stories.must_include unpublished_story
@@ -163,7 +163,6 @@ describe Api::Auth::StoriesController do
       end
   
       it 'applies multiple filters, including field:NULL' do
-        puts 'applies multiple filters'
         create(:series, stories: [unpublished_story])
         unpublished_story.series.wont_be_nil
         v3_story.wont_be :v4?
@@ -172,7 +171,7 @@ describe Api::Auth::StoriesController do
         # must re-index because we just updated unpublished_story
         unpublished_story.reindex
   
-        get(:search, api_version: 'v1', fq: { app_version: 'v4', series_id: 'NULL' }, q: search_term)
+        get(:search, api_version: 'v1', app_version: 'v4', series_id: 'NULL', q: search_term)
         assert_response :success
         assert_not_nil assigns[:stories]
         stories.wont_include unpublished_story

--- a/test/controllers/api/auth/stories_controller_test.rb
+++ b/test/controllers/api/auth/stories_controller_test.rb
@@ -244,7 +244,7 @@ describe Api::Auth::StoriesController do
     end
 
     it 'will not search anything' do
-      get(:search, api_version: 'v1', account_id: account.id, q: 'test')
+      get(:search, api_version: 'v1', account_id: account.id, q: search_term)
       assert_response :unauthorized
     end
   end

--- a/test/controllers/api/auth/stories_controller_test.rb
+++ b/test/controllers/api/auth/stories_controller_test.rb
@@ -98,6 +98,94 @@ describe Api::Auth::StoriesController do
       assert_response :unauthorized
     end
 
+    describe 'search' do
+      before do
+        ElasticsearchHelper.new.create_es_index(Story)
+      end
+
+      def stories
+        assigns[:stories].to_a
+      end
+
+      it 'searches stories under their account' do
+        get(:search, q: 'long', api_version: 'v1', account_id: account.id)
+        assert_response :success
+        JSON.parse(response.body)['count'].must_equal account.stories.count
+        account.stories.count.must_be :>, account.public_stories.count
+      end
+  
+      it 'searches stories with unpublished first, recently published after' do
+        published_story.published_at.must_be :<, latest_story.published_at
+        get(:search, api_request_opts(q: 'long', account_id: account.id, sort: 'published_at:desc'))
+        assert_response :success
+        stories[0].wont_be :published?
+        stories[1].wont_be :published?
+        stories[2].published_at.must_be :>, assigns[:stories][3].published_at
+      end
+  
+      it 'searches stories with unpublished first, oldest published after' do
+        published_story.published_at.must_be :<, latest_story.published_at
+        get(:search, api_request_opts(q: 'long', account_id: account.id, sort: 'published_at:asc'))
+        assert_response :success
+        stories[0].wont_be :published?
+        stories[1].wont_be :published?
+        stories[2].published_at.must_be :<, stories[3].published_at
+      end
+  
+      it 'searches stories with coalesced published, released dates' do
+        get(:search, api_request_opts(q: 'long', account_id: account.id, sort: 'published_released_at:desc'))
+        assert_response :success
+        JSON.parse(response.body)['count'].must_equal account.stories.count
+        stories[0].wont_be :published?
+        stories[1].wont_be :published?
+        stories[1].released_at.wont_equal nil
+        stories[1].released_at.must_be :>, assigns[:stories][2].published_at
+        stories[2].published_at.must_be :>, assigns[:stories][3].published_at
+      end
+  
+      it 'searches stories in a network' do
+        puts 'searches stories in a network'
+        puts "network_story=#{network_story.id} network.id=#{network.id}"
+        ElasticsearchHelper.new.create_es_index(Story)
+        get(:search, api_version: 'v1', q: 'long', network_id: network.id)
+        assert_response :success
+        JSON.parse(response.body)['count'].must_equal network.stories.count
+      end
+  
+      it 'filters v4 stories' do
+        unpublished_story.must_be :v4?
+        v3_story.wont_be :v4?
+        get(:search, api_version: 'v1', format: 'json', fq: { app_version: 'v4' }, q: 'long')
+        assert_response :success
+        assert_not_nil assigns[:stories]
+        stories.must_include unpublished_story
+        stories.wont_include v3_story
+      end
+  
+      it 'applies multiple filters' do
+        puts 'applies multiple filters'
+        create(:series, stories: [unpublished_story])
+        unpublished_story.series.wont_be_nil
+        v3_story.wont_be :v4?
+        v3_story.series.must_be_nil
+
+        ElasticsearchHelper.new.create_es_index(Story)
+  
+        get(:search, api_version: 'v1', fq: { app_version: 'v4', series_id: nil }, q: 'long')
+        assert_response :success
+        assert_not_nil assigns[:stories]
+        stories.wont_include unpublished_story
+        stories.wont_include v3_story
+      end
+  
+      it 'searches zero hits for network user access' do
+        other_network = create(:network)
+        get(:search, api_version: 'v1', network_id: other_network.id, q: 'long')
+        assert_response :success
+        JSON.parse(response.body)['count'].must_equal 0
+      end
+    end
+
     it 'shows an unpublished story' do
       get(:show, api_version: 'v1', id: unpublished_story.id)
       assert_response :success
@@ -152,6 +240,11 @@ describe Api::Auth::StoriesController do
 
     it 'will not index you anything' do
       get(:index, api_version: 'v1', account_id: account.id)
+      assert_response :unauthorized
+    end
+
+    it 'will not search anything' do
+      get(:search, api_version: 'v1', account_id: account.id, q: 'test')
       assert_response :unauthorized
     end
   end

--- a/test/services/story_query_builder_test.rb
+++ b/test/services/story_query_builder_test.rb
@@ -1,13 +1,17 @@
 require 'test_helper'
 
 describe StoryQueryBuilder do
-  it "#to_hash with current_user" do
-    user = create(:user)
+  let(:account) { create(:account) }
+  let(:token) { StubToken.new(account.id, ['member'], 456) }
+  let(:authorization) { Authorization.new(token) }
+  let(:unauth_account) { create(:account) }
+
+  it "#to_hash with authorization" do
     dsl = described_class.new(
       params: { from: 1, size: 5, },
       query: 'foo OR Bar',
       fielded_query: { something: '123' },
-      current_user: user,
+      authorization: authorization
     )
     dsl.to_hash.must_equal({
       _source: ["id"],
@@ -24,7 +28,7 @@ describe StoryQueryBuilder do
             },
           ],
           filter: [
-            { term: { account_id: user.account_ids } }
+            { terms: { account_id: [account.id] } }
           ],
         },
       },
@@ -34,7 +38,7 @@ describe StoryQueryBuilder do
     })
   end
 
-  it "#to_hash without current_user" do
+  it "#to_hash without authorization" do
     dsl = described_class.new(
       params: { from: 1, size: 5, },
       query: 'foo OR Bar',

--- a/test/services/story_query_builder_test.rb
+++ b/test/services/story_query_builder_test.rb
@@ -10,7 +10,7 @@ describe StoryQueryBuilder do
     dsl = described_class.new(
       params: { from: 1, size: 5, },
       query: 'foo OR Bar',
-      fielded_query: { something: '123' },
+      fielded_query: { something: '123', maybe: 'NULL', other: nil },
       authorization: authorization
     )
     dsl.to_hash.must_equal({
@@ -30,9 +30,18 @@ describe StoryQueryBuilder do
           filter: [
             { terms: { account_id: [account.id] } }
           ],
+          must_not: [
+            { exists: { field: :maybe } },
+            { exists: { field: :other } },
+          ],
         },
       },
-      sort: [ { published_at: :desc, updated_at: :desc } ],
+      sort: [
+        {
+          published_at: {order: :desc, missing: '_last'},
+          updated_at: {order: :desc, missing: '_last'}
+        }
+      ],
       size: 5,
       from: 1
     })
@@ -63,7 +72,12 @@ describe StoryQueryBuilder do
           ],
         },
       },
-      sort: [ { published_at: :desc, updated_at: :desc } ],
+      sort: [
+        {
+          published_at: {order: :desc, missing: '_last'},
+          updated_at: {order: :desc, missing: '_last'}
+        }
+      ],
       size: 5,
       from: 1
     })
@@ -119,7 +133,7 @@ describe StoryQueryBuilder do
 
   it "#structured_query" do
     dsl = described_class.new(
-      fielded_query: { something: "123" },
+      fielded_query: { something: "123", maybe: 'NULL' },
       query: "foo OR Bar",
     )
     dsl.structured_query.must_be_instance_of FieldedSearchQuery
@@ -128,7 +142,7 @@ describe StoryQueryBuilder do
 
   it "#composite_query_string" do
     dsl = described_class.new(
-      fielded_query: { something: "123" },
+      fielded_query: { something: "123", maybe: 'NULL' },
       query: "foo OR Bar",
     )
     dsl.composite_query_string.must_equal "(foo OR Bar) AND (something:(123))"
@@ -136,7 +150,7 @@ describe StoryQueryBuilder do
 
   it "#humanized_query_string" do
     dsl = described_class.new(
-      fielded_query: { something: "123" },
+      fielded_query: { something: "123", maybe: 'NULL' },
       query: "foo OR Bar",
     )
     dsl.humanized_query_string.must_equal "(foo OR Bar) AND (Something:(123))"

--- a/test/services/story_query_builder_test.rb
+++ b/test/services/story_query_builder_test.rb
@@ -28,7 +28,7 @@ describe StoryQueryBuilder do
             },
           ],
           filter: [
-            { terms: { account_id: { value: [account.id], _name: :authz } } }
+            { terms: { account_id: [account.id], _name: :authz } }
           ],
           must_not: [
             { exists: { field: :maybe } },

--- a/test/services/story_query_builder_test.rb
+++ b/test/services/story_query_builder_test.rb
@@ -28,7 +28,7 @@ describe StoryQueryBuilder do
             },
           ],
           filter: [
-            { terms: { account_id: [account.id] } }
+            { terms: { account_id: { value: [account.id], _name: :authz } } }
           ],
           must_not: [
             { exists: { field: :maybe } },
@@ -68,7 +68,84 @@ describe StoryQueryBuilder do
             },
           ],
           filter: [
-            { range: { published_at: { lte: 'now' } } },
+            {
+              range: {
+                published_at: {
+                  lte: 'now',
+                  _name: :published
+                }
+              }
+            },
+            {
+              bool: {
+                should: [
+                  {
+                    bool: {
+                      must_not: [
+                        {
+                          exists: {
+                            field: :deleted_at,
+                            _name: :deleted_at_null
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    term: {
+                      app_version: {
+                        value: 'v4',
+                        _name: :app_version_v4
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              bool: {
+                must_not: [
+                  {
+                    exists: {
+                      field: :network_only_at,
+                      _name: :network_visible
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              bool: {
+                should: [
+                  {
+                    bool: {
+                      must_not: [
+                        {
+                          term: {
+                            'series.subscription_approval_status' => {
+                              value: 'PRX Approved',
+                              _name: :prx_series_approved
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    bool: {
+                      must_not: [
+                        {
+                          exists: {
+                            field: 'series.subscriber_only_at',
+                            _name: :series_subscriber_only_at
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
           ],
         },
       },


### PR DESCRIPTION
Implements Stories authenticated API filters for authorization based on network or account. These `:search` rules should match the existing rules for the `:index` endpoint, and so the tests have been copied and adapted for the `:search` method.

The following URL parameters are supported for filtering: `:series_id`, `:account_id`, `:network_id` and `:app_version`. The `:app_version` is similar to `:v3` and `:v4` for the `:index` endpoint, and expects values like those (e.g. `app_version=v4`).

To support filtering by NULL values, the special string `NULL` is supported. So you can search for Stories that have an empty description: `fq[description]=NULL` or where the series_id is unassigned `series_id=NULL`.

Note the `fq` param is for "fielded queries" where you want to structurally limit a search by a specific field. You can also do that directly in the `q` (query) param: `q=foo:bar` and `fq[foo]=bar` should search the same way.

Sorting uses the `sort` param. (I think it is plural "sorts" on the `:index` endpoint but ES is singular so I left it singular for that consistency. It can be consistent for our API or for ES but not both.) To get the affect of SQL NULL sorting, special mangling of the sort direction is done to reflect NULL values.

