### PR TITLE
Fixup references in the distribution

### DIFF
--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -46,13 +46,13 @@ class Distribution < BaseModel
   end
 
   def self.recently_imported_stories(start_secs, end_secs)
-    story_ids = EpisodeImport.completed.where(
+    story_ids = EpisodeImport.complete.where(
       '`updated_at` <= ? AND `updated_at` >= ?',
       start_secs.seconds.ago,
       end_secs.seconds.ago
-    ).pluck(:story_id).uniq
+    ).pluck(:piece_id).uniq
 
-    Story.find(story_ids).joins(:distributions).distinct
+    Story.where(id: story_ids).joins(:distributions).distinct
   end
 
   def self.fix_story_distribution(story, dist)


### PR DESCRIPTION
This PR sets up a few minor edits for the new belt and suspenders approach to publishing audio file.

I ran through the fixup process in the console on staging and confirmed that this worked: episodes on feeder converged to an expected number of episodes w/ audio files. 