### PR TITLE
ensure that nil values are renderd in podcast import representer

### DIFF
--- a/app/representers/api/podcast_import_representer.rb
+++ b/app/representers/api/podcast_import_representer.rb
@@ -9,7 +9,7 @@ class Api::PodcastImportRepresenter < Api::BaseRepresenter
   property :created_at, writeable: false
   property :updated_at, writeable: false
   property :feed, writeable: false
-  property :feed_episode_count, writeable: false
+  property :feed_episode_count, writeable: false, render_nil: true
 
   def self_url(represented)
     if represented.persisted?

--- a/test/representers/api/podcast_import_repesenter_test.rb
+++ b/test/representers/api/podcast_import_repesenter_test.rb
@@ -42,4 +42,16 @@ describe Api::PodcastImportRepresenter do
     json['url'].must_equal 'http://google.horse'
     json['_links']['self']['href'].must_match /authorization\/podcast_imports$/
   end
+
+  it 'renders a nil feed_episode_count' do
+    podcast_import.feed_episode_count = nil
+    json = JSON.parse(representer.to_json)
+    json['feedEpisodeCount'].must_equal nil
+  end
+
+  it 'renders a numeric feed_episode_count' do
+    podcast_import.feed_episode_count = 10
+    json = JSON.parse(representer.to_json)
+    json['feedEpisodeCount'].must_equal 10
+  end
 end


### PR DESCRIPTION
This PR ensures that nil feed_episode_count values are rendered in podcast import representer.