### PR TITLE
Verify > 0 media

### DIFF
--- a/app/models/story_distributions/episode_distribution.rb
+++ b/app/models/story_distributions/episode_distribution.rb
@@ -47,7 +47,7 @@ class StoryDistributions::EpisodeDistribution < StoryDistribution
   end
 
   def completed?
-    !!get_episode.try(:is_feed_ready)
+    get_episode.try(:is_feed_ready) && get_episode.try(:media).present?
   end
 
   def create_or_update_episode(attrs = {})

--- a/test/models/story_distributions/episode_distribution_test.rb
+++ b/test/models/story_distributions/episode_distribution_test.rb
@@ -95,4 +95,13 @@ describe StoryDistributions::EpisodeDistribution do
     stub_episode! is_feed_ready: false
     distribution.wont_be :completed?
   end
+
+  it 'looks for media when checking is completed' do
+    stub_episode!
+    distribution.must_be :completed?
+    distribution.clear_episode
+
+    stub_episode! media: []
+    distribution.wont_be :completed?
+  end
 end


### PR DESCRIPTION
Feeder allows episodes with 0 media to be published in the feed.  This doesn't prevent that, but at least we'll get some New Relic warnings, plus the say when job will make sure we re-announce any audio files to Feeder.