### PR TITLE
Feat/fixup cms auth 500

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -18,6 +18,8 @@ class Api::BaseController < ApplicationController
   include PolymorphicResource
   include AnnounceActions
 
+  before_filter :authenticate_user!, only: [:create, :update, :delete]
+
   protect_from_forgery with: :null_session
 
   allow_params :show, [:api_version, :format, :zoom]

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -68,6 +68,10 @@ class Api::BaseController < ApplicationController
     Authorization.new(prx_auth_token) if prx_auth_token
   end
 
+  def authenticate_user!
+    user_not_authorized unless current_user
+  end
+
   def filtered(arel)
     keys = self.class.resources_params || []
     where_hash = params.slice(*keys)

--- a/app/controllers/api/series_controller.rb
+++ b/app/controllers/api/series_controller.rb
@@ -3,6 +3,8 @@
 class Api::SeriesController < Api::BaseController
   include ApiSearchable
 
+  before_filter :authenticate_user!, only: :create
+
   api_versions :v1
 
   filter_resources_by :account_id

--- a/app/controllers/api/series_controller.rb
+++ b/app/controllers/api/series_controller.rb
@@ -3,8 +3,6 @@
 class Api::SeriesController < Api::BaseController
   include ApiSearchable
 
-  before_filter :authenticate_user!, only: :create
-
   api_versions :v1
 
   filter_resources_by :account_id

--- a/app/controllers/concerns/api_authenticated.rb
+++ b/app/controllers/concerns/api_authenticated.rb
@@ -10,10 +10,6 @@ module ApiAuthenticated
     before_filter :authenticate_user!
   end
 
-  def authenticate_user!
-    user_not_authorized unless current_user
-  end
-
   def cache_show?
     false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180926154742) do
+ActiveRecord::Schema.define(version: 20181030200041) do
 
   create_table "account_applications", force: :cascade do |t|
     t.integer  "account_id",            limit: 4

--- a/test/controllers/api/accounts_controller_test.rb
+++ b/test/controllers/api/accounts_controller_test.rb
@@ -5,8 +5,8 @@ describe Api::AccountsController do
   let(:membership) { create(:membership, account: account) }
   let (:user_without_account) { create(:user, with_individual_account: false) }
   let (:user) { create(:user) }
-  let (:write_token) { StubToken.new(nil, ['account:write'], nil) }
-  let (:token) { StubToken.new(nil, ['account'], nil) }
+  let (:write_token) { StubToken.new(nil, ['account:write'], user.id) }
+  let (:token) { StubToken.new(nil, ['account'], user.id) }
 
   it 'should show' do
     get(:show, { api_version: 'v1', format: 'json', id: account.id } )

--- a/test/controllers/api/audio_files_controller_test.rb
+++ b/test/controllers/api/audio_files_controller_test.rb
@@ -1,8 +1,9 @@
 require 'test_helper'
 
 describe Api::AudioFilesController do
+  let(:user) { create(:user) }
   let(:account) { create(:account) }
-  let(:token) { StubToken.new(account.id, ['member']) }
+  let(:token) { StubToken.new(account.id, ['member'], user.id) }
   let(:story) { create(:story, account: account) }
   let(:story_with_version) { create(:story, account: account) }
   let(:audio_file) { create(:audio_file, story: story, account: account) }

--- a/test/controllers/api/distributions_controller_test.rb
+++ b/test/controllers/api/distributions_controller_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 describe Api::DistributionsController do
 
+  let(:user) { create(:user) }
   let(:account) { create(:account) }
   let(:series) { create(:series, account: account) }
   let(:audio_version_template) { create(:audio_version_template, series: series) }
@@ -10,7 +11,7 @@ describe Api::DistributionsController do
       dist.audio_version_templates << audio_version_template
     end
   end
-  let(:token) { StubToken.new(account.id, ['member']) }
+  let(:token) { StubToken.new(account.id, ['member'], user.id) }
 
   it 'should show' do
     get :show, api_request_opts(series_id: distribution.owner.id, id: distribution.id)

--- a/test/controllers/api/series_controller_test.rb
+++ b/test/controllers/api/series_controller_test.rb
@@ -63,6 +63,13 @@ describe Api::SeriesController do
     end
   end
 
+  describe 'without a valid token' do
+    it 'does not create a series' do
+      post :create, { title: 'foobar' }.to_json, api_version: 'v1', account_id: account.id
+      assert_response 401
+    end
+  end
+
   describe 'with a valid token' do
     around do |test|
       token = StubToken.new(account.id, ['member'], user.id)

--- a/test/controllers/api/series_images_controller_test.rb
+++ b/test/controllers/api/series_images_controller_test.rb
@@ -4,7 +4,7 @@ describe Api::SeriesImagesController do
   let(:user) { create(:user) }
   let(:series) { create(:series, account: user.individual_account) }
   let(:series_image) { create(:series_image, series: series, purpose: nil) }
-  let(:token) { StubToken.new(series.account.id, ['member']) }
+  let(:token) { StubToken.new(series.account.id, ['member'], user.id) }
 
   before(:each) do
     class << @controller; attr_accessor :prx_auth_token; end

--- a/test/controllers/api/story_distribitions_controller_test.rb
+++ b/test/controllers/api/story_distribitions_controller_test.rb
@@ -2,10 +2,11 @@ require 'test_helper'
 
 describe Api::StoryDistributionsController do
 
+  let(:user) { create(:user) }
   let(:story_distribution) { create(:episode_distribution) }
   let(:distribution) { story_distribution.distribution }
   let(:story) { story_distribution.story }
-  let(:token) { StubToken.new(story.account.id, ['member']) }
+  let(:token) { StubToken.new(story.account.id, ['member'], user.id) }
 
   it 'should show' do
     get :show, api_request_opts(story_id: story.id, id: story_distribution.id)

--- a/test/controllers/api/story_images_controller_test.rb
+++ b/test/controllers/api/story_images_controller_test.rb
@@ -1,10 +1,11 @@
 require 'test_helper'
 
 describe Api::StoryImagesController do
+  let(:user) { create(:user) }
   let(:story_image) { create(:story_image) }
   let(:story) { story_image.story }
   let(:account) { story.account }
-  let(:token) { StubToken.new(account.id, ['member']) }
+  let(:token) { StubToken.new(account.id, ['member'], user.id) }
 
   before(:each) do
     class << @controller; attr_accessor :prx_auth_token; end

--- a/test/controllers/concerns/announce_actions_test.rb
+++ b/test/controllers/concerns/announce_actions_test.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require 'announce_actions'
+require 'test_models'
 
 Api::TestObjectsController.class_eval do
   include AnnounceActions

--- a/test/controllers/concerns/api_authenticated_test.rb
+++ b/test/controllers/concerns/api_authenticated_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 describe ApiAuthenticated do
 
-  class ApiAuthenticatedTestController < ActionController::Base
+  class ApiAuthenticatedTestController < Api::BaseController
     include ApiAuthenticated
 
     def current_user


### PR DESCRIPTION
Fixes up a 500 error when calling POST on the non-auth version of the `api_account_series#create`.  Everything underneath `api/<version>/authorization` is treated as non-cacheable, which is synonymous with writing to resources (and therefor being authenticated).

This PR allows for authenticating writable api resources that are *not* under the `/api/<version>/authorization` path. 