### PR TITLE
Surface worker errors in logs

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -4,6 +4,7 @@ class ApplicationJob < ActiveJob::Base
 
   rescue_from(StandardError) do |e|
     NewRelic::Agent.notice_error(e)
+    raise e
   end
 
   around_perform do |job, block|


### PR DESCRIPTION
This PR has the goal of reducing/eliminating exceptions within the shoryuken worker machinery. Assuming that we are allowing long-running jobs (20-30 seconds) on our worker queues, then for big job batches, it's possible to consume all of our database connections. Assuming the db pool < # worker and a short db pool request timeout.

First, this PR contains a minor tweak to surface exceptions in the worker log. Looking something like:
```
ERROR: Process died, reason: Error while trying to deserialize arguments: could not obtain a database connection within 5.000 seconds (waited 5.001 seconds)
```
This should allow us to get a handle on how many workers are dying.

Secondly, we set up a env/secrets change for the workers: increase the `DATABASE_POOL_SIZE` to match `CONCURRENCY` (per the recommendations of shoryuken) plus the database needs of `say_when`.  

