### PR TITLE
try to sidestep series create transaction

### DIFF
--- a/app/models/audio_file.rb
+++ b/app/models/audio_file.rb
@@ -6,7 +6,7 @@ class AudioFile < BaseModel
   include ValidityFlag
 
   belongs_to :account
-  belongs_to :audio_version, touch: true
+  belongs_to :audio_version
 
   has_one :story, through: :audio_version
 
@@ -21,6 +21,7 @@ class AudioFile < BaseModel
 
   before_save :set_position, :set_status, only: [:update, :create]
   after_commit :update_version_status
+  after_commit :touch_audio_version
   after_destroy :update_version_status
 
   MP3_CONTENT_TYPE = 'audio/mpeg'.freeze
@@ -34,6 +35,10 @@ class AudioFile < BaseModel
     if !account && story
       self.account = story.account
     end
+  end
+
+  def touch_audio_version
+    audio_version.try(:touch)
   end
 
   def fixerable_final?

--- a/app/models/audio_file_template.rb
+++ b/app/models/audio_file_template.rb
@@ -4,7 +4,7 @@ class AudioFileTemplate < BaseModel
 
   include IntegerEnhancements
 
-  belongs_to :audio_version_template, touch: true
+  belongs_to :audio_version_template
 
   acts_as_list scope: :audio_version_template
 
@@ -19,6 +19,12 @@ class AudioFileTemplate < BaseModel
             numericality: true
 
   validate :max_is_greater_than_min_if_set
+
+  after_commit :touch_audio_version_template
+
+  def touch_audio_version_template
+    audio_version_template.try(:touch)
+  end
 
   def set_defaults
     self.label ||= 'segment'

--- a/app/models/audio_version.rb
+++ b/app/models/audio_version.rb
@@ -6,16 +6,21 @@ class AudioVersion < BaseModel
 
   belongs_to :story, -> { with_deleted },
              class_name: 'Story',
-             foreign_key: 'piece_id', touch: true
+             foreign_key: 'piece_id'
 
   belongs_to :audio_version_template
   has_many :audio_files, -> { order :position }, dependent: :destroy
 
   before_save :set_status, only: [:update, :create]
   after_commit :update_story_status
+  after_commit :touch_story
   after_destroy :update_story_status
 
   acts_as_paranoid
+
+  def touch_story
+    story.try(:touch)
+  end
 
   def length(reload=false)
     @_length = nil if reload

--- a/app/models/audio_version_template.rb
+++ b/app/models/audio_version_template.rb
@@ -4,14 +4,15 @@ class AudioVersionTemplate < BaseModel
 
   include IntegerEnhancements
 
-  belongs_to :series, touch: true
+  belongs_to :series
 
   has_many :audio_versions, dependent: :nullify
   has_many :audio_file_templates, -> { order :position }, dependent: :destroy
   has_many :distribution_templates, dependent: :destroy
   has_many :distributions, through: :distribution_templates
 
-  after_save :touch_audio_versions
+  after_commit :touch_audio_versions
+  after_commit :touch_series
 
   after_touch :touch_audio_versions
 
@@ -40,6 +41,10 @@ class AudioVersionTemplate < BaseModel
 
   def touch_audio_versions
     audio_versions.update_all(updated_at: Time.now)
+  end
+
+  def touch_series
+    series.try(:touch)
   end
 
   def validate_audio_version(audio_version)

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -63,7 +63,7 @@ class Story < BaseModel
 
   belongs_to :account, -> { with_deleted }
   belongs_to :creator, -> { with_deleted }, class_name: 'User', foreign_key: 'creator_id'
-  belongs_to :series, touch: true
+  belongs_to :series
   belongs_to :network
 
   has_many :images,
@@ -101,6 +101,8 @@ class Story < BaseModel
   before_validation :update_published_to_released
 
   before_save :set_status, only: [:update, :create]
+
+  after_commit :touch_series
 
   # indicates piece is published with promos only - not full audio
   event_attribute :promos_only_at
@@ -151,6 +153,10 @@ class Story < BaseModel
   def self.text_search(text, params = {}, authz = nil)
     builder = StoryQueryBuilder.new(query: text, params: params, authorization: authz)
     search(builder.as_dsl).records
+  end
+
+  def touch_series
+    series.try(:touch)
   end
 
   def points(level=point_level)

--- a/test/models/audio_file_test.rb
+++ b/test/models/audio_file_test.rb
@@ -85,8 +85,12 @@ describe AudioFile do
 
     audio_file.filename = 'something'
     audio_file.save!
-    story.reload
+
+    # simulate the touch chaing
+    audio_file.run_callbacks(:commit)
     version.reload
+    version.run_callbacks(:commit)
+    story.reload
 
     story.updated_at.must_be :>, stamp
     version.updated_at.must_be :>, stamp


### PR DESCRIPTION
Steps around a deadlock by touching in the `post_commit` hook.

I've been running this patch for a couple days as part up `feat/prepare-for-podcast-ui`and have not seen the deadlock since. 