### PR TITLE
connection supports 4 byte unicode characters 

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -10,7 +10,8 @@
 #   http://dev.mysql.com/doc/refman/5.0/en/old-client.html
 default: &default
   adapter: mysql2
-  encoding: utf8
+  encoding: utf8mb4
+  collation: utf8mb4_unicode_ci
   pool: <%= ENV['DATABASE_POOL_SIZE'] %>
   username: <%= ENV['DB_ENV_MYSQL_USER'] %>
   password: <%= ENV['DB_ENV_MYSQL_PASSWORD'] %>


### PR DESCRIPTION
Builds on https://github.com/PRX/exchange.prx.org/pull/482

This PR changes the default MySQL connection encoding from `utf8` to the superset encoding `utf8mb`. Non-op for existing data, but allows connections to query data with 4 byte utf8 code points (e.g. smiley emoji).