### PR TITLE
Make sure feeder episodes have media

### DIFF
--- a/app/models/episode_import.rb
+++ b/app/models/episode_import.rb
@@ -22,6 +22,7 @@ class EpisodeImport < BaseModel
   scope :having_duplicate_guids, -> do
     unscope(where: :has_duplicate_guid).where(has_duplicate_guid: true)
   end
+  scope :complete, -> { where(status: COMPLETE) }
 
   before_validation :set_defaults, on: :create
 

--- a/app/models/story_distribution.rb
+++ b/app/models/story_distribution.rb
@@ -22,6 +22,14 @@ class StoryDistribution < BaseModel
     true
   end
 
+  def complete!
+    # no op for the super class
+  end
+
+  def completed?
+    true
+  end
+
   def kind
     (type || 'StoryDistribution').safe_constantize.model_name.element.sub(/_distribution$/, '')
   end

--- a/app/models/story_distributions/episode_distribution.rb
+++ b/app/models/story_distributions/episode_distribution.rb
@@ -7,6 +7,8 @@ class StoryDistributions::EpisodeDistribution < StoryDistribution
   include Rails.application.routes.url_helpers
   include Announce::Publisher
 
+  before_save :clear_episode, if: :url_changed?
+
   def self.default_story_url(story)
     path = "#{story.class.name.underscore.pluralize}/#{story.id}"
     ENV['PRX_HOST'].nil? ? nil : "https://#{ENV['PRX_HOST']}/#{path}"
@@ -45,9 +47,7 @@ class StoryDistributions::EpisodeDistribution < StoryDistribution
   end
 
   def completed?
-    episode = get_episode
-    episode.try(:media)
-    get_episode.media.present?
+    get_episode.try(:media).present?
   end
 
   def create_or_update_episode(attrs = {})
@@ -68,6 +68,10 @@ class StoryDistributions::EpisodeDistribution < StoryDistribution
   def get_episode
     @get_episode ||= api(root: feeder_root, account: distribution.account.id).
                      tap { |a| a.href = auth_url }.get
+  end
+
+  def clear_episode
+    @get_episode = nil
   end
 
   def auth_url

--- a/app/models/story_distributions/episode_distribution.rb
+++ b/app/models/story_distributions/episode_distribution.rb
@@ -66,7 +66,8 @@ class StoryDistributions::EpisodeDistribution < StoryDistribution
   end
 
   def get_episode
-    @episode ||= api(root: feeder_root, account: distribution.account.id).tap { |a| a.href = auth_url }.get
+    @get_episode ||= api(root: feeder_root, account: distribution.account.id).
+                     tap { |a| a.href = auth_url }.get
   end
 
   def auth_url

--- a/app/models/story_distributions/episode_distribution.rb
+++ b/app/models/story_distributions/episode_distribution.rb
@@ -39,6 +39,17 @@ class StoryDistributions::EpisodeDistribution < StoryDistribution
     published
   end
 
+  def complete!
+    super
+    announce(:story, :update, Api::Msg::StoryRepresenter.new(story).to_json)
+  end
+
+  def completed?
+    episode = get_episode
+    episode.try(:media)
+    get_episode.media.present?
+  end
+
   def create_or_update_episode(attrs = {})
     episode = nil
     if url.blank?
@@ -55,7 +66,7 @@ class StoryDistributions::EpisodeDistribution < StoryDistribution
   end
 
   def get_episode
-    api(root: feeder_root, account: distribution.account.id).tap { |a| a.href = auth_url }.get
+    @episode ||= api(root: feeder_root, account: distribution.account.id).tap { |a| a.href = auth_url }.get
   end
 
   def auth_url

--- a/config/initializers/say_when.rb
+++ b/config/initializers/say_when.rb
@@ -30,6 +30,19 @@ end
 begin
   SayWhen.schedule(
     group: 'application',
+    name: 'check_imported',
+    trigger_strategy: 'cron',
+    trigger_options: { expression: '0 0/5 * * * ?', time_zone: 'UTC' },
+    job_class: 'Distribution',
+    job_method: 'check_imported!'
+  )
+rescue ActiveRecord::StatementInvalid => ex
+  puts "Failed to init say_when job: #{ex.inspect}"
+end
+
+begin
+  SayWhen.schedule(
+    group: 'application',
     name: 'reindex_stories',
     trigger_strategy: 'cron',
     trigger_options: { expression: '0 0 8 * * ? *', time_zone: 'UTC' },

--- a/test/fixtures/episode.json
+++ b/test/fixtures/episode.json
@@ -2,6 +2,7 @@
   "guid": "aguid",
   "title": "Episode 1",
   "publishedAt": "2017-08-30T04:00:00.000Z",
+  "media": [],
   "_links": {
     "curies": [
       {

--- a/test/models/distributions/podcast_distribution_test.rb
+++ b/test/models/distributions/podcast_distribution_test.rb
@@ -104,6 +104,7 @@ describe Distributions::PodcastDistribution do
       episode_distribution.wont_be_nil
       episode_distribution.wont_be :distributed?
       episode_distribution.wont_be :published?
+      episode_distribution.wont_be :completed?
 
       distribution.story_distributions.count.must_equal 1
       distribution.wont_be :stories_published?
@@ -111,6 +112,7 @@ describe Distributions::PodcastDistribution do
       episode_distribution.update_attributes(url: episode_url)
       episode_distribution.must_be :distributed?
       episode_distribution.must_be :published?
+      episode_distribution.wont_be :completed?
       distribution.story_distributions = [episode_distribution]
       distribution.must_be :stories_published?
     end

--- a/test/models/story_distributions/episode_distribution_test.rb
+++ b/test/models/story_distributions/episode_distribution_test.rb
@@ -78,4 +78,13 @@ describe StoryDistributions::EpisodeDistribution do
       end
     end
   end
+
+  it 'checks if the episode has completed' do
+    distro = build(:episode_distribution, distribution: podcast_distribution, url: episode_url)
+    podcast_distribution.stub(:get_account_token, 'token') do
+      distro.stub(:get_account_token, 'token') do
+        distro.wont_be :completed?
+      end
+    end
+  end
 end


### PR DESCRIPTION
Seen: feeder episodes with empty media.  This PR just sort of blindly re-announces an `update` to the story, until:

(1) Feeder figures it out and pulls/processes the media
or 
(2) The 60-minute window runs out