### PR TITLE
make sure account ids propagate to relations

### DIFF
--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -60,7 +60,7 @@ class Series < BaseModel
   has_many :podcast_imports
 
   before_validation :set_app_version, on: :create
-  after_save :update_account_for_stories, on: :update
+  after_save :update_account_for_relations, on: :update
 
   event_attribute :subscriber_only_at
 
@@ -196,12 +196,13 @@ class Series < BaseModel
     self.deleted_at = DateTime.now
   end
 
-  def update_account_for_stories
+  def update_account_for_relations
     if account_id_changed?
       Series.transaction do
         stories.update_all(account_id: account_id)
         audio_files.with_deleted.unscope(where: :promos).
           reorder('').update_all(account_id: account_id)
+        podcast_imports.update_all(account_id: account_id)
       end
       stories.all.each(&:index_for_search)
     end

--- a/test/models/series_test.rb
+++ b/test/models/series_test.rb
@@ -32,6 +32,15 @@ describe Series do
         af.account_id.must_equal 123
       end
     end
+
+    it 'changes account_id for podcast_imports when own account changes' do
+      user = create(:user)
+      PodcastImport.create(user: user, account: series.account, url: 'http://feeds.prx.org/transistor_stem')
+      series.update_attributes!(account_id: 123)
+      series.podcast_imports.all.each do |pi|
+        pi.account_id.must_equal 123
+      end
+    end
   end
 
   describe 'deleting' do


### PR DESCRIPTION
Targeting #530 In a lot of cases we're masquerading as users and this creates mismatched account ids between the series and import.

This PR ties into the existing stories update hook and ensures the podcast_import account id is updated as well. 