### PR TITLE
Add loudness and true peaks columns to schema

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -227,6 +227,9 @@ ActiveRecord::Schema.define(version: 20200304162904) do
     t.string   "upload_path",      limit: 255
     t.integer  "current_job_id",   limit: 4
     t.text     "status_message",   limit: 65535
+    t.decimal  "integrated_loudness",            precision: 15, scale: 10
+    t.decimal  "loudness_range",                 precision: 15, scale: 10
+    t.decimal  "true_peak",                      precision: 15, scale: 10
   end
 
   add_index "audio_files", ["account_id", "filename"], name: "index_audio_files_on_account_id_and_filename", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200304162904) do
+ActiveRecord::Schema.define(version: 20201102163043) do
 
   create_table "account_applications", force: :cascade do |t|
     t.integer  "account_id",            limit: 4


### PR DESCRIPTION
Blocked by https://github.com/PRX/exchange.prx.org/pull/540. **That migration must be run before this is merged**

Adds schema support in CMS for new loudness and true peaks columns in the DB.