### PR TITLE
Text search for publish

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -283,3 +283,6 @@ SymbolArray:
 
 BlockLength:
   Enabled: false
+
+MultilineIfModifier:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -216,9 +216,6 @@ TrailingCommaInArguments:
 TrivialAccessors:
   Enabled: false
 
-VariableInterpolation:
-  Enabled: false
-
 WhenThen:
   Enabled: false
 
@@ -270,4 +267,19 @@ Void:
   Enabled: false
 
 Style/FrozenStringLiteralComment:
+  Enabled: false
+
+SpaceInsideHashLiteralBraces:
+  Enabled: false
+
+IndentHash:
+  Enabled: false
+
+BracesAroundHashParameters:
+  Enabled: false
+
+SymbolArray:
+  Enabled: false
+
+BlockLength:
   Enabled: false

--- a/app/controllers/api/auth/series_controller.rb
+++ b/app/controllers/api/auth/series_controller.rb
@@ -12,4 +12,9 @@ class Api::Auth::SeriesController < Api::SeriesController
   def resources_base
     @series ||= authorization.token_auth_series
   end
+
+  def search
+    @series ||= Series.text_search(search_query, search_params, authorization)
+    index
+  end
 end

--- a/app/controllers/api/auth/stories_controller.rb
+++ b/app/controllers/api/auth/stories_controller.rb
@@ -67,16 +67,7 @@ class Api::Auth::StoriesController < Api::StoriesController
 
   def search_params
     sparams = super
-    sparams[:fq] ||= {}
-    [:network_id, :series_id, :account_id, :app_version].each do |p|
-      if params[p]
-        sparams[:fq][p.to_s] = params[p]
-      end
-    end
+    sparams[:fq]['series_id'] = 'NULL' if filters.noseries?
     sparams
-  end
-
-  def searchable_fields
-    Story.searchable_fields
   end
 end

--- a/app/controllers/api/series_controller.rb
+++ b/app/controllers/api/series_controller.rb
@@ -1,6 +1,8 @@
 # encoding: utf-8
 
 class Api::SeriesController < Api::BaseController
+  include ApiSearchable
+
   api_versions :v1
 
   filter_resources_by :account_id
@@ -11,6 +13,19 @@ class Api::SeriesController < Api::BaseController
               allowed: [:id, :created_at, :updated_at, :title]
 
   announce_actions
+
+  def search
+    @series ||= Series.text_search(search_query, search_params)
+    index
+  end
+
+  def search_params
+    sparams = super
+    sparams[:sort] = rename_sort_param(sparams[:sort], 'title', 'title.keyword')
+    sparams[:fq]['account_id'] = params[:account_id] if params[:account_id]
+    sparams[:fq]['app_version'] = 'v4' if filters.v4?
+    sparams
+  end
 
   def filtered(resources)
     resources = resources.v4 if filters.v4?

--- a/app/controllers/api/stories_controller.rb
+++ b/app/controllers/api/stories_controller.rb
@@ -16,12 +16,18 @@ class Api::StoriesController < Api::BaseController
   announce_actions :create, :update, :destroy, :publish, :unpublish
 
   def search
-    @stories = Story.text_search(search_query, search_params)
+    @stories ||= Story.text_search(search_query, search_params)
     index
   end
 
-  def searchable_fields
-    Story.searchable_fields
+  def search_params
+    sparams = super
+    sparams[:sort] = rename_sort_param(sparams[:sort], 'title', 'title.keyword')
+    sparams[:fq]['account_id'] = params[:account_id] if params[:account_id]
+    sparams[:fq]['network_id'] = params[:network_id] if params[:network_id]
+    sparams[:fq]['series_id'] = params[:series_id] if params[:series_id]
+    sparams[:fq]['app_version'] = 'v4' if filters.v4?
+    sparams
   end
 
   def after_create_resource(res)

--- a/app/controllers/concerns/api_searchable.rb
+++ b/app/controllers/concerns/api_searchable.rb
@@ -10,10 +10,20 @@ module ApiSearchable
   end
 
   def search_params
-    params.permit(:page, :size, :sort, fq: searchable_fields).to_h
+    sparams = {}
+    sparams[:page] = params[:page] if params[:page].present?
+    sparams[:size] = params[:per] if params[:per].present?
+    sparams[:sort] = sorts if respond_to?(:sorts) && sorts.present?
+    sparams[:fq] = {}
+    sparams
   end
 
-  def searchable_fields
-    []
+  def rename_sort_param(sort_array, from_name, to_name)
+    if sort_array.present?
+      sort_array.map do |key_val_obj|
+        key_val_obj[to_name] = key_val_obj.delete(from_name) if key_val_obj.key?(from_name)
+        key_val_obj
+      end
+    end
   end
 end

--- a/app/models/group_account.rb
+++ b/app/models/group_account.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
 
 class GroupAccount < Account
-  include Searchable
 end

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -2,7 +2,6 @@
 
 class Playlist < BaseModel
   include Storied
-  include Searchable
 
   acts_as_paranoid
 

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -14,6 +14,12 @@ class Series < BaseModel
 
   include Searchable
 
+  settings index: {number_of_shards: 1, number_of_replicas: 1} do
+    mappings dynamic: 'true' do
+      indexes :subscription_approval_status, type: 'keyword'
+    end
+  end
+
   def description_html=(html)
     self.description = v4? ? html_to_markdown(html) : html
   end
@@ -62,6 +68,11 @@ class Series < BaseModel
           "`series`.`short_description` like '%#{text}%' OR " +
           "`series`.`description` like '%#{text}%'")
   }
+
+  def self.text_search(text, params={}, authz=nil)
+    builder = SeriesQueryBuilder.new(query: text, params: params, authorization: authz)
+    search(builder.as_dsl).records
+  end
 
   def default_image
     @default_image ||= images.profile

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -69,7 +69,7 @@ class Series < BaseModel
           "`series`.`description` like '%#{text}%'")
   }
 
-  def self.text_search(text, params={}, authz=nil)
+  def self.text_search(text, params = {}, authz = nil)
     builder = SeriesQueryBuilder.new(query: text, params: params, authorization: authz)
     search(builder.as_dsl).records
   end

--- a/app/models/station_account.rb
+++ b/app/models/station_account.rb
@@ -1,5 +1,4 @@
 # encoding: utf-8
 
 class StationAccount < Account
-  include Searchable
 end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -148,7 +148,7 @@ class Story < BaseModel
 
   scope :public_stories, -> { published.network_visible.series_visible }
 
-  def self.text_search(text, params={}, authz=nil)
+  def self.text_search(text, params = {}, authz = nil)
     builder = StoryQueryBuilder.new(query: text, params: params, authorization: authz)
     search(builder.as_dsl).records
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,6 @@
 # encoding: utf-8
 
 class User < BaseModel
-  include Searchable
-
   acts_as_paranoid
 
   # DON'T touch the account, as you'll create an infinite loop

--- a/app/representers/api/api_representer.rb
+++ b/app/representers/api/api_representer.rb
@@ -31,6 +31,15 @@ class Api::ApiRepresenter < Api::BaseRepresenter
     ]
   end
 
+  link :stories_search do
+    {
+      title: 'Search for a paged collection of stories',
+      profile: profile_url(:collection, :story),
+      href: "#{search_api_stories_path}#{search_url_params}",
+      templated: true
+    }
+  end
+
   links :series do
     [
       {
@@ -47,6 +56,15 @@ class Api::ApiRepresenter < Api::BaseRepresenter
         templated: true
       }
     ]
+  end
+
+  link :series_search do
+    {
+      title: 'Search for a paged collection of series',
+      profile: profile_url(:collection, :series),
+      href: "#{search_api_series_index_path}#{search_url_params}",
+      templated: true
+    }
   end
 
   links :account do

--- a/app/representers/api/auth/series_representer.rb
+++ b/app/representers/api/auth/series_representer.rb
@@ -16,6 +16,14 @@ class Api::Auth::SeriesRepresenter < Api::SeriesRepresenter
         url: ->(_r) { api_authorization_series_stories_path(represented.parent) },
         zoom: false
 
+  link :stories_search do
+    {
+      href: "#{search_api_authorization_series_stories_path(represented)}#{search_url_params}",
+      templated: true,
+      count: represented.stories.count
+    } if represented.id
+  end
+
   def self_url(r)
     api_authorization_series_path(r)
   end

--- a/app/representers/api/authorization_representer.rb
+++ b/app/representers/api/authorization_representer.rb
@@ -36,9 +36,25 @@ class Api::AuthorizationRepresenter < Api::BaseRepresenter
     ]
   end
 
+  link :series_search do
+    {
+      href: "#{search_api_authorization_series_index_path}#{search_url_params}",
+      templated: true,
+      count: represented.token_auth_series.count
+    }
+  end
+
   link :stories do
     {
       href: "#{api_authorization_stories_path}#{index_url_params}",
+      templated: true,
+      count: represented.token_auth_stories.count
+    }
+  end
+
+  link :stories_search do
+    {
+      href: "#{search_api_authorization_stories_path}#{search_url_params}",
       templated: true,
       count: represented.token_auth_stories.count
     }

--- a/app/representers/api/base_representer.rb
+++ b/app/representers/api/base_representer.rb
@@ -22,6 +22,10 @@ class Api::BaseRepresenter < HalApi::Representer
     '{?page,per,zoom,filters,sorts}'
   end
 
+  def search_url_params
+    '{?page,per,zoom,filters,sorts,q}'
+  end
+
   def show_url_params
     '{?zoom}'
   end

--- a/app/representers/api/series_representer.rb
+++ b/app/representers/api/series_representer.rb
@@ -26,6 +26,14 @@ class Api::SeriesRepresenter < Api::BaseRepresenter
         item_decorator: Api::Min::StoryRepresenter,
         zoom: false
 
+  link :stories_search do
+    {
+      href: "#{search_api_series_stories_path(represented)}#{search_url_params}",
+      templated: true,
+      count: represented.public_stories.count
+    } if represented.id
+  end
+
   link :image do
     {
       href: api_series_series_image_path(represented, represented.default_image),

--- a/app/services/es_query_builder.rb
+++ b/app/services/es_query_builder.rb
@@ -6,7 +6,7 @@ class ESQueryBuilder
   attr_reader :authorization, :params, :query_str, :fields, :fielded_query
 
   def initialize(args)
-    @query_str = args[:query]
+    @query_str = SanitizedSearchQuery.new(args[:query])
     @fields = args[:fields] || default_fields
     @authorization = args[:authorization]
     @params = args[:params]

--- a/app/services/fielded_search_query.rb
+++ b/app/services/fielded_search_query.rb
@@ -4,7 +4,9 @@ class FieldedSearchQuery
   NULL_STRING = 'NULL'
 
   def initialize(field_pairs)
-    @field_pairs = field_pairs
+    if field_pairs
+      @field_pairs = field_pairs.with_indifferent_access
+    end
   end
 
   def present?
@@ -35,7 +37,7 @@ class FieldedSearchQuery
       field_pairs.each do |k, v|
         next if v.nil?
         next if v.blank?
-        next if v == '*' 
+        next if v == '*'
         next if v == NULL_STRING
         clauses << clause_to_s(k, v)
       end

--- a/app/services/sanitized_search_query.rb
+++ b/app/services/sanitized_search_query.rb
@@ -1,0 +1,55 @@
+class SanitizedSearchQuery
+  attr_reader :query
+
+  SPECIAL_CHARS = Regexp.escape('\\/+-&|!(){}[]^~?:')
+
+  def initialize(str)
+    @query = sanitize(str) if str.present?
+  end
+
+  def present?
+    query.present?
+  end
+
+  def to_s
+    query
+  end
+
+  private
+
+  def sanitize(str)
+    str = str.strip
+    str = escape_special_characters(str)
+    str = remove_trailing_operators(str)
+    str = remove_consecutive_operators(str)
+    str = escape_odd_quotes(str)
+    str
+  end
+
+  def escape_special_characters(str)
+    str.gsub(/([#{SPECIAL_CHARS}])/, '\\\\\1')
+  end
+
+  def remove_trailing_operators(str)
+    str.gsub(/(\s*(AND|OR|NOT))+\s*$/, '')
+  end
+
+  def remove_consecutive_operators(str)
+    str.gsub(/(AND|OR|NOT)(\s+(AND|OR|NOT))+/, '\1')
+  end
+
+  # def escape_logical_operators(str)
+  #   ['AND', 'OR', 'NOT'].each do |word|
+  #     escaped_word = word.split('').map {|char| "\\#{char}" }.join('')
+  #     str = str.gsub(/\s*\b(#{word.upcase})\b\s*/, " #{escaped_word} ")
+  #   end
+  # end
+
+  def escape_odd_quotes(str)
+    if str.count('"') % 2 == 1
+      str.gsub(/(.*)"(.*)$/, '\1\"\2')
+    else
+      str
+    end
+  end
+end

--- a/app/services/series_query_builder.rb
+++ b/app/services/series_query_builder.rb
@@ -1,0 +1,49 @@
+class SeriesQueryBuilder < ESQueryBuilder
+
+  def default_fields
+    ['title', 'short_description', 'description']
+  end
+
+  def default_sort_params
+    [updated_at: :desc]
+  end
+
+  def apply_authz?
+    authorization.present?
+  end
+
+  private
+
+  def build_filters
+    bools = []
+    if apply_authz?
+      bools.push authz_filter
+    end
+    bools.push v4_or_deleted_at_null_filter
+    bools
+  end
+
+  def authz_filter
+    searchdsl = self
+    Filter.new do
+      terms account_id: searchdsl.authorization.token_auth_accounts.try(:ids), _name: :authz
+    end
+  end
+
+  def v4_or_deleted_at_null_filter
+    Filter.new do
+      bool do
+        should do
+          bool do
+            must_not do
+              exists field: :deleted_at, _name: :deleted_at_null
+            end
+          end
+        end
+        should do
+          term app_version: { value: 'v4', _name: :app_version_v4 }
+        end
+      end
+    end
+  end
+end

--- a/app/services/story_query_builder.rb
+++ b/app/services/story_query_builder.rb
@@ -1,9 +1,5 @@
 class StoryQueryBuilder < ESQueryBuilder
 
-  def default_max_search_results
-    Story::MAX_SEARCH_RESULTS
-  end
-
   def default_fields
     ['title', 'short_description', 'description']
   end
@@ -40,10 +36,10 @@ class StoryQueryBuilder < ESQueryBuilder
     end
     if apply_public_filter?
       bools.push published_filter
-      bools.push v4_or_deleted_at_null_filter
       bools.push network_visible_filter
       bools.push series_visible_filter
     end
+    bools.push v4_or_deleted_at_null_filter
     bools
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,8 +30,11 @@ PRX::Application.routes.draw do
       end
 
       resources :series, except: [:new, :edit] do
+        get 'search', on: :collection
         resources :series_images, path: 'images', except: [:new, :edit]
-        resources :stories, only: [:index, :create]
+        resources :stories, only: [:index, :create] do
+          get 'search', on: :collection
+        end
         resources :audio_version_templates, except: [:new, :edit]
         resources :distributions, except: [:new, :edit]
       end
@@ -75,9 +78,7 @@ PRX::Application.routes.draw do
         resources :audio_files, except: [:new, :edit]
 
         resources :accounts, only: [:index, :show], module: :auth do
-          resources :stories, only: [:index, :create, :update] do
-            get 'search', on: :collection
-          end
+          resources :stories, only: [:index, :create, :update]
         end
 
         resources :podcast_imports, except: [:new, :edit], module: :auth do
@@ -89,6 +90,7 @@ PRX::Application.routes.draw do
         end
 
         resources :series, except: [:new, :edit, :create], module: :auth do
+          get 'search', on: :collection
           resources :stories, only: [:index, :create] do
             get 'search', on: :collection
           end
@@ -101,9 +103,7 @@ PRX::Application.routes.draw do
         end
 
         resources :networks, only: [:index, :show], module: :auth do
-          resources :stories, only: [:index] do
-            get 'search', on: :collection
-          end
+          resources :stories, only: [:index]
         end
       end
     end

--- a/test/controllers/api/auth/stories_controller_test.rb
+++ b/test/controllers/api/auth/stories_controller_test.rb
@@ -118,7 +118,8 @@ describe Api::Auth::StoriesController do
 
       it 'searches stories with unpublished first, recently published after' do
         published_story.published_at.must_be :<, latest_story.published_at
-        get(:search, api_request_opts(q: search_term, account_id: account.id, sorts: 'published_at:desc'))
+        sort = 'published_at:desc'
+        get(:search, api_request_opts(q: search_term, account_id: account.id, sorts: sort))
         assert_response :success
         stories[0].wont_be :published?
         stories[1].wont_be :published?
@@ -127,7 +128,8 @@ describe Api::Auth::StoriesController do
 
       it 'searches stories with unpublished first, oldest published after' do
         published_story.published_at.must_be :<, latest_story.published_at
-        get(:search, api_request_opts(q: search_term, account_id: account.id, sorts: 'published_at:asc'))
+        sort = 'published_at:asc'
+        get(:search, api_request_opts(q: search_term, account_id: account.id, sorts: sort))
         assert_response :success
         stories[0].wont_be :published?
         stories[1].wont_be :published?
@@ -135,7 +137,8 @@ describe Api::Auth::StoriesController do
       end
 
       it 'searches stories with coalesced published, released dates' do
-        get(:search, api_request_opts(q: search_term, account_id: account.id, sorts: 'published_released_at:desc'))
+        sort = 'published_released_at:desc'
+        get(:search, api_request_opts(q: search_term, account_id: account.id, sorts: sort))
         assert_response :success
         JSON.parse(response.body)['count'].must_equal account.stories.count
         stories[0].wont_be :published?

--- a/test/controllers/api/stories_controller_test.rb
+++ b/test/controllers/api/stories_controller_test.rb
@@ -316,8 +316,8 @@ describe Api::StoriesController do
   it 'should allow fielded search' do
     ElasticsearchHelper.new.create_es_index(Story)
     story = create(:story, title: 'You are all Weirdos').reindex(true)
-    story2 = create(:story, title: 'We are all Freakazoids').reindex(true)
-    get(:search, api_version: 'v1', format: 'json', fq: { title: 'weirdos' })
+    story2 = create(:story, title: 'We are all Freakazoids', description: 'And weirdos').reindex(true)
+    get(:search, api_version: 'v1', format: 'json', q: 'title:weirdos')
     assert_response :success
     assert_not_nil assigns[:stories]
     assigns[:stories].must_include story

--- a/test/controllers/api/stories_controller_test.rb
+++ b/test/controllers/api/stories_controller_test.rb
@@ -312,16 +312,4 @@ describe Api::StoriesController do
     assigns[:stories].must_include story
     assigns[:stories].wont_include story2
   end
-
-  it 'should allow fielded search' do
-    ElasticsearchHelper.new.create_es_index(Story)
-    story = create(:story, title: 'You are all Weirdos').reindex(true)
-    story2 = create(:story, title: 'We are all Freakazoids', description: 'And weirdos')
-    story2.reindex(true)
-    get(:search, api_version: 'v1', format: 'json', q: 'title:weirdos')
-    assert_response :success
-    assert_not_nil assigns[:stories]
-    assigns[:stories].must_include story
-    assigns[:stories].wont_include story2
-  end
 end

--- a/test/controllers/api/stories_controller_test.rb
+++ b/test/controllers/api/stories_controller_test.rb
@@ -316,7 +316,8 @@ describe Api::StoriesController do
   it 'should allow fielded search' do
     ElasticsearchHelper.new.create_es_index(Story)
     story = create(:story, title: 'You are all Weirdos').reindex(true)
-    story2 = create(:story, title: 'We are all Freakazoids', description: 'And weirdos').reindex(true)
+    story2 = create(:story, title: 'We are all Freakazoids', description: 'And weirdos')
+    story2.reindex(true)
     get(:search, api_version: 'v1', format: 'json', q: 'title:weirdos')
     assert_response :success
     assert_not_nil assigns[:stories]

--- a/test/controllers/concerns/api_searchable_test.rb
+++ b/test/controllers/concerns/api_searchable_test.rb
@@ -40,10 +40,12 @@ describe ApiSearchable do
 
   it 'renames sort params' do
     sorts = [{fld1: :asc}, {fld2: :desc, fld3: :asc}, {fld4: :asc}]
-    controller.rename_sort_param(sorts, :fld3, 'fld3.changed').must_equal([
-      {fld1: :asc},
-      {fld2: :desc, 'fld3.changed' => :asc},
-      {fld4: :asc}
-    ])
+    controller.rename_sort_param(sorts, :fld3, 'fld3.changed').must_equal(
+      [
+        {fld1: :asc},
+        {fld2: :desc, 'fld3.changed' => :asc},
+        {fld4: :asc}
+      ]
+    )
   end
 end

--- a/test/controllers/concerns/api_searchable_test.rb
+++ b/test/controllers/concerns/api_searchable_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+
+describe ApiSearchable do
+
+  class ApiSearchableTestController < ActionController::Base
+    include ApiSearchable
+
+    attr_accessor :_params
+    attr_accessor :_sorts
+
+    def params
+      ActionController::Parameters.new(_params)
+    end
+
+    def sorts
+      _sorts
+    end
+  end
+
+  let(:controller) { ApiSearchableTestController.new }
+
+  it 'gets the search query' do
+    controller.search_query.must_equal nil
+    controller._params = {foo: 'bar'}
+    controller.search_query.must_equal nil
+    controller._params = {foo: 'bar', q: 'stuff'}
+    controller.search_query.must_equal 'stuff'
+  end
+
+  it 'has pagination search params' do
+    controller.search_params.must_equal({fq: {}})
+    controller._params = {page: 3, per: 10}
+    controller.search_params.must_equal({page: 3, size: 10, fq: {}})
+  end
+
+  it 'has sorting search params' do
+    controller._sorts = [fld: :desc]
+    controller.search_params.must_equal({sort: [fld: :desc], fq: {}})
+  end
+
+  it 'renames sort params' do
+    sorts = [{fld1: :asc}, {fld2: :desc, fld3: :asc}, {fld4: :asc}]
+    controller.rename_sort_param(sorts, :fld3, 'fld3.changed').must_equal([
+      {fld1: :asc},
+      {fld2: :desc, 'fld3.changed' => :asc},
+      {fld4: :asc}
+    ])
+  end
+end

--- a/test/representers/api/api_representer_test.rb
+++ b/test/representers/api/api_representer_test.rb
@@ -26,4 +26,9 @@ describe Api::ApiRepresenter do
     json['_links']['prx:picks'].size.must_equal 1
   end
 
+  it 'returns search links' do
+    json['_links']['prx:series-search'].wont_be_nil
+    json['_links']['prx:stories-search'].wont_be_nil
+  end
+
 end

--- a/test/representers/api/auth/series_representer_test.rb
+++ b/test/representers/api/auth/series_representer_test.rb
@@ -17,4 +17,8 @@ describe Api::Auth::SeriesRepresenter do
     get_link_href('prx:stories').must_include('authorization')
     get_embedded_href('prx:stories').must_include('authorization')
   end
+
+  it 'has authorization links for searching stories' do
+    get_link_href('prx:stories-search').must_include('authorization')
+  end
 end

--- a/test/representers/api/authorization_representer_test.rb
+++ b/test/representers/api/authorization_representer_test.rb
@@ -29,6 +29,11 @@ describe Api::AuthorizationRepresenter do
     get_link('prx:story').must_match 'authorization/stories/{id}'
   end
 
+  it 'links directly to search endpoints' do
+    get_link('prx:series-search').must_match 'authorization/series/search'
+    get_link('prx:stories-search').must_match 'authorization/stories/search'
+  end
+
   it 'embeds the default account with the auth url' do
     get_embed('prx:default-account', 'id').must_equal account.id
     links = get_embed('prx:default-account', '_links')

--- a/test/representers/api/base_representer_test.rb
+++ b/test/representers/api/base_representer_test.rb
@@ -17,7 +17,7 @@ describe Api::BaseRepresenter do
   end
 
   it '#search_url_params' do
-    representer.index_url_params.wont_be_nil
-    representer.index_url_params.must_equal '{?page,per,zoom,filters,sorts,q}'
+    representer.search_url_params.wont_be_nil
+    representer.search_url_params.must_equal '{?page,per,zoom,filters,sorts,q}'
   end
 end

--- a/test/representers/api/base_representer_test.rb
+++ b/test/representers/api/base_representer_test.rb
@@ -15,4 +15,9 @@ describe Api::BaseRepresenter do
     representer.index_url_params.wont_be_nil
     representer.index_url_params.must_equal '{?page,per,zoom,filters,sorts}'
   end
+
+  it '#search_url_params' do
+    representer.index_url_params.wont_be_nil
+    representer.index_url_params.must_equal '{?page,per,zoom,filters,sorts,q}'
+  end
 end

--- a/test/representers/api/series_representer_test.rb
+++ b/test/representers/api/series_representer_test.rb
@@ -22,6 +22,11 @@ describe Api::SeriesRepresenter do
     json['_links']['prx:audio-version-templates'].wont_be_nil
   end
 
+  it 'includes stories search links' do
+    json['_links']['prx:stories-search'].wont_be_nil
+    json['_links']['prx:stories-search']['href'].must_match "series/#{series.id}/stories/search"
+  end
+
   it 'can set the account' do
     series.account_id.wont_be_nil
     series_hash = { title: 'Title', set_account_uri: 'api/v1/accounts/123' }

--- a/test/services/es_query_builder_test.rb
+++ b/test/services/es_query_builder_test.rb
@@ -1,0 +1,99 @@
+require 'test_helper'
+
+describe ESQueryBuilder do
+
+  let(:account) { create(:account) }
+  let(:token) { StubToken.new(account.id, ['member'], 456) }
+  let(:authorization) { Authorization.new(token) }
+  let(:unauth_account) { create(:account) }
+
+  it 'requires default fields' do
+    err = assert_raises { ESQueryBuilder.new(query: 'foobar') }
+    err.message.must_match /override default_fields/
+  end
+
+  it 'creates a query hash' do
+    dsl = ESQueryBuilder.new(
+      query: 'foobar',
+      fields: ['what', 'ever'],
+      params: {from: 1, size: 5, fq: {something: '123'}}
+    )
+    hash = dsl.to_hash
+
+    hash.keys.sort.must_equal [:_source, :from, :query, :size, :sort]
+    hash[:_source].must_equal ['id']
+    hash[:size].must_equal 5
+    hash[:from].must_equal 1
+    hash[:sort].must_equal [{updated_at: {order: :desc, missing: '_last'}}]
+    hash[:query].must_equal({
+      bool: {
+        must: [{
+          query_string: {
+            query: '(foobar) AND (something:(123))',
+            default_operator: 'and',
+            lenient: true,
+            fields: ['what', 'ever']
+          }
+        }]
+      }
+    })
+  end
+
+  it 'can have no fielded query' do
+    dsl = ESQueryBuilder.new(query: 'foobar', fields: ['foo'], params: {sort: [created_at: :asc]})
+    hash = dsl.to_hash
+
+    hash.keys.sort.must_equal [:_source, :from, :query, :size, :sort]
+    hash[:_source].must_equal ['id']
+    hash[:size].must_equal 10
+    hash[:from].must_equal 0
+    hash[:sort].must_equal [{created_at: {order: :asc, missing: '_first'}}]
+    hash[:query].must_equal({
+      bool: {
+        must: [{
+          query_string: {
+            query: 'foobar',
+            default_operator: 'and',
+            lenient: true,
+            fields: ['foo']
+          }
+        }]
+      }
+    })
+  end
+
+  it 'can have only a fielded query' do
+    dsl = ESQueryBuilder.new(fields: ['foo'], params: {fq: {something: '123'}})
+    hash = dsl.to_hash
+
+    hash.keys.sort.must_equal [:_source, :from, :query, :size, :sort]
+    hash[:_source].must_equal ['id']
+    hash[:size].must_equal 10
+    hash[:from].must_equal 0
+    hash[:sort].must_equal [{updated_at: {order: :desc, missing: '_last'}}]
+    hash[:query].must_equal({
+      bool: {
+        must: [{
+          query_string: {
+            query: 'something:(123)',
+            default_operator: 'and',
+            lenient: true,
+            fields: ['foo']
+          }
+        }]
+      }
+    })
+  end
+
+  it 'can have no query' do
+    dsl = ESQueryBuilder.new(fields: ['foo'], params: {sort: [foo: :desc]})
+    hash = dsl.to_hash
+
+    hash.keys.sort.must_equal [:_source, :from, :query, :size, :sort]
+    hash[:_source].must_equal ['id']
+    hash[:size].must_equal 10
+    hash[:from].must_equal 0
+    hash[:sort].must_equal [{foo: :desc}]
+    hash[:query].must_equal({bool: {}})
+  end
+end

--- a/test/services/es_query_builder_test.rb
+++ b/test/services/es_query_builder_test.rb
@@ -96,8 +96,8 @@ describe ESQueryBuilder do
           }
         }],
         must_not: [
-          {exists: {field: :maybe}},
-          {exists: {field: :other}}
+          {exists: {field: 'maybe'}},
+          {exists: {field: 'other'}}
         ]
       }
     })

--- a/test/services/fielded_search_query_test.rb
+++ b/test/services/fielded_search_query_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+describe FieldedSearchQuery do
+
+  it 'knows if it exists' do
+    FieldedSearchQuery.new(nil).present?.must_equal false
+    FieldedSearchQuery.new({}).present?.must_equal false
+    FieldedSearchQuery.new(something: nil).present?.must_equal false
+    FieldedSearchQuery.new(something: 'value').present?.must_equal true
+  end
+
+  it 'joins multiple clauses' do
+    query = FieldedSearchQuery.new(field_a: '123', field_b: '456')
+    query.to_h.must_equal({field_a: '123', field_b: '456'})
+    query.to_s.must_equal 'field_a:(123) field_b:(456)'
+  end
+
+  it 'humanizes clauses' do
+    query = FieldedSearchQuery.new(field_a: 'what', field_b: 'ever').humanized
+    query.to_h.must_equal({'Field A' => 'what', 'Field B' => 'ever'})
+    query.to_s.must_equal 'Field A:(what) Field B:(ever)'
+  end
+
+  it 'ignores blank clauses' do
+    query = FieldedSearchQuery.new(a: nil, b: '', c: '*', d: 'NULL', e: 123)
+    query.to_h.must_equal({e: 123})
+    query.to_s.must_equal 'e:(123)'
+  end
+
+end

--- a/test/services/fielded_search_query_test.rb
+++ b/test/services/fielded_search_query_test.rb
@@ -11,7 +11,7 @@ describe FieldedSearchQuery do
 
   it 'joins multiple clauses' do
     query = FieldedSearchQuery.new(field_a: '123', field_b: '456')
-    query.to_h.must_equal({field_a: '123', field_b: '456'})
+    query.to_h.must_equal({'field_a' => '123', 'field_b' => '456'})
     query.to_s.must_equal 'field_a:(123) field_b:(456)'
   end
 
@@ -23,7 +23,7 @@ describe FieldedSearchQuery do
 
   it 'ignores blank clauses' do
     query = FieldedSearchQuery.new(a: nil, b: '', c: '*', d: 'NULL', e: 123)
-    query.to_h.must_equal({e: 123})
+    query.to_h.must_equal({'e' => 123})
     query.to_s.must_equal 'e:(123)'
   end
 

--- a/test/services/sanitized_search_query_test.rb
+++ b/test/services/sanitized_search_query_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+describe SanitizedSearchQuery do
+
+  it 'knows if it exists' do
+    SanitizedSearchQuery.new(nil).present?.must_equal false
+    SanitizedSearchQuery.new('').present?.must_equal false
+    SanitizedSearchQuery.new('   ').present?.must_equal false
+    SanitizedSearchQuery.new(' b ').present?.must_equal true
+  end
+
+  it 'strips spaces' do
+    SanitizedSearchQuery.new('  ').to_s.must_equal nil
+    SanitizedSearchQuery.new('  hello   world ').to_s.must_equal 'hello   world'
+  end
+
+  it 'escapes reserved characters' do
+    SanitizedSearchQuery.new('hello:').to_s.must_equal 'hello\:'
+    SanitizedSearchQuery.new('this & that !other').to_s.must_equal 'this \& that \!other'
+  end
+
+  it 'leaves wildcards alone' do
+    SanitizedSearchQuery.new('hello*').to_s.must_equal 'hello*'
+  end
+
+  it 'escapes odd trailing quotes' do
+    SanitizedSearchQuery.new('a "b" "c" okay').to_s.must_equal 'a "b" "c" okay'
+    SanitizedSearchQuery.new('a "b" "c stuff here').to_s.must_equal 'a "b" \"c stuff here'
+  end
+
+  it 'removes trailing logical operators' do
+    SanitizedSearchQuery.new('a AND b OR c NOT d').to_s.must_equal 'a AND b OR c NOT d'
+    SanitizedSearchQuery.new('a AND b  NOT').to_s.must_equal 'a AND b'
+    SanitizedSearchQuery.new('a AND b  NOT  AND').to_s.must_equal 'a AND b'
+  end
+
+  it 'removes consecutive logical operators' do
+    SanitizedSearchQuery.new('a AND OR b').to_s.must_equal 'a AND b'
+    SanitizedSearchQuery.new('a AND OR NOT b OR NOT c').to_s.must_equal 'a AND b OR c'
+  end
+end

--- a/test/services/series_query_builder_test.rb
+++ b/test/services/series_query_builder_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+
+describe SeriesQueryBuilder do
+
+  let(:account) { create(:account) }
+  let(:token) { StubToken.new(account.id, ['member'], 456) }
+  let(:authorization) { Authorization.new(token) }
+
+  FILTER_PARANOID = {bool: {
+    should: [
+      {bool: {must_not: [{exists: {field: :deleted_at, _name: :deleted_at_null}}]}},
+      {term: {app_version: {value: 'v4', _name: :app_version_v4}}}
+    ]
+  }}.freeze
+
+  it 'sets sane defaults' do
+    dsl = SeriesQueryBuilder.new(query: 'foobar')
+    dsl.default_fields.must_equal ['title', 'short_description', 'description']
+    dsl.default_sort_params.must_equal [{updated_at: :desc}]
+  end
+
+  it 'queries for series' do
+    hash = SeriesQueryBuilder.new(query: 'foobar').to_hash
+    hash[:query][:bool][:must].must_equal [{
+      query_string: {
+        query: 'foobar',
+        default_operator: 'and',
+        lenient: true,
+        fields: ['title', 'short_description', 'description']
+      }
+    }]
+  end
+
+  it 'filters for non deleted series' do
+    hash = SeriesQueryBuilder.new(query: 'foobar').to_hash
+    filters = hash[:query][:bool][:filter]
+    filters.count.must_equal(1)
+    filters[0].must_equal(FILTER_PARANOID)
+  end
+
+  it 'filters for authorized series' do
+    hash = SeriesQueryBuilder.new(query: 'foobar', authorization: authorization).to_hash
+    filters = hash[:query][:bool][:filter]
+    filters.count.must_equal(2)
+    filters[0].must_equal({terms: {account_id: [account.id], _name: :authz}})
+    filters[1].must_equal(FILTER_PARANOID)
+  end
+
+end

--- a/test/services/story_query_builder_test.rb
+++ b/test/services/story_query_builder_test.rb
@@ -1,235 +1,69 @@
 require 'test_helper'
 
 describe StoryQueryBuilder do
+
   let(:account) { create(:account) }
   let(:token) { StubToken.new(account.id, ['member'], 456) }
   let(:authorization) { Authorization.new(token) }
-  let(:unauth_account) { create(:account) }
 
-  it "#to_hash with authorization" do
-    dsl = described_class.new(
-      params: { from: 1, size: 5, },
-      query: 'foo OR Bar',
-      fielded_query: { something: '123', maybe: 'NULL', other: nil },
-      authorization: authorization
-    )
-    dsl.to_hash.must_equal({
-      _source: ["id"],
-      query: {
-        bool: {
-          must: [
-            {
-              query_string: {
-                query: '(foo OR Bar) AND (something:(123))',
-                default_operator: 'and',
-                lenient: true,
-                fields: %w( title short_description description ),
-              },
-            },
-          ],
-          filter: [
-            { terms: { account_id: [account.id], _name: :authz } }
-          ],
-          must_not: [
-            { exists: { field: :maybe } },
-            { exists: { field: :other } },
-          ],
-        },
-      },
-      sort: [
-        {
-          published_at: {order: :desc, missing: '_last'},
-          updated_at: {order: :desc, missing: '_last'}
-        }
-      ],
-      size: 5,
-      from: 1
-    })
+  # sorry... ES filters can be a bit ugly
+  FILTER_PUBLISHED = {range: {published_at: {lte: 'now', _name: :published}}}.freeze
+  FILTER_NETWORK_VISIBLE = {bool: {
+    must_not: [{exists: {field: :network_only_at, _name: :network_visible}}]
+  }}.freeze
+  FILTER_SERIES_APPROVED = {bool: {
+    must_not: [{
+      term: {'series.subscription_approval_status' =>
+        {value: 'PRX Approved', _name: :prx_series_approved}}
+    }]
+  }}.freeze
+  FILTER_SERIES_NOT_SUB_ONLY = {bool: {
+    must_not: [{exists: {field: 'series.subscriber_only_at', _name: :series_subscriber_only_at}}]
+  }}.freeze
+  FILTER_SERIES_VISIBLE = {bool: {
+    should: [FILTER_SERIES_APPROVED, FILTER_SERIES_NOT_SUB_ONLY]
+  }}.freeze
+  FILTER_PARANOID = {bool: {
+    should: [
+      {bool: {must_not: [{exists: {field: :deleted_at, _name: :deleted_at_null}}]}},
+      {term: {app_version: {value: 'v4', _name: :app_version_v4}}}
+    ]
+  }}.freeze
+
+  it 'sets sane defaults' do
+    dsl = StoryQueryBuilder.new(query: 'foobar')
+    dsl.default_fields.must_equal ['title', 'short_description', 'description']
+    dsl.default_sort_params.must_equal [{published_at: :desc, updated_at: :desc}]
   end
 
-  it "#to_hash without authorization" do
-    dsl = described_class.new(
-      params: { from: 1, size: 5, },
-      query: 'foo OR Bar',
-      fielded_query: { something: '123' },
-    )
-    dsl.to_hash.must_equal({
-      _source: ["id"],
-      query: {
-        bool: {
-          must: [
-            {
-              query_string: {
-                query: '(foo OR Bar) AND (something:(123))',
-                default_operator: 'and',
-                lenient: true,
-                fields: %w( title short_description description ),
-              },
-            },
-          ],
-          filter: [
-            {
-              range: {
-                published_at: {
-                  lte: 'now',
-                  _name: :published
-                }
-              }
-            },
-            {
-              bool: {
-                should: [
-                  {
-                    bool: {
-                      must_not: [
-                        {
-                          exists: {
-                            field: :deleted_at,
-                            _name: :deleted_at_null
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    term: {
-                      app_version: {
-                        value: 'v4',
-                        _name: :app_version_v4
-                      }
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              bool: {
-                must_not: [
-                  {
-                    exists: {
-                      field: :network_only_at,
-                      _name: :network_visible
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              bool: {
-                should: [
-                  {
-                    bool: {
-                      must_not: [
-                        {
-                          term: {
-                            'series.subscription_approval_status' => {
-                              value: 'PRX Approved',
-                              _name: :prx_series_approved
-                            }
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    bool: {
-                      must_not: [
-                        {
-                          exists: {
-                            field: 'series.subscriber_only_at',
-                            _name: :series_subscriber_only_at
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            }
-          ],
-        },
-      },
-      sort: [
-        {
-          published_at: {order: :desc, missing: '_last'},
-          updated_at: {order: :desc, missing: '_last'}
-        }
-      ],
-      size: 5,
-      from: 1
-    })
+  it 'queries for stories' do
+    hash = StoryQueryBuilder.new(query: 'foobar').to_hash
+    hash[:query][:bool][:must].must_equal [{
+      query_string: {
+        query: 'foobar',
+        default_operator: 'and',
+        lenient: true,
+        fields: ['title', 'short_description', 'description']
+      }
+    }]
   end
 
-  it "defaults to sane pagination" do
-    dsl_hash = described_class.new(
-      query: "foo OR Bar",
-    ).to_hash
-    dsl_hash[:size].must_equal Story::MAX_SEARCH_RESULTS
-    dsl_hash[:from].must_equal 0
+  it 'filters for public stories' do
+    hash = StoryQueryBuilder.new(query: 'foobar').to_hash
+    filters = hash[:query][:bool][:filter]
+    filters.count.must_equal(4)
+    filters[0].must_equal(FILTER_PUBLISHED)
+    filters[1].must_equal(FILTER_NETWORK_VISIBLE)
+    filters[2].must_equal(FILTER_SERIES_VISIBLE)
+    filters[3].must_equal(FILTER_PARANOID)
   end
 
-  it "determines from/size from page param" do
-    dsl_hash = described_class.new(
-      params: { page: 3 },
-      query: "foo OR Bar",
-    ).to_hash
-    dsl_hash[:size].must_equal Story::MAX_SEARCH_RESULTS
-    dsl_hash[:from].must_equal( 2 * Story::MAX_SEARCH_RESULTS )
+  it 'filters for authorized stories' do
+    hash = StoryQueryBuilder.new(query: 'foobar', authorization: authorization).to_hash
+    filters = hash[:query][:bool][:filter]
+    filters.count.must_equal(2)
+    filters[0].must_equal({terms: {account_id: [account.id], _name: :authz}})
+    filters[1].must_equal(FILTER_PARANOID)
   end
 
-  describe "parses date ranges" do
-    it "when created_at is present" do
-      some_time = Time.zone.parse("2016-03-25T02:55:57Z")
-      dsl = described_class.new(
-        fielded_query: {
-          created_at: some_time.to_s,
-          created_within: "6 months",
-        },
-        query: "foo OR Bar",
-      )
-      dsl.composite_query_string.must_equal(
-        "(foo OR Bar) AND (created_at:[#{(some_time.utc - 6.months).iso8601} TO #{some_time.utc.iso8601}])"
-      )
-    end
-
-    it "when created_at is not present defaults to relative-to-now" do
-      Timecop.freeze do
-        six_months_ago = (Time.current.utc - 6.months).iso8601
-        dsl = described_class.new(
-          fielded_query: {
-            created_within: "6 months",
-          },
-          query: "foo OR Bar",
-        )
-        dsl.composite_query_string.must_equal(
-          "(foo OR Bar) AND (created_at:[#{six_months_ago} TO now])"
-        )
-      end
-    end
-  end
-
-  it "#structured_query" do
-    dsl = described_class.new(
-      fielded_query: { something: "123", maybe: 'NULL' },
-      query: "foo OR Bar",
-    )
-    dsl.structured_query.must_be_instance_of FieldedSearchQuery
-    dsl.structured_query.to_s.must_equal "something:(123)"
-  end
-
-  it "#composite_query_string" do
-    dsl = described_class.new(
-      fielded_query: { something: "123", maybe: 'NULL' },
-      query: "foo OR Bar",
-    )
-    dsl.composite_query_string.must_equal "(foo OR Bar) AND (something:(123))"
-  end
-
-  it "#humanized_query_string" do
-    dsl = described_class.new(
-      fielded_query: { something: "123", maybe: 'NULL' },
-      query: "foo OR Bar",
-    )
-    dsl.humanized_query_string.must_equal "(foo OR Bar) AND (Something:(123))"
-  end
 end

--- a/test/support/elasticsearch_helper.rb
+++ b/test/support/elasticsearch_helper.rb
@@ -45,7 +45,7 @@ class ElasticsearchHelper
   # create test indices.
   def self.es_setup
     helper = new
-    [User, Series, Story, StationAccount, GroupAccount, Playlist].each do |klass|
+    [Series, Story].each do |klass|
       helper.create_es_index(klass)
     end
   rescue Faraday::ConnectionFailed


### PR DESCRIPTION
Various fixes/features for PRX/publish.prx.org#540

- [x] Cleanup search routes and params
  - Only add `/search` routes we need
  - Bring query params (other than `q`) into alignment with other sort/filter stuff we use
  - Get nested routes filtering results correctly
  - Revisit some "scope" issues with story/series public vs auth routes
- [x] Fully implement series-searching
  - requires an index change
- [x] Backfill tests for ES modules
- [x] Fix various bugs found while testing Publish search-as-you-type
  - Escape input to avoid 500s
  - Don't require a `q` param present to get > 0 results
  - Various indifferent-access bugs when filtering