### PR TITLE
Fix reindexing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,8 +84,9 @@ gem 'newrelic_rpm'
 gem 'capistrano-newrelic'
 
 # elasticsearch
+gem 'elasticsearch-model'
+gem 'elasticsearch-rails'
 gem 'elasticsearch-dsl'
-gem 'elasticsearch-rails-ha'
 
 # dev-only
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,19 +109,11 @@ GEM
     elasticsearch-api (6.1.0)
       multi_json
     elasticsearch-dsl (0.1.5)
-    elasticsearch-indexstager (1.1.3)
-      elasticsearch (~> 6.0)
     elasticsearch-model (5.0.0)
       activesupport (> 3)
       elasticsearch (> 1)
       hashie
     elasticsearch-rails (5.0.2)
-    elasticsearch-rails-ha (1.1.0)
-      ansi
-      elasticsearch-indexstager (~> 1.1.3)
-      elasticsearch-model
-      elasticsearch-rails
-      term-ansicolor
     elasticsearch-transport (6.1.0)
       faraday
       multi_json
@@ -491,8 +483,6 @@ GEM
     sshkit (1.11.4)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    term-ansicolor (1.6.0)
-      tins (~> 1.0)
     test_xml (0.1.8)
       diffy (~> 3.0)
       nokogiri (>= 1.3.2)
@@ -501,7 +491,6 @@ GEM
     timecop (0.9.1)
     timers (4.0.4)
       hitimes
-    tins (1.16.3)
     trollop (2.1.2)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
@@ -542,7 +531,8 @@ DEPENDENCIES
   dalli
   dotenv-rails
   elasticsearch-dsl
-  elasticsearch-rails-ha
+  elasticsearch-model
+  elasticsearch-rails
   event_attribute
   excon
   factory_girl_rails

--- a/Makefile
+++ b/Makefile
@@ -27,20 +27,12 @@ check:
 	rubocop
 
 index: index_series index_stories
-mindex: mindex_series mindex_stories
 
-NPROCS := 2
 index_series:
-	docker-compose -f ${DOCKER_COMPOSE_FILE} run cms -- bundle exec rake environment elasticsearch:ha:import CLASS=Series FORCE=1
-
-mindex_series:
-	docker-compose -f ${DOCKER_COMPOSE_FILE} run cms -- bundle exec rake environment elasticsearch:ha:import CLASS=Series FORCE=1 NPROCS=${NPROCS}
+	docker-compose -f ${DOCKER_COMPOSE_FILE} run cms -- bundle exec rake environment elasticsearch:import CLASS=Series FORCE=1
 
 index_stories:
-	docker-compose -f ${DOCKER_COMPOSE_FILE} run cms -- bundle exec rake environment elasticsearch:ha:import CLASS=Story FORCE=1
-
-mindex_stories:
-	docker-compose -f ${DOCKER_COMPOSE_FILE} run cms -- bundle exec rake environment elasticsearch:ha:import CLASS=Story FORCE=1 NPROCS=${NPROCS}
+	docker-compose -f ${DOCKER_COMPOSE_FILE} run cms -- bundle exec rake environment elasticsearch:import CLASS=Story FORCE=1
 
 clean:
 	sudo rm -rf log/*log && chmod 777 log

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -23,9 +23,9 @@ module Searchable
     end
 
     # shorthand methods
-    def reindex
+    def reindex(refresh = false)
       __elasticsearch__.index_document
-      refresh_index
+      refresh_index if refresh
       self
     end
 
@@ -40,27 +40,12 @@ module Searchable
 
     # class method shorthand, useful for triggering via rake task or console or tests
     def self.rebuild_index(_opts = {})
-      stager = index_stager
-      indexer(stager).run
-      stager.alias_stage_to_tmp_index && stager.promote
-      __elasticsearch__.refresh_index!
-    end
-
-    private
-
-    def self.index_stager
-      Elasticsearch::Rails::HA::IndexStager.new(self.to_s)
-    end
-
-    def self.indexer(stager)
-      Elasticsearch::Rails::HA::ParallelIndexer.new(
-        klass: self.to_s,
-        idx_name: stager.tmp_index_name,
-        nprocs: ENV.fetch('NPROCS', 1),
-        batch_size: ENV.fetch('BATCH', 100),
-        force: true,
-        verbose: ENV.fetch('ES_DEBUG', false)
-      )
+      __elasticsearch__.create_index! unless __elasticsearch__.index_exists?
+      errs = import(refresh: true, return: 'errors', batch_size: 100)
+      errs.each do |err|
+        logger.error(err)
+        NewRelic::Agent.notice_error(err)
+      end
     end
   end
 end

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -41,7 +41,10 @@ module Searchable
     # class method shorthand, useful for triggering via rake task or console or tests
     def self.rebuild_index(_opts = {})
       __elasticsearch__.create_index! unless __elasticsearch__.index_exists?
-      errs = import(refresh: true, return: 'errors', batch_size: 100)
+
+      indexer_scope = respond_to?(:for_indexer) ? :for_indexer : nil
+      errs = import(refresh: true, return: 'errors', scope: indexer_scope)
+
       errs.each do |err|
         logger.error(err)
         NewRelic::Agent.notice_error(err)

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -125,6 +125,7 @@ class Story < BaseModel
   # indicates the piece is not publically available, only to the network
   event_attribute :network_only_at
 
+  scope :for_indexer, -> { eager_load(:series).select('pieces.*, series.subscription_approval_status, series.subscriber_only_at') }
   scope :published, -> { where('`published_at` <= ?', Time.now) }
   scope :unpublished, -> { where('`published_at` IS NULL OR `published_at` > ?', Time.now) }
   scope :unseries, -> { where('`series_id` IS NULL') }

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -125,7 +125,10 @@ class Story < BaseModel
   # indicates the piece is not publically available, only to the network
   event_attribute :network_only_at
 
-  scope :for_indexer, -> { eager_load(:series).select('pieces.*, series.subscription_approval_status, series.subscriber_only_at') }
+  scope :for_indexer, -> {
+    eager_load(:series).
+      select('pieces.*, series.subscription_approval_status, series.subscriber_only_at')
+  }
   scope :published, -> { where('`published_at` <= ?', Time.now) }
   scope :unpublished, -> { where('`published_at` IS NULL OR `published_at` > ?', Time.now) }
   scope :unseries, -> { where('`series_id` IS NULL') }

--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -1,1 +1,0 @@
-require 'elasticsearch/rails/ha/tasks'

--- a/test/controllers/api/auth/stories_controller_test.rb
+++ b/test/controllers/api/auth/stories_controller_test.rb
@@ -115,7 +115,7 @@ describe Api::Auth::StoriesController do
         JSON.parse(response.body)['count'].must_equal account.stories.count
         account.stories.count.must_be :>, account.public_stories.count
       end
-  
+
       it 'searches stories with unpublished first, recently published after' do
         published_story.published_at.must_be :<, latest_story.published_at
         get(:search, api_request_opts(q: search_term, account_id: account.id, sort: 'published_at:desc'))
@@ -124,7 +124,7 @@ describe Api::Auth::StoriesController do
         stories[1].wont_be :published?
         stories[2].published_at.must_be :>, assigns[:stories][3].published_at
       end
-  
+
       it 'searches stories with unpublished first, oldest published after' do
         published_story.published_at.must_be :<, latest_story.published_at
         get(:search, api_request_opts(q: search_term, account_id: account.id, sort: 'published_at:asc'))
@@ -133,7 +133,7 @@ describe Api::Auth::StoriesController do
         stories[1].wont_be :published?
         stories[2].published_at.must_be :<, stories[3].published_at
       end
-  
+
       it 'searches stories with coalesced published, released dates' do
         get(:search, api_request_opts(q: search_term, account_id: account.id, sort: 'published_released_at:desc'))
         assert_response :success
@@ -144,13 +144,13 @@ describe Api::Auth::StoriesController do
         stories[1].released_at.must_be :>, assigns[:stories][2].published_at
         stories[2].published_at.must_be :>, assigns[:stories][3].published_at
       end
-  
+
       it 'searches stories in a network' do
         get(:search, api_version: 'v1', q: search_term, network_id: network.id)
         assert_response :success
         JSON.parse(response.body)['count'].must_equal network.stories.count
       end
-  
+
       it 'filters v4 stories' do
         unpublished_story.must_be :v4?
         v3_story.wont_be :v4?
@@ -160,7 +160,7 @@ describe Api::Auth::StoriesController do
         stories.must_include unpublished_story
         stories.wont_include v3_story
       end
-  
+
       it 'applies multiple filters, including field:NULL' do
         create(:series, stories: [unpublished_story])
         unpublished_story.series.wont_be_nil
@@ -168,15 +168,15 @@ describe Api::Auth::StoriesController do
         v3_story.series.must_be_nil
 
         # must re-index because we just updated unpublished_story
-        unpublished_story.reindex
-  
+        unpublished_story.reindex(true)
+
         get(:search, api_version: 'v1', app_version: 'v4', series_id: 'NULL', q: search_term)
         assert_response :success
         assert_not_nil assigns[:stories]
         stories.wont_include unpublished_story
         stories.wont_include v3_story
       end
-  
+
       it 'searches zero hits for network user access' do
         other_network = create(:network)
         get(:search, api_version: 'v1', network_id: other_network.id, q: search_term)

--- a/test/controllers/api/stories_controller_test.rb
+++ b/test/controllers/api/stories_controller_test.rb
@@ -304,8 +304,8 @@ describe Api::StoriesController do
   it 'should search text with Elasticsearch' do
     # always start clean
     ElasticsearchHelper.new.create_es_index(Story)
-    story = create(:story, title: 'You are all Weirdos').reindex
-    story2 = create(:story, title: 'We are all Freakazoids').reindex
+    story = create(:story, title: 'You are all Weirdos').reindex(true)
+    story2 = create(:story, title: 'We are all Freakazoids').reindex(true)
     get(:search, api_version: 'v1', format: 'json', q: 'weirdos')
     assert_response :success
     assert_not_nil assigns[:stories]
@@ -313,10 +313,10 @@ describe Api::StoriesController do
     assigns[:stories].wont_include story2
   end
 
-  it 'should allow fielded search' do 
+  it 'should allow fielded search' do
     ElasticsearchHelper.new.create_es_index(Story)
-    story = create(:story, title: 'You are all Weirdos').reindex
-    story2 = create(:story, title: 'We are all Freakazoids').reindex
+    story = create(:story, title: 'You are all Weirdos').reindex(true)
+    story2 = create(:story, title: 'We are all Freakazoids').reindex(true)
     get(:search, api_version: 'v1', format: 'json', fq: { title: 'weirdos' })
     assert_response :success
     assert_not_nil assigns[:stories]

--- a/test/models/story_test.rb
+++ b/test/models/story_test.rb
@@ -376,7 +376,7 @@ describe Story do
       story = create(:story,
                      title: 'Some Weirdo',
                      description: 'Unique thing',
-                     short_description: 'Lacking sense').reindex
+                     short_description: 'Lacking sense').reindex(true)
 
       Story.text_search('weirdo').to_a.must_include story
       Story.text_search('unique').to_a.must_include story


### PR DESCRIPTION
Full reindexes were failing because of a problem in the [elasticsearch-indexstager](https://github.com/18F/elasticsearch-indexstager-gem/blob/master/lib/elasticsearch/index_stager.rb#L42) gem.  Since that repo is archived, and we're not actually doing parallel reindexing ... I opted to just remove it for now.

Also preloads the story+series together, to make that index rebuild way faster.