### PR TITLE
Validate > 0 audio files

### DIFF
--- a/app/models/audio_version.rb
+++ b/app/models/audio_version.rb
@@ -54,12 +54,6 @@ class AudioVersion < BaseModel
   end
 
   def set_status
-    if audio_files.empty?
-      self.status = INVALID
-      self.status_message = 'No audio files uploaded'
-      return
-    end
-
     noncompliant_files = audio_files.select do |af|
       !af.compliant_with_template? || af.status == INVALID
     end

--- a/app/models/audio_version.rb
+++ b/app/models/audio_version.rb
@@ -54,6 +54,12 @@ class AudioVersion < BaseModel
   end
 
   def set_status
+    if audio_files.empty?
+      self.status = INVALID
+      self.status_message = 'No audio files uploaded'
+      return
+    end
+
     noncompliant_files = audio_files.select do |af|
       !af.compliant_with_template? || af.status == INVALID
     end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -326,12 +326,12 @@ class Story < BaseModel
 
   def set_status
     av_errors = ''
-    if audio_versions.empty?
-      av_errors << "Story '#{title}' has no audio."
+    if audio_files.empty?
+      av_errors << "Story '#{title}' has no audio"
     else
       audio_versions.each do |av|
         if !av.compliant_with_template? || av.status == INVALID
-          av_errors << "Invalid audio version: '#{av.label}.' "
+          av_errors << "Invalid audio version: '#{av.label}' "
         end
       end
     end

--- a/test/factories/audio_version_factory.rb
+++ b/test/factories/audio_version_factory.rb
@@ -12,7 +12,7 @@ FactoryGirl.define do
       audio_files_count 1
     end
 
-    after(:create) do |audio_version, evaluator|
+    after(:create, :stub) do |audio_version, evaluator|
       c = evaluator.audio_files_count.to_i
       (1..c).each { |i| FactoryGirl.create(:audio_file, audio_version: audio_version, position: i) }
       audio_version.reload

--- a/test/factories/audio_version_factory.rb
+++ b/test/factories/audio_version_factory.rb
@@ -16,6 +16,7 @@ FactoryGirl.define do
       c = evaluator.audio_files_count.to_i
       (1..c).each { |i| FactoryGirl.create(:audio_file, audio_version: audio_version, position: i) }
       audio_version.reload
+      audio_version.length(true)
     end
 
     factory :promos do

--- a/test/factories/audio_version_template_factory.rb
+++ b/test/factories/audio_version_template_factory.rb
@@ -1,18 +1,10 @@
 FactoryGirl.define do
   factory :audio_version_template do
 
-    transient do
-      series { false }
-    end
-
     label 'Audio Version'
     content_type 'audio/mpeg'
     length_minimum 10
     length_maximum 100
-
-    after(:create) do |avt, evaluator|
-      avt.series = create(:series, templates_count: 0) if evaluator.series
-    end
 
     factory :audio_version_template_with_file_templates do
       after(:create) do |avt|

--- a/test/factories/audio_version_template_factory.rb
+++ b/test/factories/audio_version_template_factory.rb
@@ -1,10 +1,19 @@
 FactoryGirl.define do
   factory :audio_version_template do
-    series
+
+    transient do
+      series { false }
+    end
+
     label 'Audio Version'
     content_type 'audio/mpeg'
     length_minimum 10
     length_maximum 100
+
+    after(:create) do |avt, evaluator|
+      avt.series = create(:series, templates_count: 0) if evaluator.series
+    end
+
     factory :audio_version_template_with_file_templates do
       after(:create) do |avt|
         create_list(:audio_file_template, 3, audio_version_template: avt)

--- a/test/models/audio_file_test.rb
+++ b/test/models/audio_file_test.rb
@@ -32,7 +32,8 @@ describe AudioFile do
     af2.destroy!
     af1.reload.position.must_equal 1
     af3.reload.position.must_equal 3
-    av.save
+    av.reload
+
     av.status.must_equal 'invalid'
     av.status_message.must_equal 'Audio file missing for position 2'
   end

--- a/test/models/audio_version_template_test.rb
+++ b/test/models/audio_version_template_test.rb
@@ -2,9 +2,9 @@ require 'test_helper'
 
 describe AudioVersionTemplate do
 
-  let(:audio_version_template) {
+  let(:audio_version_template) do
     create(:audio_version_template, series: build(:series), length_minimum: 70)
-  }
+  end
   let(:audio_version) { create(:audio_version, audio_version_template: audio_version_template) }
   let(:audio_file) { create(:audio_file, audio_version: audio_version) }
 

--- a/test/models/audio_version_template_test.rb
+++ b/test/models/audio_version_template_test.rb
@@ -2,7 +2,9 @@ require 'test_helper'
 
 describe AudioVersionTemplate do
 
-  let(:audio_version_template) { create(:audio_version_template, series: build(:series), length_minimum: 70) }
+  let(:audio_version_template) {
+    create(:audio_version_template, series: build(:series), length_minimum: 70)
+  }
   let(:audio_version) { create(:audio_version, audio_version_template: audio_version_template) }
   let(:audio_file) { create(:audio_file, audio_version: audio_version) }
 

--- a/test/models/audio_version_template_test.rb
+++ b/test/models/audio_version_template_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 describe AudioVersionTemplate do
 
-  let(:audio_version_template) { create(:audio_version_template) }
+  let(:audio_version_template) { create(:audio_version_template, series: build(:series), length_minimum: 70) }
   let(:audio_version) { create(:audio_version, audio_version_template: audio_version_template) }
   let(:audio_file) { create(:audio_file, audio_version: audio_version) }
 
@@ -26,7 +26,7 @@ describe AudioVersionTemplate do
 
   it 'can tell if version length doesnt match template' do
     error_results = audio_version_template.validate_audio_version(audio_version)
-    error_results.must_include 'long but must be 10 seconds - 1 minute and'
+    error_results.must_include 'long but must be 1 minute and 10 seconds - 1 minute and'
   end
 
   it 'validates with just a minimum' do

--- a/test/models/audio_version_test.rb
+++ b/test/models/audio_version_test.rb
@@ -17,12 +17,6 @@ describe AudioVersion do
     audio_version.length(true).must_equal audio_version.duration
   end
 
-  it 'checks that the files exist' do
-    av = create(:audio_version, audio_files_count: 0)
-    av.status.must_equal 'invalid'
-    av.status_message.must_equal 'No audio files uploaded'
-  end
-
   describe 'checks files are in order' do
     let(:av) { create(:audio_version, audio_files_count: 4) }
 

--- a/test/models/audio_version_test.rb
+++ b/test/models/audio_version_test.rb
@@ -17,6 +17,12 @@ describe AudioVersion do
     audio_version.length(true).must_equal audio_version.duration
   end
 
+  it 'checks that the files exist' do
+    av = create(:audio_version, audio_files_count: 0)
+    av.status.must_equal 'invalid'
+    av.status_message.must_equal 'No audio files uploaded'
+  end
+
   describe 'checks files are in order' do
     let(:av) { create(:audio_version, audio_files_count: 4) }
 
@@ -78,7 +84,7 @@ describe AudioVersion do
 
   describe 'with a template' do
 
-    let(:audio_version_with_template) { create(:audio_version_with_template) }
+    let(:audio_version_with_template) { create(:audio_version_with_template, audio_files_count: 1) }
     let(:audio_file) { create(:audio_file, status_message: 'Foo bar', status: 'uploaded') }
 
     it 'can have a template' do
@@ -86,15 +92,15 @@ describe AudioVersion do
     end
 
     it 'shows self as valid if compliant with template and all files are valid' do
-      audio_version_with_template.instance_variable_set('@_length', 50)
-      audio_version_with_template.update_attributes(explicit: 'explicit')
+      audio_version_with_template.save
       audio_version_with_template.status_message.must_be_nil
       audio_version_with_template.status.must_equal 'complete'
       audio_version_with_template.must_be(:compliant_with_template?)
     end
 
     it 'shows self as invalid if incompliant with template' do
-      audio_version_with_template.update_attributes(explicit: 'explicit')
+      audio_version_with_template.audio_version_template.update_attributes(length_minimum: 70)
+      audio_version_with_template.save
       audio_version_with_template.status_message.must_include 'long but must be'
       audio_version_with_template.status.must_equal 'invalid'
       audio_version_with_template.wont_be(:compliant_with_template?)
@@ -102,7 +108,7 @@ describe AudioVersion do
 
     it 'shows self as invalid if any audio file is invalid' do
       audio_version_with_template.audio_files << audio_file
-      audio_version_with_template.update_attributes(explicit: 'explicit')
+      audio_version_with_template.save
       audio_version_with_template.status_message.must_include 'Foo bar'
       audio_version_with_template.status.must_equal 'invalid'
       audio_version_with_template.wont_be(:compliant_with_template?)
@@ -111,14 +117,14 @@ describe AudioVersion do
     it 'shows self as invalid if any audio file is not found or failed' do
       audio_file.update(status: 'not found', status_message: 'Was really not found')
       audio_version_with_template.audio_files << audio_file
-      audio_version_with_template.update_attributes(explicit: 'explicit')
+      audio_version_with_template.save
       audio_version_with_template.status_message.must_include 'not found'
       audio_version_with_template.status.must_equal 'invalid'
       audio_version_with_template.wont_be(:compliant_with_template?)
 
       audio_file.update(status: 'failed', status_message: 'Well that failed to process')
       audio_version_with_template.audio_files << audio_file
-      audio_version_with_template.update_attributes(explicit: 'explicit')
+      audio_version_with_template.save
       audio_version_with_template.status_message.must_include 'failed to process'
       audio_version_with_template.status.must_equal 'invalid'
       audio_version_with_template.wont_be(:compliant_with_template?)

--- a/test/models/story_test.rb
+++ b/test/models/story_test.rb
@@ -71,8 +71,8 @@ describe Story do
     let(:story) { create(:story) }
     let(:valid_version) { create(:audio_version, audio_version_template: valid_template) }
     let(:invalid_version) { create(:audio_version, audio_version_template: invalid_template) }
-    let(:valid_template) { create(:audio_version_template, length_minimum: 10)}
-    let(:invalid_template) { create(:audio_version_template, length_minimum: 70)}
+    let(:valid_template) { create(:audio_version_template, length_minimum: 10) }
+    let(:invalid_template) { create(:audio_version_template, length_minimum: 70) }
 
     it 'is invalid if it has no audio files' do
       story.audio_versions.first.audio_files = []

--- a/test/models/story_test.rb
+++ b/test/models/story_test.rb
@@ -44,7 +44,7 @@ describe Story do
       [af, av, story].each { |m| m.reload.status.must_equal 'complete' }
     end
 
-    it 'changes to valid when invalid audio file destroyed' do
+    it 'changes to invalid when no audio files' do
       av = story.audio_versions(true).first
       af = av.audio_files(true).first
       af.run_callbacks(:commit)
@@ -55,34 +55,48 @@ describe Story do
       af.run_callbacks(:commit)
       av.run_callbacks(:commit)
       [af, av, story].each { |m| m.reload.status.must_equal 'invalid' }
+      af.status_message.must_equal 'bad'
+      av.status_message.must_equal 'bad'
+      story.status_message.must_equal "Invalid audio version: 'Audio Version'"
 
       af.destroy
       av.run_callbacks(:commit)
-      [av, story].each { |m| m.reload.status.must_equal 'complete' }
+      av.reload.status.must_equal 'complete'
+      story.reload.status.must_equal 'invalid'
+      story.status_message.must_include 'has no audio'
     end
   end
 
   describe 'checking audio versions' do
     let(:story) { create(:story) }
-    let(:invalid_audio_versions) { create_list(:audio_version_with_template, 5) }
-    let(:valid_audio_versions) { create_list(:audio_version, 5) }
+    let(:valid_version) { create(:audio_version, audio_version_template: valid_template) }
+    let(:invalid_version) { create(:audio_version, audio_version_template: invalid_template) }
+    let(:valid_template) { create(:audio_version_template, length_minimum: 10)}
+    let(:invalid_template) { create(:audio_version_template, length_minimum: 70)}
 
-    it 'is invalid if it has no audio' do
+    it 'is invalid if it has no audio files' do
+      story.audio_versions.first.audio_files = []
+      story.audio_versions.first.update(label: 'test label')
+      story.status.must_equal 'invalid'
+      story.status_message.must_include 'has no audio'
+    end
+
+    it 'is invalid if it has no audio versions' do
       story.audio_versions = []
       story.update(title: 'test title')
       story.status.must_equal 'invalid'
-      story.status_message.must_include 'has no audio.'
+      story.status_message.must_include 'has no audio'
     end
 
     it 'is invalid if any its audio versions are invalid' do
-      story.audio_versions = invalid_audio_versions
+      story.audio_versions = [invalid_version]
       story.update(title: 'Title!')
       story.status.must_equal 'invalid'
       story.status_message.must_include 'Invalid audio version: '
     end
 
     it 'is valid if all its audio versions are valid' do
-      story.audio_versions = valid_audio_versions
+      story.audio_versions = [valid_version]
       story.update(title: 'Title!')
       story.status.must_equal 'complete'
       story.status_message.must_be_nil

--- a/test/representers/api/story_representer_test.rb
+++ b/test/representers/api/story_representer_test.rb
@@ -27,8 +27,6 @@ describe Api::StoryRepresenter do
   end
 
   describe 'status flags' do
-    let(:invalid_audio_versions) { create_list(:audio_version_with_template, 5) }
-    let(:valid_audio_versions) { create_list(:audio_version, 5) }
 
     it 'shows complete status if story has all valid and complete audio' do
       story.audio_versions.wont_be(:empty?)
@@ -38,7 +36,10 @@ describe Api::StoryRepresenter do
     end
 
     it 'shows invalid, plus errors, if story is invalid' do
-      story.audio_versions = invalid_audio_versions
+      tpl = create(:audio_version_template, length_minimum: 70)
+      version = create(:audio_version, audio_version_template: tpl)
+
+      story.audio_versions = [version]
       story.update(title: 'Title!')
       representer = Api::StoryRepresenter.new(story)
       json = JSON.parse(representer.to_json)


### PR DESCRIPTION
For #470.  Set a status/status_message on the story when there aren't any audio_files.

Main impact should be preventing accidental publishing of a story with 0 audio.  Not sure that's happened in real life, but can't be too careful.