### PR TITLE
Feat/unlock feeder with import

### DIFF
--- a/app/models/distributions/podcast_distribution.rb
+++ b/app/models/distributions/podcast_distribution.rb
@@ -54,10 +54,14 @@ class Distributions::PodcastDistribution < Distribution
       raise 'Failed to get podcast url on create' if podcast_url.blank?
       update_attributes!(url: podcast_url)
     else
-      podcast = get_podcast
-      podcast = podcast.put(attrs)
+      podcast = update_podcast!(attrs)
     end
     podcast
+  end
+
+  def update_podcast!(attrs = {})
+      podcast = get_podcast
+      podcast = podcast.put(attrs)
   end
 
   def get_podcast

--- a/app/models/distributions/podcast_distribution.rb
+++ b/app/models/distributions/podcast_distribution.rb
@@ -60,8 +60,7 @@ class Distributions::PodcastDistribution < Distribution
   end
 
   def update_podcast!(attrs = {})
-      podcast = get_podcast
-      podcast = podcast.put(attrs)
+    get_podcast.put(attrs)
   end
 
   def get_podcast

--- a/test/models/podcast_import_test.rb
+++ b/test/models/podcast_import_test.rb
@@ -341,7 +341,7 @@ describe PodcastImport do
         importer.podcast_distribution.stub :update_podcast!, podcast_distribution_mock do
           ep1.import
         end
-        podcast_distribution_mock.verify()
+        podcast_distribution_mock.verify
       end
     end
 

--- a/test/models/podcast_import_test.rb
+++ b/test/models/podcast_import_test.rb
@@ -336,7 +336,6 @@ describe PodcastImport do
 
       ep1.stub :podcast_import, importer do
 
-        # stub the podcast_distribution update_imports!
         podcast_distribution_mock = MiniTest::Mock.new
         podcast_distribution_mock.expect :call, true, [{locked: false}]
         importer.podcast_distribution.stub :update_podcast!, podcast_distribution_mock do


### PR DESCRIPTION
Per discussion in #publish, This sets up a way to unlock the podcast in feeder when a podcast import is complete.

At worse, we unlock a few times as the final episode imports race to completion.