### PR TITLE
Run process on imported images/audio

### DIFF
--- a/app/models/concerns/import_utils.rb
+++ b/app/models/concerns/import_utils.rb
@@ -104,10 +104,12 @@ module ImportUtils
 
   def announce_image(image)
     announce('image', 'create', Api::Msg::ImageRepresenter.new(image).to_json)
+    image.process!
   end
 
   def announce_audio(audio)
     announce('audio', 'create', Api::Msg::AudioFileRepresenter.new(audio).to_json)
+    audio.process!
   end
 
   def remind_to_unlock(title)

--- a/app/models/concerns/portered.rb
+++ b/app/models/concerns/portered.rb
@@ -5,10 +5,6 @@ require 'aws-sdk'
 module Portered
   extend ActiveSupport::Concern
 
-  unless ENV['PORTER_SNS_TOPIC_ARN'] || Rails.env.test?
-    Rails.logger.warn('No Porter SNS topic provided - Porter jobs will be skipped.')
-  end
-
   class_methods do
     def porter_callbacks(callbacks = nil)
       if callbacks.present?
@@ -67,12 +63,14 @@ module Portered
   end
 
   def publish_porter_sns(message)
-    return if Rails.env.test? || !ENV['PORTER_SNS_TOPIC_ARN'].present?
-
-    Portered.sns_client.publish(
-      topic_arn: ENV['PORTER_SNS_TOPIC_ARN'],
-      message: message.to_json
-    )
+    if ENV['PORTER_SNS_TOPIC_ARN'].present?
+      Portered.sns_client.publish(
+        topic_arn: ENV['PORTER_SNS_TOPIC_ARN'],
+        message: message.to_json
+      )
+    else
+      Rails.logger.warn('No Porter SNS topic provided - Porter jobs will be skipped.')
+    end
   end
 
 end

--- a/test/models/podcast_import_test.rb
+++ b/test/models/podcast_import_test.rb
@@ -65,10 +65,11 @@ describe PodcastImport do
     importer.distribution.distributable.must_equal importer.series
 
     # images must be processing
-    importer.series.images.count.must_equal 2
+    images = importer.series.images
+    images.count.must_equal 2
     Portered.sns_client.messages.count.must_equal 2
-    Portered.sns_client.messages[0]['Job']['Id'].must_equal importer.series.images[0].to_global_id.to_s
-    Portered.sns_client.messages[1]['Job']['Id'].must_equal importer.series.images[1].to_global_id.to_s
+    Portered.sns_client.messages[0]['Job']['Id'].must_equal images[0].to_global_id.to_s
+    Portered.sns_client.messages[1]['Job']['Id'].must_equal images[1].to_global_id.to_s
   end
 
   it 'creates a podcast' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,7 @@ ENV['META_HOST'] = 'meta.prx.org'
 ENV['PRX_HOST'] = 'beta.prx.org'
 ENV['PRX_CLIENT_ID'] = '0123456789abcdefghijklmnopqrstuvwxyzABCD'
 ENV['PRX_SECRET'] = '0123456789abcdefghijklmnopqrstuvwxyzABCD'
+ENV['PORTER_SNS_TOPIC_ARN'] = ''
 
 if !ENV['GUARD'] || ENV['GUARD_COVERAGE']
   require 'simplecov'
@@ -91,6 +92,16 @@ class StubToken < PrxAuth::Rails::Token
       "scope" => scopes,
       "sub" =>  explicit_user_id || @@fake_user_id += 1
     }))
+  end
+end
+
+class StubSns
+  attr_accessor :messages
+
+  def publish(params)
+    self.messages ||= []
+    self.messages << JSON.parse(params[:message]).with_indifferent_access
+    {message_id: 'whatever'}
   end
 end
 


### PR DESCRIPTION
When we moved over from the announcement-triggered CMS lambdas to Porter, I forgot to also check the feed import flow.

So here's a minor 2-line fix, plus a bunch of lines of me trying to figure out how to test it!