### PR TITLE
Check feeder media-ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Integrations & Dependencies
 - mysql - main database
 - memcached - caching API responses and JSON representations
 - AWS S3 - for private file access
+- Lambdas for processing audio (https://github.com/PRX/cms-audio-lambda) and images (https://github.com/PRX/cms-image-lambda)
 - (TBD) fixer.prx.org - validate/process media files
 - (TBD) meta.prx.org - defines link relations using for HAL resources
 

--- a/app/models/story_distributions/episode_distribution.rb
+++ b/app/models/story_distributions/episode_distribution.rb
@@ -47,7 +47,7 @@ class StoryDistributions::EpisodeDistribution < StoryDistribution
   end
 
   def completed?
-    get_episode.try(:media).present?
+    !!get_episode.try(:is_feed_ready)
   end
 
   def create_or_update_episode(attrs = {})

--- a/test/fixtures/episode.json
+++ b/test/fixtures/episode.json
@@ -2,7 +2,8 @@
   "guid": "aguid",
   "title": "Episode 1",
   "publishedAt": "2017-08-30T04:00:00.000Z",
-  "media": [],
+  "isFeedReady": true,
+  "media": [{"href": "https://f.prxu.org/1/aguid/filename.mp3"}],
   "_links": {
     "curies": [
       {

--- a/test/models/distributions/podcast_distribution_test.rb
+++ b/test/models/distributions/podcast_distribution_test.rb
@@ -112,7 +112,7 @@ describe Distributions::PodcastDistribution do
       episode_distribution.update_attributes(url: episode_url)
       episode_distribution.must_be :distributed?
       episode_distribution.must_be :published?
-      episode_distribution.wont_be :completed?
+      episode_distribution.must_be :completed?
       distribution.story_distributions = [episode_distribution]
       distribution.must_be :stories_published?
     end

--- a/test/models/story_distributions/episode_distribution_test.rb
+++ b/test/models/story_distributions/episode_distribution_test.rb
@@ -75,11 +75,22 @@ describe StoryDistributions::EpisodeDistribution do
   it 'checks if the episode is published' do
     stub_episode!
     distribution.must_be :published?
+    distribution.clear_episode
+
+    stub_episode! publishedAt: nil
+    distribution.wont_be :published?
+    distribution.clear_episode
+
+    stub_episode! publishedAt: '3000-01-01T00:00:00.000Z'
+    distribution.wont_be :published?
   end
 
   it 'checks if the episode is completed' do
     stub_episode!
-    distribution.wont_be :completed?
+    distribution.must_be :completed?
     distribution.clear_episode
+
+    stub_episode! is_feed_ready: false
+    distribution.wont_be :completed?
   end
 end

--- a/test/models/story_distributions/episode_distribution_test.rb
+++ b/test/models/story_distributions/episode_distribution_test.rb
@@ -3,8 +3,9 @@ require 'test_helper'
 describe StoryDistributions::EpisodeDistribution do
 
   let(:podcast_distribution) { create(:podcast_distribution) }
-  let(:distribution) { build(:episode_distribution, distribution: podcast_distribution) }
-  let(:episode_url) { URI.join(distribution.feeder_root, '/api/v1/episodes/aguid').to_s }
+  let(:feeder_root) { StoryDistributions::EpisodeDistribution.new.feeder_root }
+  let(:episode_url) { URI.join(feeder_root, '/api/v1/episodes/aguid').to_s }
+  let(:distribution) { build(:episode_distribution, distribution: podcast_distribution, url: episode_url) }
 
   before do
     stub_request(:get, 'https://feeder.prx.org/api/v1').
@@ -27,10 +28,19 @@ describe StoryDistributions::EpisodeDistribution do
       with(headers: { 'Authorization' => 'Bearer token', 'Content-Type' => 'application/json' }).
       to_return(status: 200, body: json_file('episode'), headers: {})
 
+  end
+
+  around do |test|
+    podcast_distribution.stub(:get_account_token, 'token') do
+      distribution.stub(:get_account_token, 'token') { test.call }
+    end
+  end
+
+  def stub_episode!(overrides = {})
+    episode = JSON.parse(json_file('episode')).merge(overrides)
     stub_request(:get, "https://feeder.prx.org/api/v1/authorization/episodes/aguid").
       with(:headers => {'Authorization'=>'Bearer token', 'Content-Type'=>'application/json'}).
-      to_return(status: 200, body: json_file('episode'), headers: {})
-
+      to_return(status: 200, body: episode.to_json, headers: {})
   end
 
   it 'gets the episode attributes' do
@@ -47,44 +57,29 @@ describe StoryDistributions::EpisodeDistribution do
   end
 
   it 'creates the episode on feeder' do
-    podcast_distribution.stub(:get_account_token, 'token') do
-      distribution.stub(:get_account_token, 'token') do
-        distribution.url = nil
-        distribution.wont_be :distributed?
-        distribution.save!
-        distribution.distribute!
-        distribution.must_be :distributed?
-        distribution.url.must_equal(episode_url)
-      end
-    end
+    distribution.url = nil
+    distribution.wont_be :distributed?
+    distribution.save!
+    distribution.distribute!
+    distribution.must_be :distributed?
+    distribution.url.must_equal(episode_url)
   end
 
   it 'gets the episode' do
-    distro = build(:episode_distribution, distribution: podcast_distribution, url: episode_url)
-    podcast_distribution.stub(:get_account_token, 'token') do
-      distro.stub(:get_account_token, 'token') do
-        ep = distro.get_episode
-        ep.title.must_equal 'Episode 1'
-        ep.published_at.must_equal '2017-08-30T04:00:00.000Z'
-      end
-    end
+    stub_episode!
+    ep = distribution.get_episode
+    ep.title.must_equal 'Episode 1'
+    ep.published_at.must_equal '2017-08-30T04:00:00.000Z'
   end
 
   it 'checks if the episode is published' do
-    distro = build(:episode_distribution, distribution: podcast_distribution, url: episode_url)
-    podcast_distribution.stub(:get_account_token, 'token') do
-      distro.stub(:get_account_token, 'token') do
-        distro.must_be :published?
-      end
-    end
+    stub_episode!
+    distribution.must_be :published?
   end
 
-  it 'checks if the episode has completed' do
-    distro = build(:episode_distribution, distribution: podcast_distribution, url: episode_url)
-    podcast_distribution.stub(:get_account_token, 'token') do
-      distro.stub(:get_account_token, 'token') do
-        distro.wont_be :completed?
-      end
-    end
+  it 'checks if the episode is completed' do
+    stub_episode!
+    distribution.wont_be :completed?
+    distribution.clear_episode
   end
 end

--- a/test/models/story_distributions/episode_distribution_test.rb
+++ b/test/models/story_distributions/episode_distribution_test.rb
@@ -5,7 +5,9 @@ describe StoryDistributions::EpisodeDistribution do
   let(:podcast_distribution) { create(:podcast_distribution) }
   let(:feeder_root) { StoryDistributions::EpisodeDistribution.new.feeder_root }
   let(:episode_url) { URI.join(feeder_root, '/api/v1/episodes/aguid').to_s }
-  let(:distribution) { build(:episode_distribution, distribution: podcast_distribution, url: episode_url) }
+  let(:distribution) do
+    build(:episode_distribution, distribution: podcast_distribution, url: episode_url)
+  end
 
   before do
     stub_request(:get, 'https://feeder.prx.org/api/v1').


### PR DESCRIPTION
For #508.

It's possible an episode will have some of its media ready but not all, so just checking for array length isn't enough.  This relies on PRX/feeder.prx.org#309.