### PR TITLE
Unpublished filter/sorting

### DIFF
--- a/app/controllers/api/auth/stories_controller.rb
+++ b/app/controllers/api/auth/stories_controller.rb
@@ -12,8 +12,8 @@ class Api::Auth::StoriesController < Api::StoriesController
                 before: :time, after: :time, afternull: :time
 
   sort_params default: { updated_at: :desc },
-              allowed: [:id, :created_at, :updated_at, :published_at, :title,
-                        :episode_number, :position, :published_released_at]
+              allowed: [:id, :created_at, :updated_at, :published_at, :released_at,
+                        :title, :episode_number, :position, :published_released_at]
 
   announce_actions :create, :update, :destroy, :publish, :unpublish
 
@@ -28,6 +28,9 @@ class Api::Auth::StoriesController < Api::StoriesController
     end
     if pub_sort = (sorts || []).find_index { |s| s.keys.first == 'published_at' }
       sorts.insert(pub_sort, 'ISNULL(`pieces`.`published_at`) DESC')
+    end
+    if pub_sort = (sorts || []).find_index { |s| s.keys.first == 'released_at' }
+      sorts.insert(pub_sort, 'ISNULL(`pieces`.`released_at`) DESC')
     end
     super
   end

--- a/app/controllers/api/auth/stories_controller.rb
+++ b/app/controllers/api/auth/stories_controller.rb
@@ -9,7 +9,7 @@ class Api::Auth::StoriesController < Api::StoriesController
   filter_resources_by :account_id, :series_id, :network_id
 
   filter_params :highlighted, :purchased, :v4, :text, :noseries, :state,
-                before: :time, after: :time
+                before: :time, after: :time, afternull: :time
 
   sort_params default: { updated_at: :desc },
               allowed: [:id, :created_at, :updated_at, :published_at, :title,

--- a/app/controllers/api/auth/stories_controller.rb
+++ b/app/controllers/api/auth/stories_controller.rb
@@ -50,6 +50,8 @@ class Api::Auth::StoriesController < Api::StoriesController
   def filter_by_state(resources, state)
     if state == 'published'
       resources.published
+    elsif state == 'unpublished'
+      resources.unpublished
     elsif state == 'scheduled'
       resources.scheduled
     elsif state == 'draft'
@@ -82,17 +84,13 @@ class Api::Auth::StoriesController < Api::StoriesController
   def search_params
     sparams = super
     sparams[:fq]['series_id'] = 'NULL' if filters.noseries?
-    sparams[:fq]['published_at'] = search_by_state(filters.state) if filters.state?
+    sparams[:state] = search_by_state(filters.state) if filters.state?
     sparams
   end
 
   def search_by_state(state)
-    if state == 'published'
-      '[* TO now]'
-    elsif state == 'scheduled'
-      '{now TO *}'
-    elsif state == 'draft'
-      'NULL'
+    if %w(published unpublished scheduled draft).include?(state)
+      state
     else
       raise ApiFiltering::BadFilterValueError.new("Invalid state filter: #{state}")
     end

--- a/app/controllers/api/auth/stories_controller.rb
+++ b/app/controllers/api/auth/stories_controller.rb
@@ -26,11 +26,10 @@ class Api::Auth::StoriesController < Api::StoriesController
       arel = arel.coalesce_published_released(sorts[coalesce_sort].values.first)
       sorts.delete_at(coalesce_sort)
     end
-    if pub_sort = (sorts || []).find_index { |s| s.keys.first == 'published_at' }
+    if pub_sort = (sorts || []).find_index { |s| s.try(:keys).try(:first) == 'published_at' }
       sorts.insert(pub_sort, 'ISNULL(`pieces`.`published_at`) DESC')
-    end
-    if pub_sort = (sorts || []).find_index { |s| s.keys.first == 'released_at' }
-      sorts.insert(pub_sort, 'ISNULL(`pieces`.`released_at`) DESC')
+    elsif rel_sort = (sorts || []).find_index { |s| s.try(:keys).try(:first) == 'released_at' }
+      sorts.insert(rel_sort, 'ISNULL(`pieces`.`released_at`) DESC')
     end
     super
   end

--- a/app/controllers/api/stories_controller.rb
+++ b/app/controllers/api/stories_controller.rb
@@ -7,7 +7,8 @@ class Api::StoriesController < Api::BaseController
 
   filter_resources_by :series_id, :account_id, :network_id
 
-  filter_params :highlighted, :purchased, :v4, :text, before: :time, after: :time
+  filter_params :highlighted, :purchased, :v4, :text, before: :time,
+                after: :time, afternull: :time
 
   sort_params default: { published_at: :desc, updated_at: :desc },
               allowed: [:id, :created_at, :updated_at, :published_at, :title,
@@ -114,6 +115,7 @@ class Api::StoriesController < Api::BaseController
     resources = resources.v4 if filters.v4?
     resources = resources.match_text(filters.text) if filters.text?
     resources = resources.published_released_after(filters.after) if filters.after?
+    resources = resources.published_released_after_null(filters.afternull) if filters.afternull?
     resources = resources.published_released_before(filters.before) if filters.before?
     if highlighted?
       resources

--- a/app/controllers/api/stories_controller.rb
+++ b/app/controllers/api/stories_controller.rb
@@ -7,8 +7,7 @@ class Api::StoriesController < Api::BaseController
 
   filter_resources_by :series_id, :account_id, :network_id
 
-  filter_params :highlighted, :purchased, :v4, :text, before: :time,
-                after: :time, afternull: :time
+  filter_params :highlighted, :purchased, :v4, :text, before: :time, after: :time, afternull: :time
 
   sort_params default: { published_at: :desc, updated_at: :desc },
               allowed: [:id, :created_at, :updated_at, :published_at, :title,

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -140,6 +140,10 @@ class Story < BaseModel
   scope :published_released_after, ->(time) {
     where('published_at >= ? OR (published_at IS NULL AND released_at >= ?)', time, time)
   }
+  scope :published_released_after_null, ->(time) {
+    where('published_at >= ? OR (published_at IS NULL AND released_at >= ?) ' +
+          'OR (published_at IS NULL and released_at IS NULL)', time, time)
+  }
 
   scope :series_visible, -> {
     joins('LEFT OUTER JOIN `series` ON `pieces`.`series_id` = `series`.`id`').

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -123,6 +123,7 @@ class Story < BaseModel
       select('pieces.*, series.subscription_approval_status, series.subscriber_only_at')
   }
   scope :published, -> { where('`published_at` <= ?', Time.now) }
+  scope :unpublished, -> { where('`published_at` IS NULL OR `published_at` > ?', Time.now) }
   scope :scheduled, -> { where('`published_at` > ?', Time.now) }
   scope :draft, -> { where('`published_at` IS NULL') }
   scope :unseries, -> { where('`series_id` IS NULL') }

--- a/app/services/story_query_builder.rb
+++ b/app/services/story_query_builder.rb
@@ -58,7 +58,6 @@ class StoryQueryBuilder < ESQueryBuilder
   end
 
   def state_filter
-    searchdsl = self
     if params[:state] === 'published'
       Filter.new do
         range published_at: { lte: 'now' }
@@ -82,7 +81,7 @@ class StoryQueryBuilder < ESQueryBuilder
       Filter.new do
         range published_at: { gt: 'now' }
       end
-    else params[:state] === 'draft'
+    elsif params[:state] === 'draft'
       Filter.new do
         bool do
           must_not do

--- a/test/controllers/api/auth/stories_controller_test.rb
+++ b/test/controllers/api/auth/stories_controller_test.rb
@@ -92,6 +92,16 @@ describe Api::Auth::StoriesController do
       assigns[:stories].wont_include unpublished_story
     end
 
+    it 'filters unpublished stories' do
+      published_story.must_be :published?
+      scheduled_story.must_be :scheduled?
+      unpublished_story.must_be :draft?
+      get(:index, api_version: 'v1', format: 'json', filters: 'state=unpublished')
+      assigns[:stories].wont_include published_story
+      assigns[:stories].must_include scheduled_story
+      assigns[:stories].must_include unpublished_story
+    end
+
     it 'filters scheduled stories' do
       published_story.must_be :published?
       scheduled_story.must_be :scheduled?
@@ -201,14 +211,48 @@ describe Api::Auth::StoriesController do
         stories.wont_include v3_story
       end
 
-      it 'filters published state stories' do
-        published_story.must_be :published?
-        unpublished_story.must_be :draft?
-        get(:search, api_version: 'v1', format: 'json', filters: 'state=published', q: search_term)
-        assert_response :success
-        assert_not_nil assigns[:stories]
-        stories.must_include published_story
-        stories.wont_include unpublished_story
+      describe 'state filter' do
+        before(:all) do
+          published_story.reindex(true)
+          scheduled_story.reindex(true)
+          unpublished_story.reindex(true)
+        end
+
+        it 'filters published state stories' do
+          get(:search, api_version: 'v1', filters: 'state=published', q: search_term)
+          assert_response :success
+          assert_not_nil assigns[:stories]
+          stories.must_include published_story
+          stories.wont_include scheduled_story
+          stories.wont_include unpublished_story
+        end
+
+        it 'filters unpublished state stories' do
+          get(:search, api_version: 'v1', filters: 'state=unpublished', q: search_term)
+          assert_response :success
+          assert_not_nil assigns[:stories]
+          stories.wont_include published_story
+          stories.must_include scheduled_story
+          stories.must_include unpublished_story
+        end
+
+        it 'filters scheduled state stories' do
+          get(:search, api_version: 'v1', filters: 'state=scheduled', q: search_term)
+          assert_response :success
+          assert_not_nil assigns[:stories]
+          stories.wont_include published_story
+          stories.must_include scheduled_story
+          stories.wont_include unpublished_story
+        end
+
+        it 'filters draft state stories' do
+          get(:search, api_version: 'v1', filters: 'state=draft', q: search_term)
+          assert_response :success
+          assert_not_nil assigns[:stories]
+          stories.wont_include published_story
+          stories.wont_include scheduled_story
+          stories.must_include unpublished_story
+        end
       end
 
       it 'applies multiple filters' do

--- a/test/models/story_test.rb
+++ b/test/models/story_test.rb
@@ -505,16 +505,19 @@ describe Story do
     it 'filters by published state' do
       story = create(:story)
       Story.where(id: story.id).published.must_include story
+      Story.where(id: story.id).unpublished.wont_include story
       Story.where(id: story.id).scheduled.wont_include story
       Story.where(id: story.id).draft.wont_include story
 
       story.update_attributes(published_at: Time.now + 1.hour)
       Story.where(id: story.id).published.wont_include story
+      Story.where(id: story.id).unpublished.must_include story
       Story.where(id: story.id).scheduled.must_include story
       Story.where(id: story.id).draft.wont_include story
 
       story.update_attributes(published_at: nil)
       Story.where(id: story.id).published.wont_include story
+      Story.where(id: story.id).unpublished.must_include story
       Story.where(id: story.id).scheduled.wont_include story
       Story.where(id: story.id).draft.must_include story
     end

--- a/test/models/story_test.rb
+++ b/test/models/story_test.rb
@@ -335,6 +335,18 @@ describe Story do
       stories.pluck(:short_description).must_equal ['1', '2']
     end
 
+    it 'filters stories published or released after or null' do
+      now = Time.parse('2019-03-22T00:00:10Z')
+      title = 'filter-published-released-null'
+      create(:unpublished_story, title: title, short_description: '0')
+      create(:unpublished_story, title: title, short_description: '1', released_at: now)
+      create(:story, title: title, short_description: '2', published_at: now)
+      create(:story, title: title, short_description: '3', published_at: now - 1.second)
+
+      stories = Story.where(title: title).published_released_after_null(now)
+      stories.pluck(:short_description).must_equal ['0', '1', '2']
+    end
+
     it 'wont publish when already published' do
       lambda do
         story.publish!


### PR DESCRIPTION
For #526

- [x] Add an `afternull` filter, similar to `after` but also returns episodes with a null published_released_at
- [x] Allow sorting auth-stories by `released_at`, but always returning nulls first (similar to the auth-stories `published_at` sort).
- [x] Add a `state=unpublished` filter value, which allows _either_ `published_at > now()` or `published_at = null`
    _NOTE: this required some changes to how the **?state** filter was applied to elasticsearch.  Instead of using/abusing the `FieldedSearchQuery` class, this sets up ES filters directly through the `StoryQueryBuilder`._