### PR TITLE
Leave mp3 extensions alone

### DIFF
--- a/app/models/audio_file.rb
+++ b/app/models/audio_file.rb
@@ -46,7 +46,13 @@ class AudioFile < BaseModel
   end
 
   def enclosure_url
-    audio? ? public_url(version: :broadcast, extension: 'mp3') : public_url
+    if audio? && filename_extension.downcase == 'mp3'
+      public_url(version: :broadcast)
+    elsif audio?
+      public_url(version: :broadcast, extension: 'mp3') # force extension
+    else
+      public_url
+    end
   end
 
   def enclosure_content_type

--- a/test/models/audio_file_test.rb
+++ b/test/models/audio_file_test.rb
@@ -59,6 +59,21 @@ describe AudioFile do
     audio_file.enclosure_content_type.must_match 'audio/mpeg'
   end
 
+  # because of all the caching in carrierwave, just stub the asset filename
+  it 'sets a correct extension on the enclosure_url' do
+    audio_file.stub(:public_asset_filename, 'something.MP2') do
+      audio_file.enclosure_url.must_match "/web/audio_file/#{audio_file.id}/broadcast/something.mp3"
+    end
+
+    audio_file.stub(:public_asset_filename, 'something.MP3') do
+      audio_file.enclosure_url.must_match "/web/audio_file/#{audio_file.id}/broadcast/something.MP3"
+    end
+
+    audio_file.stub(:public_asset_filename, 'something.mp3') do
+      audio_file.enclosure_url.must_match "/web/audio_file/#{audio_file.id}/broadcast/something.mp3"
+    end
+  end
+
   it 'can update the underlying file' do
     audio_file.update_file!('test2.mp3')
     audio_file.filename.must_equal 'test2.mp3'


### PR DESCRIPTION
Issue where user uploaded a `something.MP3` file via Publish/CMS.  And then the PublicAsset stuff in CMS returns the wrong case in the `enclosure_url`, and the signed redirect-to-S3 is a 404/403.

The cms-audio-lambda copies the file over as-is to:

```
s3://production.mediajoint.prx.org/public/audio_files/<id>/something.MP3
s3://production.mediajoint.prx.org/public/audio_files/<id>/something_broadcast.MP3
```

This mirrors what Exchange does, where the original file would be an mp2 or something, but `_broadcast` is a transcoded mp3.  But unlink Exchange, the cms-audio-lambda leaves the extension alone.

CMS should just return the original extension lower-or-uppercase.