### PR TITLE
Authorization endpoint N+1 fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'mysql2'
 # ActiveRecord model additions
 gem 'acts_as_list'
 gem 'event_attribute'
+gem 'left_joins'
 gem 'paranoia', ' ~> 2.0'
 
 # file uploads

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,6 +315,8 @@ GEM
       activerecord
       kaminari-core (= 1.2.1)
     kaminari-core (1.2.1)
+    left_joins (1.0.8)
+      activerecord (>= 3)
     listen (2.10.1)
       celluloid (~> 0.16.0)
       rb-fsevent (>= 0.9.3)
@@ -555,6 +557,7 @@ DEPENDENCIES
   hyperresource
   icalendar (~> 2.5.0)
   kaminari
+  left_joins
   loofah
   m (~> 1.5.0)
   minitest (~> 5.9.1)

--- a/app/controllers/api/series_controller.rb
+++ b/app/controllers/api/series_controller.rb
@@ -37,7 +37,7 @@ class Api::SeriesController < Api::BaseController
     super.tap do |series|
       series.account_id ||= account.id if account
       series.account_id ||= current_user.account_id
-      series.account_id ||= authorization.token_auth_accounts.first.try(:id)
+      series.account_id ||= authorization.token_auth_account_ids.first
     end
   end
 

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -3,6 +3,15 @@
 class Address < BaseModel
   belongs_to :addressable, -> { with_deleted }, polymorphic: true, touch: true
 
+  def account_id
+    if addressable_type == 'Account'
+      addressable_id
+    elsif addressable_type == 'User'
+      # warning: this will load things
+      addressable.individual_account.id
+    end
+  end
+
   def account
     if addressable.is_a?(Account)
       addressable

--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -25,7 +25,9 @@ class Authorization
   end
 
   def token_auth_accounts
-    @token_auth_accounts ||= Account.where(id: account_ids(:read_private))
+    @token_auth_accounts ||= Account.where(id: account_ids(:read_private)).
+                             joins(:address, :image, :opener).
+                             includes(:address, :image, :opener)
   end
 
   def token_auth_stories

--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -24,9 +24,13 @@ class Authorization
     token.resources(scope).map(&:to_i)
   end
 
+  def token_auth_account_ids
+    account_ids(:read_private)
+  end
+
   def token_auth_accounts
-    @token_auth_accounts ||= Account.where(id: account_ids(:read_private)).
-                             joins(:address, :image, :opener).
+    @token_auth_accounts ||= Account.where(id: token_auth_account_ids).
+                             left_joins(:address, :image, :opener).
                              includes(:address, :image, :opener)
   end
 

--- a/app/representers/api/address_representer.rb
+++ b/app/representers/api/address_representer.rb
@@ -11,6 +11,6 @@ class Api::AddressRepresenter < Api::BaseRepresenter
   property :country
 
   def self_url(address)
-    api_account_address_path(address.account) if address.account
+    api_account_address_path(address.account_id) if address.account_id
   end
 end

--- a/app/representers/api/auth/account_min_representer.rb
+++ b/app/representers/api/auth/account_min_representer.rb
@@ -5,8 +5,7 @@ class Api::Auth::AccountMinRepresenter < Api::Min::AccountRepresenter
   link :stories do
     {
       href: "#{api_authorization_account_stories_path(represented)}#{index_url_params}",
-      templated: true,
-      count: represented.stories.count
+      templated: true
     }
   end
   embed :stories,

--- a/app/representers/api/min/account_representer.rb
+++ b/app/representers/api/min/account_representer.rb
@@ -36,8 +36,7 @@ class Api::Min::AccountRepresenter < Api::BaseRepresenter
   link :stories do
     {
       href: "#{api_account_stories_path(represented)}#{index_url_params}",
-      templated: true,
-      count: represented.public_stories.count
+      templated: true
     }
   end
   embed :public_stories,

--- a/app/services/series_query_builder.rb
+++ b/app/services/series_query_builder.rb
@@ -26,7 +26,7 @@ class SeriesQueryBuilder < ESQueryBuilder
   def authz_filter
     searchdsl = self
     Filter.new do
-      terms account_id: searchdsl.authorization.token_auth_accounts.try(:ids), _name: :authz
+      terms account_id: searchdsl.authorization.token_auth_account_ids, _name: :authz
     end
   end
 

--- a/app/services/story_query_builder.rb
+++ b/app/services/story_query_builder.rb
@@ -95,7 +95,7 @@ class StoryQueryBuilder < ESQueryBuilder
   def authz_filter
     searchdsl = self
     Filter.new do
-      terms account_id: searchdsl.authorization.token_auth_accounts.try(:ids), _name: :authz
+      terms account_id: searchdsl.authorization.token_auth_account_ids, _name: :authz
     end
   end
 


### PR DESCRIPTION
The `/api/v1/authorization` loads real slow if you have many accounts.

Made a few improvements:
- [x] Joins/includes on account addresses/images/openers
  - I'm actually not sure why the auth+min account representer includes all this stuff, or if anything relies on that.  Maybe would be better to just remove those by-default embeds from the min representers?
- [x] Remove story counts from auth+min account representers
  - It's unlikely anything was really relying on these counts. 
  - Or maybe there's an easy way to eager-loading N+1 counts that i don't know about
- [x] The address representer had a self_url that reloaded the account