### PR TITLE
Convert permission checking to use token scopes

### DIFF
--- a/app/controllers/api/series_controller.rb
+++ b/app/controllers/api/series_controller.rb
@@ -35,14 +35,8 @@ class Api::SeriesController < Api::BaseController
 
   def create_resource
     super.tap do |series|
-      if account && authorization.authorized?(account)
-        series.account_id ||= account.id
-      end
-
-      if authorization.authorized?(current_user.default_account)
-        series.account_id ||= current_user.account_id
-      end
-
+      series.account_id ||= account.id if account
+      series.account_id ||= current_user.account_id
       series.account_id ||= authorization.token_auth_accounts.first.try(:id)
     end
   end

--- a/app/controllers/api/stories_controller.rb
+++ b/app/controllers/api/stories_controller.rb
@@ -84,14 +84,10 @@ class Api::StoriesController < Api::BaseController
   end
 
   def create_resource
-    super.tap do |story|
+    @create_resource ||= super.tap do |story|
       story.creator_id = current_user.id
-      story.account_id ||= story.series.try(:account_id)
       story.account_id ||= account.id if account
       story.account_id ||= current_user.account_id
-      story.account_id ||= (
-        authorization.resources(:story) + authorization.resources(:story_draft)
-      ).first
     end
   end
 

--- a/app/controllers/api/stories_controller.rb
+++ b/app/controllers/api/stories_controller.rb
@@ -87,13 +87,9 @@ class Api::StoriesController < Api::BaseController
     super.tap do |story|
       story.creator_id = current_user.id
       story.account_id ||= story.series.try(:account_id)
-
-      if account
-        story.account_id ||= account.id
-      end
-      
+      story.account_id ||= account.id if account
       story.account_id ||= current_user.account_id
-      story.account_id ||= authorization.token_auth_accounts.first.try(:id)
+      story.account_id ||= (authorization.resources(:story) + authorization.resources(:story_draft)).first
     end
   end
 

--- a/app/controllers/api/stories_controller.rb
+++ b/app/controllers/api/stories_controller.rb
@@ -88,14 +88,11 @@ class Api::StoriesController < Api::BaseController
       story.creator_id = current_user.id
       story.account_id ||= story.series.try(:account_id)
 
-      if account && authorization.authorized?(account)
+      if account
         story.account_id ||= account.id
       end
-
-      if authorization.authorized?(current_user.default_account)
-        story.account_id ||= current_user.account_id
-      end
-
+      
+      story.account_id ||= current_user.account_id
       story.account_id ||= authorization.token_auth_accounts.first.try(:id)
     end
   end

--- a/app/controllers/api/stories_controller.rb
+++ b/app/controllers/api/stories_controller.rb
@@ -89,7 +89,9 @@ class Api::StoriesController < Api::BaseController
       story.account_id ||= story.series.try(:account_id)
       story.account_id ||= account.id if account
       story.account_id ||= current_user.account_id
-      story.account_id ||= (authorization.resources(:story) + authorization.resources(:story_draft)).first
+      story.account_id ||= (
+        authorization.resources(:story) + authorization.resources(:story_draft)
+      ).first
     end
   end
 

--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -25,47 +25,19 @@ class Authorization
   end
 
   def token_auth_accounts
-    @token_auth_accounts ||= begin
-      token_ids = account_ids(:read_private)
-      if token_ids.empty?
-        []
-      else
-        Account.where(id: token_ids)
-      end
-    end
+    @token_auth_accounts ||= Account.where(id: account_ids(:read_private))
   end
 
   def token_auth_stories
-    @token_auth_stories ||= begin
-      token_ids = account_ids(:read_private)
-      if token_ids.empty?
-        []
-      else
-        Story.where(account_id: token_ids)
-      end
-    end
+    @token_auth_stories ||= Story.where(account_id: account_ids(:read_private))
   end
 
   def token_auth_series
-    @token_auth_series ||= begin
-      token_ids = account_ids(:read_private)
-      if token_ids.empty?
-        []
-      else
-        Series.where(account_id: token_ids)
-      end
-    end
+    @token_auth_series ||= Series.where(account_id: account_ids(:read_private))
   end
 
   def podcast_imports
-    @podcast_imports ||= begin
-      token_ids = account_ids(:read_private)
-      if token_ids.empty?
-        []
-      else
-        PodcastImport.where(account_id: token_ids)
-      end
-    end
+    @podcast_imports ||= PodcastImport.where(account_id: account_ids(:read_private))
   end
 
   def cache_key

--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -27,28 +27,44 @@ class Authorization
   def token_auth_accounts
     @token_auth_accounts ||= begin
       token_ids = account_ids(:read_private)
-      Account.where(id: token_ids) unless token_ids.empty?
+      if token_ids.empty?
+        []
+      else
+        Account.where(id: token_ids)
+      end
     end
   end
 
   def token_auth_stories
     @token_auth_stories ||= begin
       token_ids = account_ids(:read_private)
-      Story.where(account_id: token_ids) unless token_ids.empty?
+      if token_ids.empty?
+        []
+      else
+        Story.where(account_id: token_ids)
+      end
     end
   end
 
   def token_auth_series
     @token_auth_series ||= begin
       token_ids = account_ids(:read_private)
-      Series.where(account_id: token_ids) unless token_ids.empty?
+      if token_ids.empty?
+        []
+      else
+        Series.where(account_id: token_ids)
+      end
     end
   end
 
   def podcast_imports
     @podcast_imports ||= begin
       token_ids = account_ids(:read_private)
-      PodcastImport.where(account_id: token_ids) unless token_ids.empty?
+      if token_ids.empty?
+        []
+      else
+        PodcastImport.where(account_id: token_ids)
+      end
     end
   end
 

--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -5,7 +5,8 @@ class Authorization
   include HalApi::RepresentedModel
 
   attr_accessor :token
-  attr_reader :token_auth_accounts
+
+  delegate :resources, to: :token
 
   def initialize(token)
     @token = token
@@ -19,30 +20,41 @@ class Authorization
     User.find(token.user_id).default_account
   end
 
+  def account_ids(scope = nil)
+    token.resources(scope).map(&:to_i)
+  end
+
   def token_auth_accounts
-    token_ids = (token.resources(:member) + token.resources(:admin)).uniq
-    @token_auth_accounts = Account.where(id: token_ids) if token_ids
+    @token_auth_accounts ||= begin
+      token_ids = account_ids(:read_private)
+      Account.where(id: token_ids) unless token_ids.empty?
+    end
   end
 
   def token_auth_stories
-    Story.where(account_id: token_auth_accounts.try(:ids)) unless token_auth_accounts.nil?
+    @token_auth_stories ||= begin
+      token_ids = account_ids(:read_private)
+      Story.where(account_id: token_ids) unless token_ids.empty?
+    end
   end
 
   def token_auth_series
-    Series.where(account_id: token_auth_accounts.try(:ids)) unless token_auth_accounts.nil?
+    @token_auth_series ||= begin
+      token_ids = account_ids(:read_private)
+      Series.where(account_id: token_ids) unless token_ids.empty?
+    end
   end
 
   def podcast_imports
-    PodcastImport.where(account_id: token_auth_accounts.try(:ids)) unless token_auth_accounts.nil?
-  end
-
-  def authorized?(account)
-    token_auth_accounts.include?(account)
+    @podcast_imports ||= begin
+      token_ids = account_ids(:read_private)
+      PodcastImport.where(account_id: token_ids) unless token_ids.empty?
+    end
   end
 
   def cache_key
     key_components = ['c', self.class.model_name.cache_key]
-    key_components << OpenSSL::Digest::MD5.hexdigest(token.resources.join(' '))
+    key_components << OpenSSL::Digest::MD5.hexdigest(token.resources(:read_private).sort.join(' '))
     ActiveSupport::Cache.expand_cache_key(key_components)
   end
 

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -172,6 +172,6 @@ class Distribution < BaseModel
   end
 
   def self.policy_class
-    AccountablePolicy
+    DistributablePolicy
   end
 end

--- a/app/models/distribution_template.rb
+++ b/app/models/distribution_template.rb
@@ -18,7 +18,11 @@ class DistributionTemplate < BaseModel
     distribution.try(:account)
   end
 
+  def distributable
+    distribution&.distributable
+  end
+
   def self.policy_class
-    AccountablePolicy
+    DistributablePolicy
   end
 end

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -181,7 +181,7 @@ class Series < BaseModel
   end
 
   def self.policy_class
-    AccountablePolicy
+    SeriesPolicy
   end
 
   def import_url=(url)

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -282,6 +282,14 @@ class Story < BaseModel
     published_at.nil?
   end
 
+  def was_draft?
+    if published_at_changed?
+      published_at_was.nil?
+    else
+      draft?
+    end
+  end
+
   def date_for_boolean(value)
     if value.is_a?(Date) || value.is_a?(Time)
       value

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -184,6 +184,16 @@ class Story < BaseModel
     series.try(:touch)
   end
 
+  def series=(series_object)
+    super
+    self.account_id = series.account_id if series&.account_id.present?
+  end
+
+  def series_id=(series_id)
+    super
+    self.account_id = series.account_id if series&.account_id.present?
+  end
+
   def points(level=point_level)
     has_custom_points? ? self.custom_points : Economy.points(level, self.length)
   end

--- a/app/policies/account_policy.rb
+++ b/app/policies/account_policy.rb
@@ -4,10 +4,10 @@ class AccountPolicy < ApplicationPolicy
   end
 
   def update?
-    token && token.authorized?(resource.id, :account)
+    token&.authorized?(resource.id, :account)
   end
 
   def destroy?
-    token && token.authorized?(resource.id, :account_members)
+    token&.authorized?(resource.id, :account_members)
   end
 end

--- a/app/policies/account_policy.rb
+++ b/app/policies/account_policy.rb
@@ -4,10 +4,10 @@ class AccountPolicy < ApplicationPolicy
   end
 
   def update?
-    token && token.authorized?(resource.id)
+    token && token.authorized?(resource.id, :account)
   end
 
   def destroy?
-    token && token.authorized?(resource.id, :admin)
+    token && token.authorized?(resource.id, :account_members)
   end
 end

--- a/app/policies/accountable_policy.rb
+++ b/app/policies/accountable_policy.rb
@@ -1,5 +1,5 @@
 class AccountablePolicy < ApplicationPolicy
-  def initialize(token, resource, scope=nil)
+  def initialize(token, resource, scope = nil)
     super(token, resource)
     @scope = scope
   end

--- a/app/policies/accountable_policy.rb
+++ b/app/policies/accountable_policy.rb
@@ -15,4 +15,16 @@ class AccountablePolicy < ApplicationPolicy
   def destroy?
     update?
   end
+
+  private
+
+  def resource_id
+    resource&.account&.id
+  end
+
+  def resource_id_was
+    resource&.account_was&.id
+  rescue StandardError
+    nil
+  end
 end

--- a/app/policies/accountable_policy.rb
+++ b/app/policies/accountable_policy.rb
@@ -9,7 +9,7 @@ class AccountablePolicy < ApplicationPolicy
   end
 
   def update?
-    token&.authorized?(resource.account.id, @scope)
+    authorized?(@scope)
   end
 
   def destroy?

--- a/app/policies/accountable_policy.rb
+++ b/app/policies/accountable_policy.rb
@@ -1,7 +1,7 @@
 class AccountablePolicy < ApplicationPolicy
-  def initialize(token, resource, scope = :account)
+  def initialize(token, resource, scopes = :account)
     super(token, resource)
-    @scope = scope
+    @scopes = Array.wrap(scopes)
   end
 
   def create?
@@ -9,7 +9,7 @@ class AccountablePolicy < ApplicationPolicy
   end
 
   def update?
-    authorized?(@scope)
+    @scopes.all? { |scope| authorized?(scope) }
   end
 
   def destroy?

--- a/app/policies/accountable_policy.rb
+++ b/app/policies/accountable_policy.rb
@@ -1,5 +1,5 @@
 class AccountablePolicy < ApplicationPolicy
-  def initialize(token, resource, scope = nil)
+  def initialize(token, resource, scope = :account)
     super(token, resource)
     @scope = scope
   end

--- a/app/policies/accountable_policy.rb
+++ b/app/policies/accountable_policy.rb
@@ -1,10 +1,15 @@
 class AccountablePolicy < ApplicationPolicy
+  def initialize(token, resource, scope=nil)
+    super(token, resource)
+    @scope = scope
+  end
+
   def create?
     update?
   end
 
   def update?
-    token && token.authorized?(resource.account.id)
+    token&.authorized?(resource.account.id, @scope)
   end
 
   def destroy?

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -15,14 +15,19 @@ class ApplicationPolicy
 
   private
 
-  def authorized?(scope, resource_id_method_name = :account_id)
-    resource_id = resource.public_send(resource_id_method_name)
-    resource_id_was = resource.public_send("#{resource_id_method_name}_was")
-
+  def authorized?(scope)
     if resource_id_was.present? && resource_id_was != resource_id
       token&.authorized?(resource_id, scope) && token.authorized?(resource_id_was, scope)
     else
       token&.authorized?(resource_id, scope)
     end
+  end
+
+  def resource_id
+    resource&.account_id
+  end
+
+  def resource_id_was
+    resource&.account_id_was
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,4 +1,6 @@
-class ApplicationPolicy < Struct.new(:token, :resource)
+ApplicationPolicy = Struct.new(:token, :resource)
+
+class ApplicationPolicy
   def create?
     false
   end
@@ -9,5 +11,18 @@ class ApplicationPolicy < Struct.new(:token, :resource)
 
   def destroy?
     update?
+  end
+
+  private
+
+  def authorized?(scope, resource_id_method_name = :account_id)
+    resource_id = resource.public_send(resource_id_method_name)
+    resource_id_was = resource.public_send("#{resource_id_method_name}_was")
+
+    if resource_id_was.present? && resource_id_was != resource_id
+      token&.authorized?(resource_id, scope) && token.authorized?(resource_id_was, scope)
+    else
+      token&.authorized?(resource_id, scope)
+    end
   end
 end

--- a/app/policies/audio_file_policy.rb
+++ b/app/policies/audio_file_policy.rb
@@ -1,5 +1,5 @@
 class AudioFilePolicy < AccountablePolicy
   def original?
-    token && token.authorized?(resource.account.id) #todo: read-private
+    token&.authorized?(resource.account.id, :read_private)
   end
 end

--- a/app/policies/distributable_policy.rb
+++ b/app/policies/distributable_policy.rb
@@ -1,0 +1,15 @@
+class DistributablePolicy < ApplicationPolicy
+  def initialize(token, resource)
+    super
+    sub_policy_class = resource && Pundit::PolicyFinder.new(resource.distributable.class).policy!
+    @sub_policy = sub_policy_class.new(token, resource.distributable)
+  end
+
+  def create?
+    @sub_policy&.create?
+  end
+
+  def update?
+    @sub_policy&.update?
+  end
+end

--- a/app/policies/membership_policy.rb
+++ b/app/policies/membership_policy.rb
@@ -1,6 +1,6 @@
 class MembershipPolicy < ApplicationPolicy
   def create?
-    update? || (token.user_id == resource.user.id && !resource.approved?)
+    update?
   end
 
   def update?
@@ -8,6 +8,6 @@ class MembershipPolicy < ApplicationPolicy
   end
 
   def destroy?
-    token.user_id == resource.user.id || update?
+    update?
   end
 end

--- a/app/policies/membership_policy.rb
+++ b/app/policies/membership_policy.rb
@@ -4,7 +4,7 @@ class MembershipPolicy < ApplicationPolicy
   end
 
   def update?
-    token && token.authorized?(resource.account.id, :admin)
+    token && token.authorized?(resource.account.id, :account_members)
   end
 
   def destroy?

--- a/app/policies/membership_policy.rb
+++ b/app/policies/membership_policy.rb
@@ -4,7 +4,7 @@ class MembershipPolicy < ApplicationPolicy
   end
 
   def update?
-    token && token.authorized?(resource.account.id, :account_members)
+    token&.authorized?(resource.account.id, :account_members)
   end
 
   def destroy?

--- a/app/policies/network_membership_policy.rb
+++ b/app/policies/network_membership_policy.rb
@@ -5,14 +5,12 @@ class NetworkMembershipPolicy < ApplicationPolicy
 
   # create or update by network owner account admin
   def update?
-    token && token.authorized?(resource.network.account.id, :admin)
+    token&.authorized?(resource.network.account.id, :network_members)
   end
 
   # destroy by network owner account admin, or by network member account admin
   def destroy?
-    token && (
-      token.authorized?(resource.network.account.id, :admin) ||
-      token.authorized?(resource.account.id, :admin)
-    )
+    token&.authorized?(resource.network.account.id, :network_members) ||
+      token&.authorized?(resource.account.id, :network_members)
   end
 end

--- a/app/policies/podcast_import_policy.rb
+++ b/app/policies/podcast_import_policy.rb
@@ -1,4 +1,8 @@
 class PodcastImportPolicy < AccountablePolicy
+  def initialize(token, import)
+    super(token, import, [:story, :series])
+  end
+
   def verify_rss?
     true
   end

--- a/app/policies/producer_policy.rb
+++ b/app/policies/producer_policy.rb
@@ -4,8 +4,6 @@ class ProducerPolicy < ApplicationPolicy
   end
 
   def update?
-    token &&
-      (resource.user.id == token.user_id ||
-       AccountablePolicy.new(token, resource.story, :story).update?)
+    AccountablePolicy.new(token, resource.story, :story).update?
   end
 end

--- a/app/policies/producer_policy.rb
+++ b/app/policies/producer_policy.rb
@@ -6,6 +6,6 @@ class ProducerPolicy < ApplicationPolicy
   def update?
     token &&
       (resource.user.id == token.user_id ||
-       AccountablePolicy.new(token, resource.story).update?)
+       AccountablePolicy.new(token, resource.story, :story).update?)
   end
 end

--- a/app/policies/purchase_policy.rb
+++ b/app/policies/purchase_policy.rb
@@ -1,6 +1,6 @@
 class PurchasePolicy < ApplicationPolicy
   def create?
-    token && token.authorized?(resource.purchaser_account.id, :admin)
+    token&.authorized?(resource.purchaser_account.id, :purchase)
   end
 
   def update?

--- a/app/policies/series_attribute_policy.rb
+++ b/app/policies/series_attribute_policy.rb
@@ -4,6 +4,6 @@ class SeriesAttributePolicy < ApplicationPolicy
   end
 
   def update?
-    AccountablePolicy.new(token, resource.series).update?
+    AccountablePolicy.new(token, resource.series, :series).update?
   end
 end

--- a/app/policies/series_policy.rb
+++ b/app/policies/series_policy.rb
@@ -2,8 +2,4 @@ class SeriesPolicy < AccountablePolicy
   def initialize(token, series)
     super(token, series, :series)
   end
-  
-  def destroy?
-    false
-  end
 end

--- a/app/policies/series_policy.rb
+++ b/app/policies/series_policy.rb
@@ -1,9 +1,9 @@
-class SeriesPolicy < ApplicationPolicy
-  def create?
-    update?
+class SeriesPolicy < AccountablePolicy
+  def initialize(token, series)
+    super(token, series, :series)
   end
-
-  def update?
-    AccountablePolicy.new(token, resource, :series).update?
+  
+  def destroy?
+    false
   end
 end

--- a/app/policies/series_policy.rb
+++ b/app/policies/series_policy.rb
@@ -1,0 +1,9 @@
+class SeriesPolicy < ApplicationPolicy
+  def create?
+    update?
+  end
+
+  def update?
+    AccountablePolicy.new(token, resource, :series).update?
+  end
+end

--- a/app/policies/story_attribute_policy.rb
+++ b/app/policies/story_attribute_policy.rb
@@ -4,6 +4,6 @@ class StoryAttributePolicy < ApplicationPolicy
   end
 
   def update?
-    AccountablePolicy.new(token, resource.story).update?
+    AccountablePolicy.new(token, resource.story, :story).update?
   end
 end

--- a/app/policies/story_attribute_policy.rb
+++ b/app/policies/story_attribute_policy.rb
@@ -1,9 +1,5 @@
-class StoryAttributePolicy < ApplicationPolicy
-  def create?
-    update?
-  end
-
-  def update?
-    AccountablePolicy.new(token, resource.story, :story).update?
+class StoryAttributePolicy < StoryPolicy
+  def initialize(token, resource)
+    super(token, resource.story)
   end
 end

--- a/app/policies/story_policy.rb
+++ b/app/policies/story_policy.rb
@@ -2,7 +2,7 @@ class StoryPolicy < AccountablePolicy
   def initialize(token, resource)
     super(token, resource, :story)
   end
-  
+
   def publish?
     update?
   end

--- a/app/policies/story_policy.rb
+++ b/app/policies/story_policy.rb
@@ -1,13 +1,11 @@
 class StoryPolicy < ApplicationPolicy
 
   def create?
-    token&.authorized?(resource.account_id, :story) ||
-      (resource.draft? && token&.authorized?(resource.account_id, :story_draft))
+    authorized?(:story) || (resource.draft? && authorized?(:story_draft))
   end
 
   def update?
-    token&.authorized?(resource.account_id, :story) ||
-      (token&.authorized?(resource.account_id, :story_draft) && resource.draft? &&  resource.was_draft?)
+    authorized?(:story) || (authorized?(:story_draft) && resource.draft? && resource.was_draft?)
   end
 
   def destroy?
@@ -15,7 +13,7 @@ class StoryPolicy < ApplicationPolicy
   end
 
   def publish?
-    token&.authorized?(resource.account_id, :story)
+    authorized?(:story)
   end
 
   def unpublish?

--- a/app/policies/story_policy.rb
+++ b/app/policies/story_policy.rb
@@ -1,13 +1,24 @@
-class StoryPolicy < AccountablePolicy
-  def initialize(token, resource)
-    super(token, resource, :story)
+class StoryPolicy < ApplicationPolicy
+
+  def create?
+    token&.authorized?(resource.account_id, :story) ||
+      (resource.draft? && token&.authorized?(resource.account_id, :story_draft))
+  end
+
+  def update?
+    token&.authorized?(resource.account_id, :story) ||
+      (token&.authorized?(resource.account_id, :story_draft) && resource.draft? &&  resource.was_draft?)
+  end
+
+  def destroy?
+    update?
   end
 
   def publish?
-    update?
+    token&.authorized?(resource.account_id, :story)
   end
 
   def unpublish?
-    update?
+    publish?
   end
 end

--- a/app/policies/story_policy.rb
+++ b/app/policies/story_policy.rb
@@ -1,4 +1,8 @@
 class StoryPolicy < AccountablePolicy
+  def initialize(token, resource)
+    super(token, resource, :story)
+  end
+  
   def publish?
     update?
   end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -4,6 +4,6 @@ class UserPolicy < ApplicationPolicy
   end
 
   def update?
-    token.user_id == resource.id
+    false
   end
 end

--- a/test/controllers/api/account_images_controller_test.rb
+++ b/test/controllers/api/account_images_controller_test.rb
@@ -12,7 +12,7 @@ describe Api::AccountImagesController do
 
   describe 'write' do
 
-    let(:token) { StubToken.new(account.id, ['member'], user.id) }
+    let(:token) { StubToken.new(account.id, ['cms:account'], user.id) }
 
     before(:each) do
       class << @controller; attr_accessor :prx_auth_token; end

--- a/test/controllers/api/accounts_controller_test.rb
+++ b/test/controllers/api/accounts_controller_test.rb
@@ -6,7 +6,7 @@ describe Api::AccountsController do
   let (:user_without_account) { create(:user, with_individual_account: false) }
   let (:user) { create(:user) }
   let (:write_token) { StubToken.new(nil, nil, user_without_account.id) }
-  let (:token) { StubToken.new(nil, ['account'], user.id) }
+  let (:token) { StubToken.new(nil, ['cms:account'], user.id) }
 
   it 'should show' do
     get(:show, { api_version: 'v1', format: 'json', id: account.id })

--- a/test/controllers/api/audio_files_controller_test.rb
+++ b/test/controllers/api/audio_files_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe Api::AudioFilesController do
   let(:user) { create(:user) }
   let(:account) { create(:account) }
-  let(:token) { StubToken.new(account.id, ['cms:read-private cms:story'], user.id) }
+  let(:token) { StubToken.new(account.id, ['cms:read-private cms:story cms:account'], user.id) }
   let(:story) { create(:story, account: account) }
   let(:story_with_version) { create(:story, account: account) }
   let(:audio_file) { create(:audio_file, story: story, account: account) }

--- a/test/controllers/api/audio_files_controller_test.rb
+++ b/test/controllers/api/audio_files_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe Api::AudioFilesController do
   let(:user) { create(:user) }
   let(:account) { create(:account) }
-  let(:token) { StubToken.new(account.id, ['member'], user.id) }
+  let(:token) { StubToken.new(account.id, ['cms:read-private cms:story'], user.id) }
   let(:story) { create(:story, account: account) }
   let(:story_with_version) { create(:story, account: account) }
   let(:audio_file) { create(:audio_file, story: story, account: account) }

--- a/test/controllers/api/audio_files_controller_test.rb
+++ b/test/controllers/api/audio_files_controller_test.rb
@@ -97,8 +97,8 @@ describe Api::AudioFilesController do
   end
 
   describe '#original' do
-    let(:bad_token) { StubToken.new("bad", ['member']) }
-    let(:token) { StubToken.new(account.id, ['member']) }
+    let(:bad_token) { StubToken.new(account.id, ['member']) }
+    let(:token) { StubToken.new(account.id, ['cms:read-private']) }
 
     before(:each) do
       class << @controller; attr_accessor :prx_auth_token; end

--- a/test/controllers/api/auth/accounts_controller_test.rb
+++ b/test/controllers/api/auth/accounts_controller_test.rb
@@ -9,8 +9,8 @@ describe Api::Auth::AccountsController do
   let (:token) { PrxAuth::Rails::Token.new(Rack::PrxAuth::TokenData.new('sub' => user.id, 'aur' => aur)) }
   let (:aur) do
     {
-      member_account.id.to_s => 'member',
-      individual_account.id.to_s => 'admin'
+      member_account.id.to_s => 'cms:read-private cms:account',
+      individual_account.id.to_s => 'cms:read-private cms:account'
     }
   end
 

--- a/test/controllers/api/auth/episode_imports_controller_test.rb
+++ b/test/controllers/api/auth/episode_imports_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe Api::Auth::EpisodeImportsController do
 
   let (:user) { create(:user) }
-  let (:token) { StubToken.new(account.id, ['member'], user.id) }
+  let (:token) { StubToken.new(account.id, ['cms:story'], user.id) }
   let (:account) { user.individual_account }
   let (:podcast_import) { create(:podcast_import, account: account) }
   let (:episode_import) { create(:episode_import, podcast_import: podcast_import) }

--- a/test/controllers/api/auth/podcast_imports_controller_test.rb
+++ b/test/controllers/api/auth/podcast_imports_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe Api::Auth::PodcastImportsController do
 
   let (:user) { create(:user) }
-  let (:token) { StubToken.new(account.id, ['member'], user.id) }
+  let (:token) { StubToken.new(account.id, ['cms:account cms:read-private'], user.id) }
   let (:account) { user.individual_account }
   let (:podcast_url) { 'http://feeds.prx.org/transistor_stem' }
   let (:podcast_import) { create(:podcast_import, account: account) }

--- a/test/controllers/api/auth/podcast_imports_controller_test.rb
+++ b/test/controllers/api/auth/podcast_imports_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe Api::Auth::PodcastImportsController do
 
   let (:user) { create(:user) }
-  let (:token) { StubToken.new(account.id, ['cms:account cms:read-private'], user.id) }
+  let (:token) { StubToken.new(account.id, ['cms:series cms:story cms:read-private'], user.id) }
   let (:account) { user.individual_account }
   let (:podcast_url) { 'http://feeds.prx.org/transistor_stem' }
   let (:podcast_import) { create(:podcast_import, account: account) }

--- a/test/controllers/api/auth/series_controller_test.rb
+++ b/test/controllers/api/auth/series_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 describe Api::Auth::SeriesController do
   let(:user) { create(:user) }
-  let(:token) { StubToken.new(account.id, ['member'], user.id) }
+  let(:token) { StubToken.new(account.id, ['cms:series cms:read-private'], user.id) }
   let(:account) { user.individual_account }
   let(:series) { create(:series, account: account) }
   let(:v3_series) { create(:series_v3, account: account) }

--- a/test/controllers/api/auth/stories_controller_test.rb
+++ b/test/controllers/api/auth/stories_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe Api::Auth::StoriesController do
   let (:search_term) { 'title' } # factory value
   let (:user) { create(:user) }
-  let (:token) { StubToken.new(account.id, ['member'], user.id) }
+  let (:token) { StubToken.new(account.id, ['cms:read-private'], user.id) }
   let (:account) { user.individual_account }
   let (:published_story) { account.stories.last }
   let (:latest_story) { create(:story, account: account) }

--- a/test/controllers/api/auth/stories_controller_test.rb
+++ b/test/controllers/api/auth/stories_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe Api::Auth::StoriesController do
   let (:search_term) { 'title' } # factory value
   let (:user) { create(:user) }
-  let (:token) { StubToken.new(account.id, ['cms:read-private'], user.id) }
+  let (:token) { StubToken.new(account.id, ['cms:read-private cms:story cms:account'], user.id) }
   let (:account) { user.individual_account }
   let (:published_story) { account.stories.last }
   let (:latest_story) { create(:story, account: account) }

--- a/test/controllers/api/authorizations_controller_test.rb
+++ b/test/controllers/api/authorizations_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe Api::AuthorizationsController do
 
   let (:user) { create(:user) }
-  let (:token) { StubToken.new(user.individual_account.id, 'admin', user.id) }
+  let (:token) { StubToken.new(user.individual_account.id, 'cms:read-private', user.id) }
 
   it 'returns unauthorized with invalid token' do
     @controller.stub(:prx_auth_token, OpenStruct.new) do

--- a/test/controllers/api/distributions_controller_test.rb
+++ b/test/controllers/api/distributions_controller_test.rb
@@ -81,7 +81,7 @@ describe Api::DistributionsController do
         }
         @request.env['CONTENT_TYPE'] = 'application/json'
         def @controller.after_create_resource(res)
-          res.update_attributes!(url: 'http://feeder.prx.org/api/v1/podcast/12345')
+          res.update_attributes!(url: podcast_uri)
         end
         post :create, pd_hash.to_json, api_request_opts(series_id: series.id)
         assert_response :unauthorized

--- a/test/controllers/api/distributions_controller_test.rb
+++ b/test/controllers/api/distributions_controller_test.rb
@@ -73,7 +73,6 @@ describe Api::DistributionsController do
 
       it 'cannot create a podcast distribution' do
         template_uri = "/api/v1/audio_version_templates/#{audio_version_template.id}"
-        podcast_uri = 'http://feeder.prx.org/api/v1/podcast/12345'
         pd_hash = {
           kind: 'podcast',
           guid: 'SET TEMPLATE',
@@ -81,7 +80,7 @@ describe Api::DistributionsController do
         }
         @request.env['CONTENT_TYPE'] = 'application/json'
         def @controller.after_create_resource(res)
-          res.update_attributes!(url: podcast_uri)
+          res.update_attributes!(url: 'http://feeder.prx.org/api/v1/podcast/12345')
         end
         post :create, pd_hash.to_json, api_request_opts(series_id: series.id)
         assert_response :unauthorized

--- a/test/controllers/api/series_controller_test.rb
+++ b/test/controllers/api/series_controller_test.rb
@@ -72,7 +72,7 @@ describe Api::SeriesController do
 
   describe 'with a valid token' do
     around do |test|
-      token = StubToken.new(account.id, ['member'], user.id)
+      token = StubToken.new(account.id, ['cms:series'], user.id)
       @request.env['CONTENT_TYPE'] = 'application/json'
       @controller.stub(:prx_auth_token, token) { test.call }
     end

--- a/test/controllers/api/series_images_controller_test.rb
+++ b/test/controllers/api/series_images_controller_test.rb
@@ -4,7 +4,7 @@ describe Api::SeriesImagesController do
   let(:user) { create(:user) }
   let(:series) { create(:series, account: user.individual_account) }
   let(:series_image) { create(:series_image, series: series, purpose: nil) }
-  let(:token) { StubToken.new(series.account.id, ['member'], user.id) }
+  let(:token) { StubToken.new(series.account.id, ['cms:read-private cms:series'], user.id) }
 
   before(:each) do
     class << @controller; attr_accessor :prx_auth_token; end

--- a/test/controllers/api/stories_controller_test.rb
+++ b/test/controllers/api/stories_controller_test.rb
@@ -124,8 +124,8 @@ describe Api::StoriesController do
     end
 
     it 'can create a missing story distribution on update' do
-      series = create(:series, templates_count: 1, dist_count: 1)
-      story = create(:story, title: 'not this', account: account, series: series)
+      series = create(:series, templates_count: 1, dist_count: 1, account: account)
+      story = create(:story, title: 'not this', account: series.account, series: series)
       story.distributions.must_be_empty
 
       template_id = series.audio_version_templates.first.id
@@ -156,8 +156,8 @@ describe Api::StoriesController do
     end
 
     it 'won\'t create duplicate or needless distributions when updating a story' do
-      series = create(:series, templates_count: 2, dist_count: 2)
-      story = create(:story, title: 'not this', account: account, series: series, audio_versions_count: 2)
+      series = create(:series, templates_count: 2, dist_count: 2, account: account)
+      story = create(:story, title: 'not this', account: series.account, series: series, audio_versions_count: 2)
       story.distributions.must_be_empty
 
       common_template = series.audio_version_templates.first

--- a/test/controllers/api/stories_controller_test.rb
+++ b/test/controllers/api/stories_controller_test.rb
@@ -157,7 +157,11 @@ describe Api::StoriesController do
 
     it 'won\'t create duplicate or needless distributions when updating a story' do
       series = create(:series, templates_count: 2, dist_count: 2, account: account)
-      story = create(:story, title: 'not this', account: series.account, series: series, audio_versions_count: 2)
+      story = create(:story,
+                     title: 'not this',
+                     account: series.account,
+                     series: series,
+                     audio_versions_count: 2)
       story.distributions.must_be_empty
 
       common_template = series.audio_version_templates.first

--- a/test/controllers/api/stories_controller_test.rb
+++ b/test/controllers/api/stories_controller_test.rb
@@ -49,13 +49,13 @@ describe Api::StoriesController do
     end
 
     it 'can create a new story for a series' do
-      skip 'Not sure why this would have stopped working?'
       post :create,
            { title: 'story', set_series_uri: "/api/v1/series/#{series.id}" }.to_json,
            api_version: 'v1'
       assert_response :success
       id = JSON.parse(response.body)['id']
-      Story.find(id).account_id.must_equal account.id
+      Story.find(id).account_id.must_equal series.account.id
+      Story.find(id).series_id.must_equal series.id
     end
 
     it 'can create a new story and distributions' do

--- a/test/controllers/api/stories_controller_test.rb
+++ b/test/controllers/api/stories_controller_test.rb
@@ -11,7 +11,7 @@ describe Api::StoriesController do
 
   describe 'editing' do
     let (:user) { create(:user) }
-    let (:token) { StubToken.new(account.id, ['member'], user.id) }
+    let (:token) { StubToken.new(account.id, ['cms:read-private cms:story'], user.id) }
 
     before(:each) do
       class << @controller; attr_accessor :prx_auth_token; end
@@ -49,6 +49,7 @@ describe Api::StoriesController do
     end
 
     it 'can create a new story for a series' do
+      skip 'Not sure why this would have stopped working?'
       post :create,
            { title: 'story', set_series_uri: "/api/v1/series/#{series.id}" }.to_json,
            api_version: 'v1'

--- a/test/controllers/api/story_distribitions_controller_test.rb
+++ b/test/controllers/api/story_distribitions_controller_test.rb
@@ -6,7 +6,7 @@ describe Api::StoryDistributionsController do
   let(:story_distribution) { create(:episode_distribution) }
   let(:distribution) { story_distribution.distribution }
   let(:story) { story_distribution.story }
-  let(:token) { StubToken.new(story.account.id, ['member'], user.id) }
+  let(:token) { StubToken.new(story.account.id, ['cms:story'], user.id) }
 
   it 'should show' do
     get :show, api_request_opts(story_id: story.id, id: story_distribution.id)

--- a/test/controllers/api/story_images_controller_test.rb
+++ b/test/controllers/api/story_images_controller_test.rb
@@ -5,7 +5,7 @@ describe Api::StoryImagesController do
   let(:story_image) { create(:story_image) }
   let(:story) { story_image.story }
   let(:account) { story.account }
-  let(:token) { StubToken.new(account.id, ['member'], user.id) }
+  let(:token) { StubToken.new(account.id, ['cms:read-private cms:story'], user.id) }
 
   before(:each) do
     class << @controller; attr_accessor :prx_auth_token; end

--- a/test/controllers/api/user_images_controller_test.rb
+++ b/test/controllers/api/user_images_controller_test.rb
@@ -12,7 +12,7 @@ describe Api::UserImagesController do
 
   describe 'write' do
 
-    let(:token) { StubToken.new(account.id, ['member'], user.id) }
+    let(:token) { StubToken.new(account.id, ['cms:account'], user.id) }
 
     before(:each) do
       class << @controller; attr_accessor :prx_auth_token; end

--- a/test/models/authorization_test.rb
+++ b/test/models/authorization_test.rb
@@ -18,7 +18,7 @@ describe Authorization do
     assert_same_elements(authorization.token_auth_stories, account.stories)
     assert_same_elements(authorization.token_auth_series, account.series)
   end
-  
+
   it 'implements to_model' do
     skip "should implement Token#hash in library"
     authorization.cache_key.must_equal 'c/authorizations/b9c423a32f16a0997c5c5de0bf906027'

--- a/test/models/authorization_test.rb
+++ b/test/models/authorization_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 describe Authorization do
   let(:account) { create(:account) }
-  let(:token) { StubToken.new(account.id, ['member'], 456) }
+  let(:token) { StubToken.new(account.id, ['read-private'], 456) }
   let(:authorization) { Authorization.new(token) }
   let(:unauth_account) { create(:account) }
 
@@ -18,15 +18,9 @@ describe Authorization do
     assert_same_elements(authorization.token_auth_stories, account.stories)
     assert_same_elements(authorization.token_auth_series, account.series)
   end
-
-  it 'checks against token to see if accounts are authorized' do
-    authorization.authorized?(account).must_equal true
-    authorization.authorized?(unauth_account).must_equal false
-  end
-
+  
   it 'implements to_model' do
     skip "should implement Token#hash in library"
-    authorization.token.attributes = { aur: [1,2,3], uid: 1 }
     authorization.cache_key.must_equal 'c/authorizations/b9c423a32f16a0997c5c5de0bf906027'
   end
 

--- a/test/policies/account_policy_test.rb
+++ b/test/policies/account_policy_test.rb
@@ -1,9 +1,9 @@
 require 'test_helper'
 
 describe AccountPolicy do
-  let(:admin_token) { StubToken.new(account.id, ['admin']) }
-  let(:member_token) { StubToken.new(account.id, ['member']) }
-  let(:non_member_token) { StubToken.new(account.id + 2, ['admin']) }
+  let(:admin_token) { StubToken.new(account.id, ['cms:account', 'cms:account-members']) }
+  let(:member_token) { StubToken.new(account.id, ['cms:account']) }
+  let(:non_member_token) { StubToken.new(account.id + 2, ['cms:account-members', 'cms:account']) }
   let(:account) { build_stubbed(:account) }
 
   describe '#create?' do

--- a/test/policies/accountable_policy_test.rb
+++ b/test/policies/accountable_policy_test.rb
@@ -4,7 +4,7 @@ describe AccountablePolicy do
   let(:non_member_token) { StubToken.new(account.id + 1, ['cms:account']) }
   let(:member_token) { StubToken.new(account.id, ['cms:account']) }
   let(:account) { create(:account) }
-  let(:playlist) { create(:playlist, account: account)}
+  let(:playlist) { create(:playlist, account: account) }
   let(:playlist_section) { create(:playlist_section, playlist: playlist) }
   let(:pick) { create(:pick, playlist_section: playlist_section) }
 

--- a/test/policies/accountable_policy_test.rb
+++ b/test/policies/accountable_policy_test.rb
@@ -3,29 +3,31 @@ require 'test_helper'
 describe AccountablePolicy do
   let(:non_member_token) { StubToken.new(account.id + 1, ['cms:account']) }
   let(:member_token) { StubToken.new(account.id, ['cms:account']) }
-  let(:account) { build_stubbed(:account) }
-  let(:story) { build(:story, account: account) }
+  let(:account) { create(:account) }
+  let(:playlist) { create(:playlist, account: account)}
+  let(:playlist_section) { create(:playlist_section, playlist: playlist) }
+  let(:pick) { create(:pick, playlist_section: playlist_section) }
 
   describe '#update?' do
     it 'returns false if user is not present' do
-      AccountablePolicy.new(nil, story).wont_allow :update?
+      AccountablePolicy.new(nil, pick).wont_allow :update?
     end
 
     it 'returns false if user is not a member of the account' do
-      AccountablePolicy.new(non_member_token, story).wont_allow :update?
+      AccountablePolicy.new(non_member_token, pick).wont_allow :update?
     end
 
     it 'returns true if is a member of the account' do
-      AccountablePolicy.new(member_token, story).must_allow :update?
+      AccountablePolicy.new(member_token, pick).must_allow :update?
     end
 
     describe 'with a scope specified' do
       it 'returns true if the scope is present in the token for the given account-owned object' do
-        AccountablePolicy.new(member_token, story, :account).must_allow :update?
+        AccountablePolicy.new(member_token, pick, :account).must_allow :update?
       end
 
       it 'returns false if the scope is missing in the token for the given account-owned object' do
-        AccountablePolicy.new(member_token, story, :admin).wont_allow :update?
+        AccountablePolicy.new(member_token, pick, :admin).wont_allow :update?
       end
     end
   end

--- a/test/policies/accountable_policy_test.rb
+++ b/test/policies/accountable_policy_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 
 describe AccountablePolicy do
-  let(:non_member_token) { StubToken.new(account.id + 1, ['no']) }
-  let(:member_token) { StubToken.new(account.id, ['member']) }
+  let(:non_member_token) { StubToken.new(account.id + 1, ['cms:account']) }
+  let(:member_token) { StubToken.new(account.id, ['cms:account']) }
   let(:account) { build_stubbed(:account) }
   let(:story) { build(:story, account: account) }
 
@@ -17,6 +17,16 @@ describe AccountablePolicy do
 
     it 'returns true if is a member of the account' do
       AccountablePolicy.new(member_token, story).must_allow :update?
+    end
+
+    describe 'with a scope specified' do
+      it 'returns true if the scope is present in the token for the given account-owned object' do
+        AccountablePolicy.new(member_token, story, :account).must_allow :update?
+      end
+
+      it 'returns false if the scope is missing in the token for the given account-owned object' do
+        AccountablePolicy.new(member_token, story, :admin).wont_allow :update?
+      end
     end
   end
 end

--- a/test/policies/audio_file_template_policy_test.rb
+++ b/test/policies/audio_file_template_policy_test.rb
@@ -5,8 +5,9 @@ describe AudioFileTemplatePolicy do
   let(:series) { create(:series, account: account) }
   let(:audio_version_template) { create(:audio_version_template, series: series) }
   let(:audio_file_template) { build_stubbed(:audio_file_template, audio_version_template: audio_version_template) }
-  let(:token) { StubToken.new(series.account_id, ['member']) }
-  let(:non_member_token) { StubToken.new(series.account_id + 1, ['no']) }
+  let(:token) { StubToken.new(series.account_id, ['cms:series']) }
+  let(:non_member_token) { StubToken.new(series.account_id + 1, ['cms:series']) }
+  let(:non_series_token) { StubToken.new(series.account_id, ['cms:account']) }
   let(:user) { build_stubbed(:user, id: token.user_id) }
 
   describe '#update? and #create?' do
@@ -15,9 +16,15 @@ describe AudioFileTemplatePolicy do
       AudioFileTemplatePolicy.new(token, audio_file_template).must_allow :create?
     end
 
+    it 'returns false if the token lacks the series scope' do
+      AudioFileTemplatePolicy.new(non_series_token, audio_file_template).wont_allow :update?
+      AudioFileTemplatePolicy.new(non_series_token, audio_file_template).wont_allow :create?
+    end
+
     it 'returns false otherwise' do
       AudioFileTemplatePolicy.new(non_member_token, audio_file_template).wont_allow :update?
       AudioFileTemplatePolicy.new(non_member_token, audio_file_template).wont_allow :create?
     end
+
   end
 end

--- a/test/policies/image_policy_test.rb
+++ b/test/policies/image_policy_test.rb
@@ -2,31 +2,31 @@ require 'test_helper'
 
 describe ImagePolicy do
   let(:account) { build_stubbed(:account) }
-  let(:member_token) { StubToken.new(account.id, ['member']) }
-  let(:non_member_token) { StubToken.new(account.id + 1, ['no']) }
+  let(:series_member_token) { StubToken.new(account.id, ['cms:series']) }
+  let(:account_member_token) { StubToken.new(account.id, ['cms:account']) }
 
   describe 'series images' do
     let(:series) { build_stubbed(:series, account: account) }
     let(:series_image) { build_stubbed(:series_image, series: series) }
 
     it 'returns true if user is a member of account' do
-      ImagePolicy.new(member_token, series_image).must_allow :update?
+      ImagePolicy.new(series_member_token, series_image).must_allow :update?
     end
 
     it 'returns false if user is not a member' do
-      ImagePolicy.new(non_member_token, series_image).wont_allow :update?
+      ImagePolicy.new(account_member_token, series_image).wont_allow :update?
     end
   end
 
   describe 'user images' do
-    let(:user_image) { build_stubbed(:user_image, user: User.new(id: member_token.user_id)) }
+    let(:user_image) { build_stubbed(:user_image, user: User.new(id: series_member_token.user_id)) }
 
-    it 'returns true if users are the same' do
-      ImagePolicy.new(member_token, user_image).must_allow :update?
+    it 'returns false if users are the same' do
+      ImagePolicy.new(series_member_token, user_image).wont_allow :update?
     end
 
     it 'returns false if users are different' do
-      ImagePolicy.new(non_member_token, user_image).wont_allow :update?
+      ImagePolicy.new(account_member_token, user_image).wont_allow :update?
     end
   end
 end

--- a/test/policies/membership_policy_test.rb
+++ b/test/policies/membership_policy_test.rb
@@ -1,9 +1,9 @@
 require 'test_helper'
 
 describe MembershipPolicy do
-  let(:member_token) { StubToken.new(account.id, ['member']) }
-  let(:admin_token) { StubToken.new(account.id, ['admin']) }
-  let(:non_member_token) { StubToken.new(account.id + 1, ['no']) }
+  let(:member_token) { StubToken.new(account.id, ['account']) }
+  let(:admin_token) { StubToken.new(account.id, ['account', 'account-members']) }
+  let(:non_member_token) { StubToken.new(account.id + 1, ['account', 'account-members']) }
   let(:membership) { build_stubbed(:membership, user: user, account: account, approved: false) }
   let(:user) { build_stubbed(:user, id: non_member_token.user_id) }
   let(:account) { build_stubbed(:account) }

--- a/test/policies/membership_policy_test.rb
+++ b/test/policies/membership_policy_test.rb
@@ -26,8 +26,8 @@ describe MembershipPolicy do
         MembershipPolicy.new(non_member_token, membership).wont_allow :create?
       end
 
-      it 'returns true otherwise' do
-        MembershipPolicy.new(non_member_token, membership).must_allow :create?
+      it 'returns false otherwise' do
+        MembershipPolicy.new(non_member_token, membership).wont_allow :create?
       end
     end
   end
@@ -51,8 +51,8 @@ describe MembershipPolicy do
   end
 
   describe '#destroy?' do
-    it 'returns true if user is the member' do
-      MembershipPolicy.new(non_member_token, membership).must_allow :destroy?
+    it 'returns false if user is the member' do
+      MembershipPolicy.new(non_member_token, membership).wont_allow :destroy?
     end
 
     it 'returns true if user is an admin' do

--- a/test/policies/membership_policy_test.rb
+++ b/test/policies/membership_policy_test.rb
@@ -1,9 +1,9 @@
 require 'test_helper'
 
 describe MembershipPolicy do
-  let(:member_token) { StubToken.new(account.id, ['account']) }
-  let(:admin_token) { StubToken.new(account.id, ['account', 'account-members']) }
-  let(:non_member_token) { StubToken.new(account.id + 1, ['account', 'account-members']) }
+  let(:member_token) { StubToken.new(account.id, ['cms:account']) }
+  let(:admin_token) { StubToken.new(account.id, ['cms:account', 'cms:account-members']) }
+  let(:non_member_token) { StubToken.new(account.id + 1, ['cms:account', 'cms:account-members']) }
   let(:membership) { build_stubbed(:membership, user: user, account: account, approved: false) }
   let(:user) { build_stubbed(:user, id: non_member_token.user_id) }
   let(:account) { build_stubbed(:account) }

--- a/test/policies/network_membership_policy_test.rb
+++ b/test/policies/network_membership_policy_test.rb
@@ -7,8 +7,8 @@ describe NetworkMembershipPolicy do
   let(:network) { create(:network, account: admin_account) }
   let(:membership) { NetworkMembership.new(network: network, account: member_account) }
 
-  let(:member_token) { StubToken.new(member_account.id, ['admin']) }
-  let(:admin_token) { StubToken.new(admin_account.id, ['admin']) }
+  let(:member_token) { StubToken.new(member_account.id, ['cms:network-members']) }
+  let(:admin_token) { StubToken.new(admin_account.id, ['cms:network-members']) }
   let(:non_member_token) { StubToken.new(random_account, ['no']) }
 
   describe '#update?' do

--- a/test/policies/owned_policy_test.rb
+++ b/test/policies/owned_policy_test.rb
@@ -7,8 +7,8 @@ end
 describe OwnedPolicy do
   let(:account) { create(:account) }
   let(:owned) { OwnedTestModel.new.tap { |o| o.owner = account } }
-  let(:token) { StubToken.new(account.id, ['account']) }
-  let(:bad_token) { StubToken.new(account.id + 1, ['account']) }
+  let(:token) { StubToken.new(account.id, ['cms:account']) }
+  let(:bad_token) { StubToken.new(account.id + 1, ['cms:account']) }
 
   describe '#update? or #create?' do
     it 'returns true if authorized on owning account' do

--- a/test/policies/owned_policy_test.rb
+++ b/test/policies/owned_policy_test.rb
@@ -7,8 +7,8 @@ end
 describe OwnedPolicy do
   let(:account) { create(:account) }
   let(:owned) { OwnedTestModel.new.tap { |o| o.owner = account } }
-  let(:token) { StubToken.new(account.id, ['member']) }
-  let(:bad_token) { StubToken.new(account.id + 1, ['member']) }
+  let(:token) { StubToken.new(account.id, ['account']) }
+  let(:bad_token) { StubToken.new(account.id + 1, ['account']) }
 
   describe '#update? or #create?' do
     it 'returns true if authorized on owning account' do

--- a/test/policies/podcast_import_policy_test.rb
+++ b/test/policies/podcast_import_policy_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+describe PodcastImportPolicy do
+  let(:account) { build_stubbed(:account, id: 1234) }
+  let(:import) { build(:podcast_import, account: account) }
+
+  def policy(scope)
+    PodcastImportPolicy.new(StubToken.new(account.id, scope), import)
+  end
+
+  it 'requires both story and series scopes' do
+    policy('cms:series cms:story').must_allow :create?
+    policy('cms:series cms:story').must_allow :update?
+
+    policy('cms:story').wont_allow :create?
+    policy('cms:series').wont_allow :create?
+  end
+end

--- a/test/policies/producer_policy_test.rb
+++ b/test/policies/producer_policy_test.rb
@@ -1,9 +1,10 @@
 require 'test_helper'
 
 describe ProducerPolicy do
-  let(:producer_token) { StubToken.new(story.account_id + 1, ['member']) }
-  let(:member_token) { StubToken.new(story.account_id, ['member']) }
-  let(:non_member_token) { StubToken.new(story.account_id + 1, ['no']) }
+  let(:producer_token) { StubToken.new(story.account_id + 1, ['cms:story']) }
+  let(:member_token) { StubToken.new(story.account_id, ['cms:story']) }
+  let(:n_s_member_token) { StubToken.new(story.account_id, ['cms:account']) }
+  let(:non_member_token) { StubToken.new(story.account_id + 1, ['cms:story']) }
   let(:producer) { build_stubbed(:producer_with_user_and_story, user: user, story: story) }
   let(:story) { build(:story, account: account) }
   let(:account) { build_stubbed(:account) }
@@ -23,6 +24,11 @@ describe ProducerPolicy do
     it 'returns false otherwise' do
       ProducerPolicy.new(non_member_token, producer).wont_allow :update?
       ProducerPolicy.new(non_member_token, producer).wont_allow :create?
+    end
+
+    it 'returns false if the token lacks story permission' do
+      ProducerPolicy.new(n_s_member_token, producer).wont_allow :update?
+      ProducerPolicy.new(n_s_member_token, producer).wont_allow :create?
     end
   end
 end

--- a/test/policies/producer_policy_test.rb
+++ b/test/policies/producer_policy_test.rb
@@ -11,9 +11,9 @@ describe ProducerPolicy do
   let(:user) { build_stubbed(:user, id: producer_token.user_id) }
 
   describe '#update? and #create?' do
-    it 'returns true if user is the producer' do
-      ProducerPolicy.new(producer_token, producer).must_allow :update?
-      ProducerPolicy.new(producer_token, producer).must_allow :create?
+    it 'returns true if false is the producer' do
+      ProducerPolicy.new(producer_token, producer).wont_allow :update?
+      ProducerPolicy.new(producer_token, producer).wont_allow :create?
     end
 
     it 'returns true if user is associated with story' do

--- a/test/policies/purchase_policy_test.rb
+++ b/test/policies/purchase_policy_test.rb
@@ -3,8 +3,8 @@ require 'test_helper'
 describe PurchasePolicy do
   let(:purchase) { create(:purchase) }
   let(:account) { purchase.purchaser_account }
-  let(:admin_token) { StubToken.new(account.id, ['admin']) }
-  let(:member_token) { StubToken.new(account.id, ['member']) }
+  let(:admin_token) { StubToken.new(account.id, ['cms:purchase cms:account']) }
+  let(:member_token) { StubToken.new(account.id, ['cms:account']) }
 
   it 'allows admins to make purchases' do
     PurchasePolicy.new(admin_token, purchase).must_allow :create?

--- a/test/policies/series_attribute_policy_test.rb
+++ b/test/policies/series_attribute_policy_test.rb
@@ -4,8 +4,9 @@ describe SeriesAttributePolicy do
   describe '#update?' do
     let(:series) { build_stubbed(:series) }
     let(:template) { build_stubbed(:audio_version_template, series: series) }
-    let(:member_token) { StubToken.new(series.account_id, ['member']) }
-    let(:n_m_token) { StubToken.new(series.account_id + 1, ['no']) }
+    let(:member_token) { StubToken.new(series.account_id, ['cms:series']) }
+    let(:n_m_token) { StubToken.new(series.account_id + 1, ['cms:series']) }
+    let(:n_s_token) { StubToken.new(series.account_id, ['cms:account']) }
 
     it 'returns true if user is a member of series account' do
       SeriesAttributePolicy.new(member_token, template).must_allow :update?
@@ -20,6 +21,11 @@ describe SeriesAttributePolicy do
     it 'returns false if user is not a member of series account' do
       SeriesAttributePolicy.new(n_m_token, template).wont_allow :update?
       SeriesAttributePolicy.new(n_m_token, template).wont_allow :create?
+    end
+
+    it 'returns false if token lacks series permission for account' do
+      SeriesAttributePolicy.new(n_s_token, template).wont_allow :update?
+      SeriesAttributePolicy.new(n_s_token, template).wont_allow :create?
     end
   end
 end

--- a/test/policies/series_policy_test.rb
+++ b/test/policies/series_policy_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+describe SeriesPolicy do
+  describe '#update?' do
+    let(:series) { build_stubbed(:series) }
+    let(:member_token) { StubToken.new(series.account_id, ['cms:series']) }
+    let(:n_m_token) { StubToken.new(series.account_id + 1, ['cms:series']) }
+    let(:n_s_token) { StubToken.new(series.account_id, ['cms:account']) }
+
+    it 'returns true if user is a member of series account' do
+      SeriesPolicy.new(member_token, series).must_allow :update?
+      SeriesPolicy.new(member_token, series).must_allow :create?
+    end
+
+    it 'returns false if user is not present' do
+      SeriesPolicy.new(nil, series).wont_allow :update?
+      SeriesPolicy.new(nil, series).wont_allow :create?
+    end
+
+    it 'returns false if user is not a member of series account' do
+      SeriesPolicy.new(n_m_token, series).wont_allow :update?
+      SeriesPolicy.new(n_m_token, series).wont_allow :create?
+    end
+
+    it 'returns false if token lacks series permission for account' do
+      SeriesPolicy.new(n_s_token, series).wont_allow :update?
+      SeriesPolicy.new(n_s_token, series).wont_allow :create?
+    end
+  end
+end

--- a/test/policies/series_policy_test.rb
+++ b/test/policies/series_policy_test.rb
@@ -26,5 +26,12 @@ describe SeriesPolicy do
       SeriesPolicy.new(n_s_token, series).wont_allow :update?
       SeriesPolicy.new(n_s_token, series).wont_allow :create?
     end
+
+    it 'returns false if the account has been changed from one the token has no access to' do
+      other_series = create(:series, account_id: series.account_id + 1)
+
+      other_series.account_id = series.account_id
+      SeriesPolicy.new(member_token, other_series).wont_allow :update?
+    end
   end
 end

--- a/test/policies/story_attribute_policy_test.rb
+++ b/test/policies/story_attribute_policy_test.rb
@@ -29,9 +29,20 @@ describe StoryAttributePolicy do
     end
 
     describe 'with a draft token' do
-      it 'returns true if token has story-draft and story is a draft'
-      it 'returns false if token has story-draft but story is published'
-      it 'returns false if token lacks story-draft and story is a draft'
+      let (:draft_token) { StubToken.new(story.account_id, ['cms:story-draft']) }
+      it 'returns true if token has story-draft and story is a draft' do
+        story.update_attribute :published_at, nil
+
+        StoryAttributePolicy.new(draft_token, musical_work).must_allow :update?
+        StoryAttributePolicy.new(draft_token, musical_work).must_allow :create?
+      end
+
+      it 'returns false if token has story-draft but story is published' do
+        story.update_attribute :published_at, 10.days.ago
+
+        StoryAttributePolicy.new(draft_token, musical_work).wont_allow :update?
+        StoryAttributePolicy.new(draft_token, musical_work).wont_allow :create?
+      end
     end
   end
 end

--- a/test/policies/story_attribute_policy_test.rb
+++ b/test/policies/story_attribute_policy_test.rb
@@ -2,8 +2,9 @@ require 'test_helper'
 
 describe StoryAttributePolicy do
   describe '#update?' do
-    let(:member_token) { StubToken.new(story.account_id, ['member']) }
-    let(:n_m_token) { StubToken.new(story.account_id + 1, ['no']) }
+    let(:member_token) { StubToken.new(story.account_id, ['cms:story']) }
+    let(:n_m_token) { StubToken.new(story.account_id + 1, ['cms:story']) }
+    let(:n_s_token) { StubToken.new(story.account_id, ['cms:member']) }
     let(:story) { build(:story) }
     let(:musical_work) { build(:musical_work, story: story) }
 
@@ -20,6 +21,17 @@ describe StoryAttributePolicy do
     it 'returns false if user is not a member of story account' do
       StoryAttributePolicy.new(n_m_token, musical_work).wont_allow :update?
       StoryAttributePolicy.new(n_m_token, musical_work).wont_allow :create?
+    end
+
+    it 'returns false if token does not have story permission for referenced account' do
+      StoryAttributePolicy.new(n_s_token, musical_work).wont_allow :update?
+      StoryAttributePolicy.new(n_s_token, musical_work).wont_allow :create?
+    end
+
+    describe 'with a draft token' do
+      it 'returns true if token has story-draft and story is a draft'
+      it 'returns false if token has story-draft but story is published'
+      it 'returns false if token lacks story-draft and story is a draft'
     end
   end
 end

--- a/test/policies/story_policy_test.rb
+++ b/test/policies/story_policy_test.rb
@@ -13,9 +13,19 @@ describe StoryPolicy do
       policy.must_allow :create?
     end
 
-    it 'is allowed to #update?' do
-      story.published_at = 7.minutes.ago
-      policy.must_allow :update?
+    describe '#update?' do
+      it 'is allowed' do
+        story.published_at = 7.minutes.ago
+        policy.must_allow :update?
+      end
+
+      it 'is not allowed when account_id was not controlled' do
+        story.account_id = account.id + 1
+        story.save
+
+        story.account_id = account.id
+        policy.wont_allow :update?
+      end
     end
 
     it 'is allowed to #destroy?' do
@@ -69,6 +79,15 @@ describe StoryPolicy do
         story.published_at = 14.seconds.ago
         story.save
 
+        policy.wont_allow :update?
+      end
+
+      it 'is not allowed when account_id was not controlled' do
+        story.published_at = nil
+        story.account_id = account.id + 1
+        story.save
+
+        story.account_id = account.id
         policy.wont_allow :update?
       end
     end

--- a/test/policies/story_policy_test.rb
+++ b/test/policies/story_policy_test.rb
@@ -1,0 +1,110 @@
+require 'test_helper'
+
+describe StoryPolicy do
+  let(:token) { StubToken.new(account.id, ['cms:story']) }
+  let(:account) { build_stubbed(:account) }
+  let(:story) { build(:story, account: account) }
+  let(:policy) { StoryPolicy.new(token, story) }
+
+
+  describe 'with a full token' do
+    it 'is allowed to #create?' do
+      story.published_at = 13.days.ago
+      policy.must_allow :create?
+    end
+
+    it 'is allowed to #update?' do
+      story.published_at = 7.minutes.ago
+      policy.must_allow :update?
+    end
+
+    it 'is allowed to #destroy?' do
+      story.published_at = 12.seconds.from_now
+    end
+
+    it 'is allowed to #publish?' do
+      policy.must_allow :publish?
+    end
+
+    it 'is allowed to #unpublish?' do
+      policy.must_allow :unpublish?
+    end
+  end
+
+  describe 'with draft token' do
+
+    let(:token) { StubToken.new(account.id, ['cms:story-draft']) }
+
+    describe '#create?' do
+      it 'is allowed when story is a draft' do
+        story.published_at = nil
+
+        policy.must_allow :create?
+      end
+
+      it 'is not allowed when story is not a draft' do
+        story.published_at = 10.days.from_now
+
+        policy.wont_allow :create?
+      end
+    end
+
+    describe '#update?' do
+      it 'is allowed when story is a draft and was a draft' do
+        story.published_at = nil
+        story.save
+
+        policy.must_allow :update?
+      end
+
+      it 'is not allowed when story was not a draft, even if it is now' do
+        story.published_at = 14.seconds.ago
+        story.save
+
+        story.published_at = nil
+        policy.wont_allow :update?
+      end
+
+      it 'is not allowed if story is not a draft' do
+        story.published_at = 14.seconds.ago
+        story.save
+
+        policy.wont_allow :update?
+      end
+    end
+
+    describe '#destroy?' do
+      it 'is allowed when story is a draft and was a draft' do
+        story.published_at = nil
+        story.save
+
+        policy.must_allow :destroy?
+      end
+
+      it 'is not allowed if story is not a draft' do
+        story.published_at = 10.years.ago
+        story.save
+
+        policy.wont_allow :destroy?
+      end
+    end
+  
+    describe '#publish?' do
+      it 'is not allowed, even with draft story' do
+        story.published_at = nil
+        story.save
+
+        policy.wont_allow :publish?
+      end
+    end
+  
+    describe '#unpublish?' do
+      it 'is not allowed, even with draft story' do
+        story.published_at = nil
+        story.save
+
+        policy.wont_allow :unpublish?
+      end
+    end
+  end
+end

--- a/test/policies/story_policy_test.rb
+++ b/test/policies/story_policy_test.rb
@@ -6,7 +6,6 @@ describe StoryPolicy do
   let(:story) { build(:story, account: account) }
   let(:policy) { StoryPolicy.new(token, story) }
 
-
   describe 'with a full token' do
     it 'is allowed to #create?' do
       story.published_at = 13.days.ago
@@ -107,7 +106,7 @@ describe StoryPolicy do
         policy.wont_allow :destroy?
       end
     end
-  
+
     describe '#publish?' do
       it 'is not allowed, even with draft story' do
         story.published_at = nil
@@ -116,7 +115,7 @@ describe StoryPolicy do
         policy.wont_allow :publish?
       end
     end
-  
+
     describe '#unpublish?' do
       it 'is not allowed, even with draft story' do
         story.published_at = nil

--- a/test/policies/user_policy_test.rb
+++ b/test/policies/user_policy_test.rb
@@ -6,8 +6,8 @@ describe UserPolicy do
   let(:user) { build_stubbed(:user, id: user_token.user_id) }
 
   describe '#update?' do
-    it 'lets users update themselves' do
-      UserPolicy.new(user_token, user).must_allow :update?
+    it 'doesnt let users update themselves' do
+      UserPolicy.new(user_token, user).wont_allow :update?
     end
 
     it 'does not let users update each other' do

--- a/test/policies/user_policy_test.rb
+++ b/test/policies/user_policy_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 
 describe UserPolicy do
-  let(:user_token) { StubToken.new(123, ['member']) }
-  let(:other_token) { StubToken.new(123, ['member']) }
+  let(:user_token) { StubToken.new(123, ['cms:account']) }
+  let(:other_token) { StubToken.new(123, ['cms:account']) }
   let(:user) { build_stubbed(:user, id: user_token.user_id) }
 
   describe '#update?' do

--- a/test/policies/user_tag_policy_test.rb
+++ b/test/policies/user_tag_policy_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe UserTagPolicy do
   let(:user_tag) { create(:user_tag) }
   let(:account) { create(:account) }
-  let(:token) { StubToken.new(account.id, ['member']) }
+  let(:token) { StubToken.new(account.id, ['cms:account']) }
 
   it 'allows anyone to create a tag' do
     UserTagPolicy.new(token, UserTag.new(name: 'test-tag')).must_allow :create?

--- a/test/representers/api/authorization_representer_test.rb
+++ b/test/representers/api/authorization_representer_test.rb
@@ -4,7 +4,7 @@ describe Api::AuthorizationRepresenter do
 
   let(:user) { create(:user) }
   let(:account) { user.default_account }
-  let(:token) { StubToken.new(account.id, 'admin', user.id) }
+  let(:token) { StubToken.new(account.id, 'cms:read-private', user.id) }
   let(:authorization) { Authorization.new(token) }
   let(:representer) { Api::AuthorizationRepresenter.new(authorization) }
   let(:json) { JSON.parse(representer.to_json) }

--- a/test/representers/api/story_representer_test.rb
+++ b/test/representers/api/story_representer_test.rb
@@ -24,6 +24,15 @@ describe Api::StoryRepresenter do
       d_story.title.must_equal 'title'
       d_story.account_id.must_equal 8
     end
+
+    it 'can set the series' do
+      series = create(:series, account_id: 8)
+      story_hash = { title: 'title', set_series_uri: "api/v1/series/#{series.id}" }
+      d_representer = Api::StoryRepresenter.new(Story.new)
+      d_story = d_representer.from_json(story_hash.to_json)
+      d_story.title.must_equal 'title'
+      d_story.series_id.must_equal series.id
+    end
   end
 
   describe 'status flags' do

--- a/test/services/series_query_builder_test.rb
+++ b/test/services/series_query_builder_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe SeriesQueryBuilder do
 
   let(:account) { create(:account) }
-  let(:token) { StubToken.new(account.id, ['member'], 456) }
+  let(:token) { StubToken.new(account.id, ['cms:read-private'], 456) }
   let(:authorization) { Authorization.new(token) }
 
   FILTER_PARANOID = {bool: {

--- a/test/services/story_query_builder_test.rb
+++ b/test/services/story_query_builder_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe StoryQueryBuilder do
 
   let(:account) { create(:account) }
-  let(:token) { StubToken.new(account.id, ['member'], 456) }
+  let(:token) { StubToken.new(account.id, ['cms:read-private cms:story'], 456) }
   let(:authorization) { Authorization.new(token) }
 
   # sorry... ES filters can be a bit ugly

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -78,7 +78,9 @@ end
 Minitest::Expectations.infect_an_assertion :assert_operator, :must_allow, :reverse
 Minitest::Expectations.infect_an_assertion :refute_operator, :wont_allow, :reverse
 
+# rubocop:disable Style/MixinUsage
 include Announce::Testing
+# rubocop:enable Style/MixinUsage
 reset_announce
 
 class StubToken < PrxAuth::Rails::Token
@@ -88,10 +90,10 @@ class StubToken < PrxAuth::Rails::Token
     scopes = Array.wrap(scopes).map(&:to_s).join(' ')
     aur = { res.to_s => scopes }
     super(Rack::PrxAuth::TokenData.new({
-      "aur" => aur,
-      "scope" => scopes,
-      "sub" =>  explicit_user_id || @@fake_user_id += 1
-    }))
+                                         'aur' => aur,
+                                         'scope' => scopes,
+                                         'sub' =>  explicit_user_id || @@fake_user_id += 1
+                                       }))
   end
 end
 


### PR DESCRIPTION
Modify Policy classes to check for narrow scopes instead of (a) general membership or (b) role-level abilities. Tokens are distinct from profiles and may not include all of the permissions implied by a given role.