### PR TITLE
No unpublish side effects

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,282 +7,276 @@ AllCops:
 Naming/AccessorMethodName:
   Enabled: false
 
-ActionFilter:
+Style/Alias:
   Enabled: false
 
-Alias:
+Style/ArrayJoin:
   Enabled: false
 
-ArrayJoin:
+Style/AsciiComments:
   Enabled: false
 
-AsciiComments:
+Naming/AsciiIdentifiers:
   Enabled: false
 
-AsciiIdentifiers:
+Style/Attr:
   Enabled: false
 
-Attr:
+Metrics/BlockNesting:
   Enabled: false
 
-BlockNesting:
+Style/CaseEquality:
   Enabled: false
 
-CaseEquality:
+Style/CharacterLiteral:
   Enabled: false
 
-CharacterLiteral:
+Style/ClassAndModuleChildren:
   Enabled: false
 
-ClassAndModuleChildren:
+Metrics/ClassLength:
   Enabled: false
 
-ClassLength:
+Style/ClassVars:
   Enabled: false
 
-ClassVars:
-  Enabled: false
-
-CollectionMethods:
+Style/CollectionMethods:
   PreferredMethods:
     find: detect
     reduce: inject
     collect: map
     find_all: select
 
-ColonMethodCall:
+Style/ColonMethodCall:
   Enabled: false
 
-CommentAnnotation:
+Style/CommentAnnotation:
   Enabled: false
 
-CyclomaticComplexity:
-  Enabled: false
-
-Delegate:
+Metrics/CyclomaticComplexity:
   Enabled: false
 
 Style/PreferredHashMethods:
   Enabled: false
 
-Documentation:
+Style/Documentation:
   Enabled: false
 
-DotPosition:
+Layout/DotPosition:
   EnforcedStyle: trailing
 
-DoubleNegation:
+Style/DoubleNegation:
   Enabled: false
 
-EachWithObject:
+Style/EachWithObject:
   Enabled: false
 
-EmptyLinesAroundBlockBody:
+Layout/EmptyLinesAroundBlockBody:
   Enabled: false
 
-EmptyLinesAroundClassBody:
+Layout/EmptyLinesAroundClassBody:
   Enabled: false
 
-EmptyLinesAroundModuleBody:
+Layout/EmptyLinesAroundModuleBody:
   Enabled: false
 
-EmptyLiteral:
+Style/EmptyLiteral:
   Enabled: false
 
-Encoding:
+Style/Encoding:
   Enabled: false
 
-EvenOdd:
+Style/EvenOdd:
   Enabled: false
 
 Naming/FileName:
   Enabled: false
 
-FlipFlop:
+Lint/FlipFlop:
   Enabled: false
 
-FormatString:
+Style/FormatString:
   Enabled: false
 
-GlobalVars:
+Style/GlobalVars:
   Enabled: false
 
-GuardClause:
+Style/GuardClause:
   Enabled: false
 
-IfUnlessModifier:
+Style/IfUnlessModifier:
   Enabled: false
 
-IfWithSemicolon:
+Style/IfWithSemicolon:
   Enabled: false
 
-InlineComment:
+Style/InlineComment:
   Enabled: false
 
-Lambda:
+Style/Lambda:
   Enabled: false
 
-LambdaCall:
+Style/LambdaCall:
   Enabled: false
 
-LineEndConcatenation:
+Style/LineEndConcatenation:
   Enabled: false
 
-LineLength:
+Layout/LineLength:
   Max: 100
 
-MethodLength:
+Metrics/MethodLength:
   Enabled: false
 
-ModuleFunction:
+Style/ModuleFunction:
   Enabled: false
 
-NegatedIf:
+Style/NegatedIf:
   Enabled: false
 
-NegatedWhile:
+Style/NegatedWhile:
   Enabled: false
 
-Next:
+Style/Next:
   Enabled: false
 
-NilComparison:
+Style/NilComparison:
   Enabled: false
 
-Not:
+Style/Not:
   Enabled: false
 
-NumericLiterals:
+Style/NumericLiterals:
   Enabled: false
 
-OneLineConditional:
+Style/OneLineConditional:
   Enabled: false
 
 Naming/BinaryOperatorParameterName:
   Enabled: false
 
-ParameterLists:
+Metrics/ParameterLists:
   Enabled: false
 
-PercentLiteralDelimiters:
+Style/PercentLiteralDelimiters:
   Enabled: false
 
-PerlBackrefs:
+Style/PerlBackrefs:
   Enabled: false
 
 Naming/PredicateName:
-  NamePrefixBlacklist:
+  ForbiddenPrefixes:
     - is_
 
-Proc:
+Style/Proc:
   Enabled: false
 
-RaiseArgs:
+Style/RaiseArgs:
   Enabled: false
 
-RegexpLiteral:
+Style/RegexpLiteral:
   Enabled: false
 
-SelfAssignment:
+Style/SelfAssignment:
   Enabled: false
 
-SingleLineBlockParams:
+Style/SingleLineBlockParams:
   Enabled: false
 
-SingleLineMethods:
+Style/SingleLineMethods:
   Enabled: false
 
-SignalException:
+Style/SignalException:
   Enabled: false
 
-SpecialGlobalVars:
+Style/SpecialGlobalVars:
   Enabled: false
 
-StringLiterals:
+Style/StringLiterals:
   EnforcedStyle: single_quotes
 
-VariableInterpolation:
+Style/VariableInterpolation:
   Enabled: false
 
-TrailingCommaInArrayLiteral:
+Style/TrailingCommaInArrayLiteral:
   Enabled: false
 
-TrailingCommaInHashLiteral:
+Style/TrailingCommaInHashLiteral:
   Enabled: false
 
-TrailingCommaInArguments:
+Style/TrailingCommaInArguments:
   Enabled: false
 
-TrivialAccessors:
+Style/TrivialAccessors:
   Enabled: false
 
-WhenThen:
+Style/WhenThen:
   Enabled: false
 
-WhileUntilModifier:
+Style/WhileUntilModifier:
   Enabled: false
 
-WordArray:
+Style/WordArray:
   Enabled: false
 
 # Lint
 
-AmbiguousOperator:
+Lint/AmbiguousOperator:
   Enabled: false
 
-AmbiguousRegexpLiteral:
+Lint/AmbiguousRegexpLiteral:
   Enabled: false
 
-AssignmentInCondition:
+Lint/AssignmentInCondition:
   Enabled: false
 
-ConditionPosition:
+Layout/ConditionPosition:
   Enabled: false
 
-DeprecatedClassMethods:
+Lint/DeprecatedClassMethods:
   Enabled: false
 
-ElseLayout:
+Lint/ElseLayout:
   Enabled: false
 
-HandleExceptions:
+Lint/SuppressedException:
   Enabled: false
 
-LiteralInInterpolation:
+Lint/LiteralInInterpolation:
   Enabled: false
 
-Loop:
+Lint/Loop:
   Enabled: false
 
-ParenthesesAsGroupedExpression:
+Lint/ParenthesesAsGroupedExpression:
   Enabled: false
 
-RequireParentheses:
+Lint/RequireParentheses:
   Enabled: false
 
-UnderscorePrefixedVariableName:
+Lint/UnderscorePrefixedVariableName:
   Enabled: false
 
-Void:
+Lint/Void:
   Enabled: false
 
 Style/FrozenStringLiteralComment:
   Enabled: false
 
-SpaceInsideHashLiteralBraces:
+Layout/SpaceInsideHashLiteralBraces:
   Enabled: false
 
-IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   Enabled: false
 
-BracesAroundHashParameters:
+Style/BracesAroundHashParameters:
   Enabled: false
 
-SymbolArray:
+Style/SymbolArray:
   Enabled: false
 
-BlockLength:
+Metrics/BlockLength:
   Enabled: false
 
-MultilineIfModifier:
+Style/MultilineIfModifier:
   Enabled: false

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -349,10 +349,14 @@ class Story < BaseModel
   # If story is published and user wants to update the published_at value
   # OR if story is published for future release and user wants to undo that
   def update_published_to_released
-    canceling_future_release = released_at.nil? && published_at && published_at > DateTime.now
-    updating_release = !released_at.nil?
-    if published_at && released_at_changed? && (canceling_future_release || updating_release)
+    if published_at? && released_at_changed?
+      if published? && released_at.nil?
+        errors.add(:released_at, 'already published - cannot unset scheduled date')
+      elsif published? && (released_at > Time.now)
+        errors.add(:released_at, 'already published - cannot schedule for future publishing')
+      else
         self.published_at = released_at
+      end
     end
   end
 

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -351,9 +351,9 @@ class Story < BaseModel
   def update_published_to_released
     if published_at? && released_at_changed?
       if published? && released_at.nil?
-        errors.add(:released_at, 'already published - cannot unset scheduled date')
+        errors.add(:released_at, 'cannot be unset - already published')
       elsif published? && (released_at > Time.now)
-        errors.add(:released_at, 'already published - cannot schedule for future publishing')
+        errors.add(:released_at, 'cannot be set to future - already published')
       else
         self.published_at = released_at
       end

--- a/test/controllers/api/auth/stories_controller_test.rb
+++ b/test/controllers/api/auth/stories_controller_test.rb
@@ -12,8 +12,8 @@ describe Api::Auth::StoriesController do
   let (:network) { create(:network, account: account) }
   let (:network_story) { create(:story, network_id: network.id, network_only_at: Time.now) }
   let (:v3_story) { create(:story_v3, account: account) }
-  let (:released_story) { create(:story, account: account, released_at: Time.now + 1.day) }
-  let (:scheduled_story) { create(:story, account: account, published_at: Time.now + 1.day) }
+  let (:released_story) { create(:unpublished_story, account: account, released_at: Time.now + 1.day) }
+  let (:scheduled_story) { create(:unpublished_story, account: account, published_at: Time.now + 1.day) }
 
   before do
     account.stories.each { |s| s }

--- a/test/controllers/api/auth/stories_controller_test.rb
+++ b/test/controllers/api/auth/stories_controller_test.rb
@@ -13,7 +13,7 @@ describe Api::Auth::StoriesController do
   let (:network_story) { create(:story, network_id: network.id, network_only_at: Time.now) }
   let (:v3_story) { create(:story_v3, account: account) }
 
-  let (:tomorrow) { Time.now + 1.day.from.now }
+  let (:tomorrow) { Time.now + 1.day }
   let (:released_story) { create(:unpublished_story, account: account, released_at: tomorrow) }
   let (:scheduled_story) { create(:unpublished_story, account: account, published_at: tomorrow) }
 

--- a/test/controllers/api/auth/stories_controller_test.rb
+++ b/test/controllers/api/auth/stories_controller_test.rb
@@ -12,8 +12,10 @@ describe Api::Auth::StoriesController do
   let (:network) { create(:network, account: account) }
   let (:network_story) { create(:story, network_id: network.id, network_only_at: Time.now) }
   let (:v3_story) { create(:story_v3, account: account) }
-  let (:released_story) { create(:unpublished_story, account: account, released_at: Time.now + 1.day) }
-  let (:scheduled_story) { create(:unpublished_story, account: account, published_at: Time.now + 1.day) }
+
+  let (:tomorrow) { Time.now + 1.day.from.now }
+  let (:released_story) { create(:unpublished_story, account: account, released_at: tomorrow) }
+  let (:scheduled_story) { create(:unpublished_story, account: account, published_at: tomorrow) }
 
   before do
     account.stories.each { |s| s }

--- a/test/factories/story_factory.rb
+++ b/test/factories/story_factory.rb
@@ -59,9 +59,7 @@ FactoryGirl.define do
     end
 
     factory :unpublished_story do
-      after(:create, :stub) do |story, _evaluator|
-        story.update_attributes(published_at: nil)
-      end
+      published_at nil
     end
 
   end

--- a/test/models/story_test.rb
+++ b/test/models/story_test.rb
@@ -320,7 +320,7 @@ describe Story do
       story.published_at.wont_be_nil
       story.update_attributes(released_at: nil)
       story.wont_be :valid?
-      story.errors[:released_at].must_include 'already published - cannot unset scheduled date'
+      story.errors[:released_at].must_include 'cannot be unset - already published'
     end
 
     it 'refuses to set a past publish date into the future' do
@@ -328,7 +328,7 @@ describe Story do
       story.published_at.wont_be_nil
       story.update_attributes(released_at: 1.week.from_now)
       story.wont_be :valid?
-      story.errors[:released_at].must_include 'already published - cannot schedule for future publishing'
+      story.errors[:released_at].must_include 'cannot be set to future - already published'
     end
 
     it 'orders coalesce publish and release dates' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -37,7 +37,7 @@ def use_webmock?
   ENV['USE_WEBMOCK'].nil? || (ENV['USE_WEBMOCK'] == 'true')
 end
 WebMock.allow_net_connect! unless use_webmock?
-WebMock.disable_net_connect!(allow: /elasticsearch/) if use_webmock?
+WebMock.disable_net_connect!(allow: /elasticsearch|9200/) if use_webmock?
 
 Dir[File.expand_path(File.join(File.dirname(__FILE__),'support','**','*.rb'))].each {|f| require f}
 


### PR DESCRIPTION
For PRX/publish.prx.org#698.

This prevents 2 bad cases, when updating `story.published_at` to match the `story.released_at`.

1. If published (published_at <= now) ... don't allow nulling out published_at.
2. If published (published_at <= now) ... don't allow setting published_at > now.

Some fallout on the frontend (PRX/publish.prx.org#702).  But I think we always want to prevent these 2 cases on the backend in any case.  The only API path to unpublishing something is `POST /api/v1/stories/1234/unpublish`.