### PR TITLE
Published/released range filter

### DIFF
--- a/app/controllers/api/auth/stories_controller.rb
+++ b/app/controllers/api/auth/stories_controller.rb
@@ -8,7 +8,7 @@ class Api::Auth::StoriesController < Api::StoriesController
 
   filter_resources_by :account_id, :series_id, :network_id
 
-  filter_params :highlighted, :purchased, :v4, :text, :noseries
+  filter_params :highlighted, :purchased, :v4, :text, :noseries, before: :time, after: :time
 
   sort_params default: { updated_at: :desc },
               allowed: [:id, :created_at, :updated_at, :published_at, :title,

--- a/app/controllers/api/stories_controller.rb
+++ b/app/controllers/api/stories_controller.rb
@@ -7,7 +7,7 @@ class Api::StoriesController < Api::BaseController
 
   filter_resources_by :series_id, :account_id, :network_id
 
-  filter_params :highlighted, :purchased, :v4, :text
+  filter_params :highlighted, :purchased, :v4, :text, before: :time, after: :time
 
   sort_params default: { published_at: :desc, updated_at: :desc },
               allowed: [:id, :created_at, :updated_at, :published_at, :title,
@@ -27,6 +27,7 @@ class Api::StoriesController < Api::BaseController
     sparams[:fq]['network_id'] = params[:network_id] if params[:network_id]
     sparams[:fq]['series_id'] = params[:series_id] if params[:series_id]
     sparams[:fq]['app_version'] = 'v4' if filters.v4?
+    sparams[:fq]['published_released_at'] = search_before_after() if filters.before? || filters.after?
     sparams
   end
 
@@ -112,10 +113,22 @@ class Api::StoriesController < Api::BaseController
   def filtered(resources)
     resources = resources.v4 if filters.v4?
     resources = resources.match_text(filters.text) if filters.text?
+    resources = resources.published_released_after(filters.after) if filters.after?
+    resources = resources.published_released_before(filters.before) if filters.before?
     if highlighted?
       resources
     else
       super
+    end
+  end
+
+  def search_before_after
+    if filters.before? && filters.after?
+      "[#{filters.after.iso8601} TO #{filters.before.iso8601}}"
+    elsif filters.before?
+      "[* TO #{filters.before.iso8601}}"
+    elsif filters.after?
+      "[#{filters.after.iso8601} TO *}"
     end
   end
 

--- a/app/controllers/api/stories_controller.rb
+++ b/app/controllers/api/stories_controller.rb
@@ -27,7 +27,7 @@ class Api::StoriesController < Api::BaseController
     sparams[:fq]['network_id'] = params[:network_id] if params[:network_id]
     sparams[:fq]['series_id'] = params[:series_id] if params[:series_id]
     sparams[:fq]['app_version'] = 'v4' if filters.v4?
-    sparams[:fq]['published_released_at'] = search_before_after() if filters.before? || filters.after?
+    sparams[:fq]['published_released_at'] = search_before_after if filters.before? || filters.after?
     sparams
   end
 

--- a/app/controllers/concerns/api_filtering.rb
+++ b/app/controllers/concerns/api_filtering.rb
@@ -52,9 +52,9 @@ module ApiFiltering
     private
 
     def add_filter_param(name, type = nil)
-      unless self.allowed_filter_names.include? name
-        self.allowed_filter_names << name
-        self.allowed_filter_types[name] = type unless type.nil?
+      unless allowed_filter_names.include? name
+        allowed_filter_names << name
+        allowed_filter_types[name] = type unless type.nil?
       end
     end
   end
@@ -84,8 +84,8 @@ module ApiFiltering
       filters_map[name] =
         if force_types[name] == 'date'
           parse_date(value)
-        elsif force_types[name] == 'datetime'
-          parse_datetime(value)
+        elsif force_types[name] == 'time'
+          parse_time(value)
         elsif value.nil?
           true
         elsif value.blank?
@@ -109,9 +109,9 @@ module ApiFiltering
     raise BadFilterValueError.new "Invalid filter date: '#{str}'"
   end
 
-  def parse_datetime(str)
-    DateTime.parse(str)
+  def parse_time(str)
+    Time.find_zone('UTC').parse(str) || (raise ArgumentError.new 'Nil result!')
   rescue ArgumentError
-    raise BadFilterValueError.new "Invalid filter datetime: '#{str}'"
+    raise BadFilterValueError.new "Invalid filter time: '#{str}'"
   end
 end

--- a/app/controllers/concerns/api_filtering.rb
+++ b/app/controllers/concerns/api_filtering.rb
@@ -8,10 +8,16 @@ module ApiFiltering
   included do
     class_eval do
       class_attribute :allowed_filter_names
+      class_attribute :allowed_filter_types
     end
   end
 
   class UnknownFilterError < NoMethodError
+  end
+  class BadFilterValueError < HalApi::Errors::ApiError
+    def initialize(msg)
+      super(msg, 400)
+    end
   end
 
   class FilterParams < OpenStruct
@@ -32,7 +38,24 @@ module ApiFiltering
 
   module ClassMethods
     def filter_params(*args)
-      self.allowed_filter_names = args.map(&:to_s).uniq || []
+      self.allowed_filter_names = []
+      self.allowed_filter_types = {}
+      (args || []).map do |arg|
+        if arg.is_a? Hash
+          arg.to_a.each { |key, val| add_filter_param(key.to_s, val.to_s) }
+        else
+          add_filter_param(arg.to_s)
+        end
+      end
+    end
+
+    private
+
+    def add_filter_param(name, type = nil)
+      unless self.allowed_filter_names.include? name
+        self.allowed_filter_names << name
+        self.allowed_filter_types[name] = type unless type.nil?
+      end
     end
   end
 
@@ -45,6 +68,7 @@ module ApiFiltering
   def parse_filters_param
     filters_map = {}
     filters = self.class.allowed_filter_names
+    force_types = self.class.allowed_filter_types
 
     # set nils
     filters.each do |name|
@@ -58,7 +82,11 @@ module ApiFiltering
 
       # convert/guess type of known params
       filters_map[name] =
-        if value.nil?
+        if force_types[name] == 'date'
+          parse_date(value)
+        elsif force_types[name] == 'datetime'
+          parse_datetime(value)
+        elsif value.nil?
           true
         elsif value.blank?
           ''
@@ -73,5 +101,17 @@ module ApiFiltering
         end
     end
     FilterParams.new(filters_map)
+  end
+
+  def parse_date(str)
+    Date.parse(str)
+  rescue ArgumentError
+    raise BadFilterValueError.new "Invalid filter date: '#{str}'"
+  end
+
+  def parse_datetime(str)
+    DateTime.parse(str)
+  rescue ArgumentError
+    raise BadFilterValueError.new "Invalid filter datetime: '#{str}'"
   end
 end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -131,6 +131,12 @@ class Story < BaseModel
       order("ISNULL(pieces_published_released_at) #{dir}").
       order("pieces_published_released_at #{dir}")
   }
+  scope :published_released_before, ->(time) {
+    where('published_at < ? OR (published_at IS NULL AND released_at < ?)', time, time)
+  }
+  scope :published_released_after, ->(time) {
+    where('published_at >= ? OR (published_at IS NULL AND released_at >= ?)', time, time)
+  }
 
   scope :series_visible, -> {
     joins('LEFT OUTER JOIN `series` ON `pieces`.`series_id` = `series`.`id`').

--- a/test/controllers/concerns/api_filtering_test.rb
+++ b/test/controllers/concerns/api_filtering_test.rb
@@ -5,7 +5,7 @@ describe ApiFiltering do
   class ApiFilteringTestController < ActionController::Base
     include ApiFiltering
 
-    filter_params :one, :two, :three, :four, :five, six: :date, seven: :datetime
+    filter_params :one, :two, :three, :four, :five, six: :date, seven: :time
 
     attr_accessor :filter_string
 
@@ -65,18 +65,18 @@ describe ApiFiltering do
   end
 
   it 'parses datetimes' do
-    controller.filter_string = 'seven=2019-02-03T01:02:03Z'
+    controller.filter_string = 'seven=2019-02-03T01:02:03 -0700'
     controller.filters.seven?.must_equal true
-    controller.filters.seven.must_equal DateTime.parse('2019-02-03T01:02:03Z')
+    controller.filters.seven.must_equal Time.parse('2019-02-03T08:02:03Z')
   end
 
   it 'defaults datetimes to utc' do
     controller.filter_string = 'seven=20190203'
     controller.filters.seven?.must_equal true
-    controller.filters.seven.must_equal DateTime.parse('2019-02-03T00:00:00Z')
+    controller.filters.seven.must_equal Time.parse('2019-02-03T00:00:00Z')
   end
 
-  it 'raises parse errors for datetimes' do
+  it 'raises parse errors for times' do
     controller.filter_string = 'seven=bad-string'
     err = assert_raises { puts controller.filters.seven }
     err.must_be_instance_of(ApiFiltering::BadFilterValueError)

--- a/test/controllers/concerns/api_filtering_test.rb
+++ b/test/controllers/concerns/api_filtering_test.rb
@@ -5,7 +5,7 @@ describe ApiFiltering do
   class ApiFilteringTestController < ActionController::Base
     include ApiFiltering
 
-    filter_params :one, :two, :three, :four, :five
+    filter_params :one, :two, :three, :four, :five, six: :date, seven: :datetime
 
     attr_accessor :filter_string
 
@@ -41,6 +41,8 @@ describe ApiFiltering do
     controller.filters.three?.must_equal false
     controller.filters.four?.must_equal true
     controller.filters.five?.must_equal true
+    controller.filters.six?.must_equal false
+    controller.filters.seven?.must_equal false
     assert_raises { controller.filters.whatever? }
   end
 
@@ -48,6 +50,36 @@ describe ApiFiltering do
     controller.filter_string = nil
     controller.filters.one.must_be_nil
     controller.filters.one?.must_equal false
+  end
+
+  it 'parses dates' do
+    controller.filter_string = 'six=20190203'
+    controller.filters.six?.must_equal true
+    controller.filters.six.must_equal Date.parse('2019-02-03')
+  end
+
+  it 'raises parse errors for dates' do
+    controller.filter_string = 'six=bad-string'
+    err = assert_raises { puts controller.filters.six }
+    err.must_be_instance_of(ApiFiltering::BadFilterValueError)
+  end
+
+  it 'parses datetimes' do
+    controller.filter_string = 'seven=2019-02-03T01:02:03Z'
+    controller.filters.seven?.must_equal true
+    controller.filters.seven.must_equal DateTime.parse('2019-02-03T01:02:03Z')
+  end
+
+  it 'defaults datetimes to utc' do
+    controller.filter_string = 'seven=20190203'
+    controller.filters.seven?.must_equal true
+    controller.filters.seven.must_equal DateTime.parse('2019-02-03T00:00:00Z')
+  end
+
+  it 'raises parse errors for datetimes' do
+    controller.filter_string = 'seven=bad-string'
+    err = assert_raises { puts controller.filters.seven }
+    err.must_be_instance_of(ApiFiltering::BadFilterValueError)
   end
 
 end

--- a/test/models/story_test.rb
+++ b/test/models/story_test.rb
@@ -288,6 +288,30 @@ describe Story do
       stories.map(&:short_description).must_equal ['0', '3', '1', '2']
     end
 
+    it 'filters stories published or released before a date' do
+      now = DateTime.parse('2019-03-22T00:00:10Z')
+      title = 'filter-published-released'
+      create(:unpublished_story, title: title, short_description: '0')
+      create(:unpublished_story, title: title, short_description: '1', released_at: now)
+      create(:story, title: title, short_description: '2', published_at: now)
+      create(:story, title: title, short_description: '3', published_at: now + 1.second)
+
+      stories = Story.where(title: title).published_released_before(now + 1.second)
+      stories.pluck(:short_description).must_equal ['1', '2']
+    end
+
+    it 'filters stories published or released after a date' do
+      now = DateTime.parse('2019-03-22T00:00:10Z')
+      title = 'filter-published-released'
+      create(:unpublished_story, title: title, short_description: '0')
+      create(:unpublished_story, title: title, short_description: '1', released_at: now)
+      create(:story, title: title, short_description: '2', published_at: now)
+      create(:story, title: title, short_description: '3', published_at: now - 1.second)
+
+      stories = Story.where(title: title).published_released_after(now)
+      stories.pluck(:short_description).must_equal ['1', '2']
+    end
+
     it 'wont publish when already published' do
       lambda do
         story.publish!

--- a/test/models/story_test.rb
+++ b/test/models/story_test.rb
@@ -289,7 +289,7 @@ describe Story do
     end
 
     it 'filters stories published or released before a date' do
-      now = DateTime.parse('2019-03-22T00:00:10Z')
+      now = Time.parse('2019-03-22T00:00:10Z')
       title = 'filter-published-released'
       create(:unpublished_story, title: title, short_description: '0')
       create(:unpublished_story, title: title, short_description: '1', released_at: now)
@@ -301,7 +301,7 @@ describe Story do
     end
 
     it 'filters stories published or released after a date' do
-      now = DateTime.parse('2019-03-22T00:00:10Z')
+      now = Time.parse('2019-03-22T00:00:10Z')
       title = 'filter-published-released'
       create(:unpublished_story, title: title, short_description: '0')
       create(:unpublished_story, title: title, short_description: '1', released_at: now)


### PR DESCRIPTION
For #505.  Adds new `?filter`s to the stories/search endpoints, which restricts the range of the `published_at || released_at` timestamps:

- [x] `?filters=before%3D2019-03-01T:00:00:00Z` (published or released set before 3/1, exclusive)
- [x] `?filters=after%3D2019-03-01T:00:00:00Z` (published or released set after 3/1, inclusive)

Note these are added to the _public_ stories endpoints as well.  And the filters can be combined.

Also note that you can just give a date as the start end - which should work for the production calendar view in Publish:

```
/api/v1/authorized/stories?filters=after%3D2019-02-01,before%3D2019-03-01
```