### PR TITLE
Filter by published state

### DIFF
--- a/app/controllers/api/auth/stories_controller.rb
+++ b/app/controllers/api/auth/stories_controller.rb
@@ -8,7 +8,7 @@ class Api::Auth::StoriesController < Api::StoriesController
 
   filter_resources_by :account_id, :series_id, :network_id
 
-  filter_params :highlighted, :purchased, :v4, :text, :noseries
+  filter_params :highlighted, :purchased, :v4, :text, :noseries, :state
 
   sort_params default: { updated_at: :desc },
               allowed: [:id, :created_at, :updated_at, :published_at, :title,
@@ -42,7 +42,20 @@ class Api::Auth::StoriesController < Api::StoriesController
 
   def filtered(resources)
     resources = resources.unseries if filters.noseries?
+    resources = filter_by_state(resources, filters.state) if filters.state?
     super(resources)
+  end
+
+  def filter_by_state(resources, state)
+    if state == 'published'
+      resources.published
+    elsif state == 'scheduled'
+      resources.scheduled
+    elsif state == 'draft'
+      resources.draft
+    else
+      resources.none
+    end
   end
 
   def resources_base

--- a/app/controllers/api/auth/stories_controller.rb
+++ b/app/controllers/api/auth/stories_controller.rb
@@ -20,6 +20,12 @@ class Api::Auth::StoriesController < Api::StoriesController
 
   before_filter :check_user_network, only: [:index], if: -> { params[:network_id] }
 
+  class InvalidState < HalApi::Errors::ApiError
+    def initialize(state = nil)
+      super("Invalid state filter: #{state}", 400)
+    end
+  end
+
   def sorted(arel)
     if coalesce_sort = (sorts || []).find_index { |s| s.keys.first == 'published_released_at' }
       arel = arel.coalesce_published_released(sorts[coalesce_sort].values.first)
@@ -54,7 +60,7 @@ class Api::Auth::StoriesController < Api::StoriesController
     elsif state == 'draft'
       resources.draft
     else
-      resources.none
+      raise InvalidState.new(state)
     end
   end
 
@@ -93,7 +99,7 @@ class Api::Auth::StoriesController < Api::StoriesController
     elsif state == 'draft'
       'NULL'
     else
-      'this-will-not-match'
+      raise InvalidState.new(state)
     end
   end
 end

--- a/app/controllers/api/auth/stories_controller.rb
+++ b/app/controllers/api/auth/stories_controller.rb
@@ -81,6 +81,19 @@ class Api::Auth::StoriesController < Api::StoriesController
   def search_params
     sparams = super
     sparams[:fq]['series_id'] = 'NULL' if filters.noseries?
+    sparams[:fq]['published_at'] = search_by_state(filters.state) if filters.state?
     sparams
+  end
+
+  def search_by_state(state)
+    if state == 'published'
+      '[* TO now]'
+    elsif state == 'scheduled'
+      '{now TO *}'
+    elsif state == 'draft'
+      'NULL'
+    else
+      'this-will-not-match'
+    end
   end
 end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -122,7 +122,8 @@ class Story < BaseModel
       select('pieces.*, series.subscription_approval_status, series.subscriber_only_at')
   }
   scope :published, -> { where('`published_at` <= ?', Time.now) }
-  scope :unpublished, -> { where('`published_at` IS NULL OR `published_at` > ?', Time.now) }
+  scope :scheduled, -> { where('`published_at` > ?', Time.now) }
+  scope :draft, -> { where('`published_at` IS NULL', Time.now) }
   scope :unseries, -> { where('`series_id` IS NULL') }
   scope :v4, -> { where(app_version: PRX::APP_VERSION) }
   scope :network_visible, -> { where('`network_only_at` IS NULL') }
@@ -231,13 +232,21 @@ class Story < BaseModel
   end
 
   def published
-    published_at && published_at <= DateTime.now
+    !!published_at && published_at <= DateTime.now
   end
 
   alias_method :"published?", :published
 
   def published=(value)
     self.published_at = date_for_boolean(value)
+  end
+
+  def scheduled?
+    !!published_at && published_at > DateTime.now
+  end
+
+  def draft?
+    published_at.nil?
   end
 
   def date_for_boolean(value)

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -232,7 +232,7 @@ class Story < BaseModel
   end
 
   def published
-    !!published_at && published_at <= DateTime.now
+    !!published_at && published_at <= Time.now
   end
 
   alias_method :"published?", :published
@@ -242,7 +242,7 @@ class Story < BaseModel
   end
 
   def scheduled?
-    !!published_at && published_at > DateTime.now
+    !!published_at && published_at > Time.now
   end
 
   def draft?

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -123,7 +123,7 @@ class Story < BaseModel
   }
   scope :published, -> { where('`published_at` <= ?', Time.now) }
   scope :scheduled, -> { where('`published_at` > ?', Time.now) }
-  scope :draft, -> { where('`published_at` IS NULL', Time.now) }
+  scope :draft, -> { where('`published_at` IS NULL') }
   scope :unseries, -> { where('`series_id` IS NULL') }
   scope :v4, -> { where(app_version: PRX::APP_VERSION) }
   scope :network_visible, -> { where('`network_only_at` IS NULL') }

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -43,7 +43,7 @@ services:
     volumes:
       - ./test/db/:/docker-entrypoint-initdb.d/
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.3.0
+    image: elasticsearch:6.4.3
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
     networks:
       - cms-net
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.3.0
+    image: elasticsearch:6.4.3
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster

--- a/test/controllers/api/auth/stories_controller_test.rb
+++ b/test/controllers/api/auth/stories_controller_test.rb
@@ -112,9 +112,10 @@ describe Api::Auth::StoriesController do
       assigns[:stories].must_include unpublished_story
     end
 
-    it 'filters to no stories' do
+    it 'throws an error for unknown states' do
       get(:index, api_version: 'v1', format: 'json', filters: 'state=whatever')
-      assigns[:stories].must_equal []
+      assert_response :bad_request
+      JSON.parse(response.body)['message'].must_match /invalid state filter/i
     end
 
     it 'applies multiple filters' do

--- a/test/controllers/api/auth/stories_controller_test.rb
+++ b/test/controllers/api/auth/stories_controller_test.rb
@@ -13,6 +13,7 @@ describe Api::Auth::StoriesController do
   let (:network_story) { create(:story, network_id: network.id, network_only_at: Time.now) }
   let (:v3_story) { create(:story_v3, account: account) }
   let (:released_story) { create(:story, account: account, released_at: Time.now + 1.day) }
+  let (:scheduled_story) { create(:story, account: account, published_at: Time.now + 1.day) }
 
   before do
     account.stories.each { |s| s }
@@ -79,6 +80,41 @@ describe Api::Auth::StoriesController do
       assert_not_nil assigns[:stories]
       assigns[:stories].must_include unpublished_story
       assigns[:stories].wont_include v3_story
+    end
+
+    it 'filters published stories' do
+      published_story.must_be :published?
+      scheduled_story.must_be :scheduled?
+      unpublished_story.must_be :draft?
+      get(:index, api_version: 'v1', format: 'json', filters: 'state=published')
+      assigns[:stories].must_include published_story
+      assigns[:stories].wont_include scheduled_story
+      assigns[:stories].wont_include unpublished_story
+    end
+
+    it 'filters scheduled stories' do
+      published_story.must_be :published?
+      scheduled_story.must_be :scheduled?
+      unpublished_story.must_be :draft?
+      get(:index, api_version: 'v1', format: 'json', filters: 'state=scheduled')
+      assigns[:stories].wont_include published_story
+      assigns[:stories].must_include scheduled_story
+      assigns[:stories].wont_include unpublished_story
+    end
+
+    it 'filters draft stories' do
+      published_story.must_be :published?
+      scheduled_story.must_be :scheduled?
+      unpublished_story.must_be :draft?
+      get(:index, api_version: 'v1', format: 'json', filters: 'state=draft')
+      assigns[:stories].wont_include published_story
+      assigns[:stories].wont_include scheduled_story
+      assigns[:stories].must_include unpublished_story
+    end
+
+    it 'filters to no stories' do
+      get(:index, api_version: 'v1', format: 'json', filters: 'state=whatever')
+      assigns[:stories].must_equal []
     end
 
     it 'applies multiple filters' do

--- a/test/controllers/api/auth/stories_controller_test.rb
+++ b/test/controllers/api/auth/stories_controller_test.rb
@@ -200,6 +200,16 @@ describe Api::Auth::StoriesController do
         stories.wont_include v3_story
       end
 
+      it 'filters published state stories' do
+        published_story.must_be :published?
+        unpublished_story.must_be :draft?
+        get(:search, api_version: 'v1', format: 'json', filters: 'state=published', q: search_term)
+        assert_response :success
+        assert_not_nil assigns[:stories]
+        stories.must_include published_story
+        stories.wont_include unpublished_story
+      end
+
       it 'applies multiple filters' do
         create(:series, stories: [unpublished_story])
         unpublished_story.reindex(true)

--- a/test/models/story_test.rb
+++ b/test/models/story_test.rb
@@ -27,17 +27,17 @@ describe Story do
 
     it 'has a published state' do
       story.must_be :published?
-      story.must_be :scheduled?
-      story.must_be :draft?
+      story.wont_be :scheduled?
+      story.wont_be :draft?
 
       story.published_at = Time.now + 1.hour
-      story.must_be :published?
+      story.wont_be :published?
       story.must_be :scheduled?
-      story.must_be :draft?
+      story.wont_be :draft?
 
       story.published_at = nil
-      story.must_be :published?
-      story.must_be :scheduled?
+      story.wont_be :published?
+      story.wont_be :scheduled?
       story.must_be :draft?
     end
   end

--- a/test/models/story_test.rb
+++ b/test/models/story_test.rb
@@ -24,6 +24,22 @@ describe Story do
     it 'is deleted by default' do
       create(:story).must_be :deleted?
     end
+
+    it 'has a published state' do
+      story.must_be :published?
+      story.must_be :scheduled?
+      story.must_be :draft?
+
+      story.published_at = Time.now + 1.hour
+      story.must_be :published?
+      story.must_be :scheduled?
+      story.must_be :draft?
+
+      story.published_at = nil
+      story.must_be :published?
+      story.must_be :scheduled?
+      story.must_be :draft?
+    end
   end
 
   describe 'status updates' do
@@ -444,6 +460,23 @@ describe Story do
       Story.public_stories.wont_include story_n
       Story.public_stories.wont_include story_s
       Story.public_stories.wont_include story_u
+    end
+
+    it 'filters by published state' do
+      story = create(:story)
+      Story.where(id: story.id).published.must_include story
+      Story.where(id: story.id).scheduled.wont_include story
+      Story.where(id: story.id).draft.wont_include story
+
+      story.update_attributes(published_at: Time.now + 1.hour)
+      Story.where(id: story.id).published.wont_include story
+      Story.where(id: story.id).scheduled.must_include story
+      Story.where(id: story.id).draft.wont_include story
+
+      story.update_attributes(published_at: nil)
+      Story.where(id: story.id).published.wont_include story
+      Story.where(id: story.id).scheduled.wont_include story
+      Story.where(id: story.id).draft.must_include story
     end
   end
 


### PR DESCRIPTION
For #505.  Adds a new `state` filter to authorized story endpoints.  Filters include (url-encoding the `=`):

- [x] `?filters=state%3Dpublished` (published_at in the past)
- [x] `?filters=state%3Dscheduled` (published_at in the future)
- [x] `?filters=state%3Ddraft` (published_at is null)

Endpoints include:

- [x] `/api/v1/authorization/stories`
- [x] `/api/v1/authorization/accounts/:account_id/stories`
- [x] `/api/v1/authorization/networks/:network_id/stories`
- [x] `/api/v1/authorization/series/:series_id/stories`

And also added to the search endpoints:

- [x] `/api/v1/authorization/stories/search`
- [x] `/api/v1/authorization/series/:series_id/stories/search`