### PR TITLE
Change explicits back to true/false

### DIFF
--- a/app/models/concerns/import_utils.rb
+++ b/app/models/concerns/import_utils.rb
@@ -33,15 +33,17 @@ module ImportUtils
     clean_string(truncated)
   end
 
-  def explicit(str)
-    return nil if str.blank?
-    explicit = clean_string(str).downcase
-    if %w(true yes).include?(explicit)
-      explicit = 'explicit'
-    elsif %w(no false).include?(explicit)
-      explicit = 'clean'
+  # only 'true'/'false' now allowed
+  def explicit(str, default = nil)
+    explicit = clean_string(str).try(:downcase)
+
+    if %w(true yes explicit).include?(explicit)
+      'true'
+    elsif %w(false no clean).include?(explicit)
+      'false'
+    else
+      default
     end
-    explicit
   end
 
   def person(arg)

--- a/app/models/podcast_import.rb
+++ b/app/models/podcast_import.rb
@@ -310,7 +310,7 @@ class PodcastImport < BaseModel
 
     podcast_attributes[:summary] = clean_text(feed.itunes_summary)
     podcast_attributes[:link] = clean_string(feed.url)
-    podcast_attributes[:explicit] = explicit(feed.itunes_explicit)
+    podcast_attributes[:explicit] = explicit(feed.itunes_explicit, 'false')
     podcast_attributes[:new_feed_url] = clean_string(feed.itunes_new_feed_url)
     podcast_attributes[:enclosure_prefix] ||= enclosure_prefix(feed.entries.first)
     podcast_attributes[:feedburner_url] ||= feedburner_url(feed.feedburner_name)

--- a/test/models/episode_import_test.rb
+++ b/test/models/episode_import_test.rb
@@ -155,9 +155,9 @@ describe EpisodeImport do
     end
 
     it 'can interpret explicit values' do
-      %w(Yes TRUE Explicit).each { |x| episode_import.explicit(x).must_equal 'explicit' }
-      %w(NO False Clean).each { |x| episode_import.explicit(x).must_equal 'clean' }
-      %w(UnClean y N 1 0).each { |x| episode_import.explicit(x).must_equal x.downcase }
+      %w(Yes TRUE Explicit).each { |x| episode_import.explicit(x).must_equal 'true' }
+      %w(NO False Clean).each { |x| episode_import.explicit(x).must_equal 'false' }
+      %w(UnClean y N 1 0).each { |x| episode_import.explicit(x).must_equal nil }
     end
   end
 end

--- a/test/models/podcast_import_test.rb
+++ b/test/models/podcast_import_test.rb
@@ -195,9 +195,9 @@ describe PodcastImport do
     end
 
     it 'can interpret explicit values' do
-      %w(Yes TRUE Explicit).each { |x| importer.explicit(x).must_equal 'explicit' }
-      %w(NO False Clean).each { |x| importer.explicit(x).must_equal 'clean' }
-      %w(UnClean y N 1 0).each { |x| importer.explicit(x).must_equal x.downcase }
+      %w(Yes TRUE Explicit).each { |x| importer.explicit(x).must_equal 'true' }
+      %w(NO False Clean).each { |x| importer.explicit(x).must_equal 'false' }
+      %w(UnClean y N 1 0).each { |x| importer.explicit(x, 'false').must_equal 'false' }
     end
   end
 
@@ -362,7 +362,7 @@ end
 
 def stub_requests
   stub_request(:put, 'https://feeder.prx.org/api/v1/podcasts/51').
-    with(:body => "{\"copyright\":\"Copyright 2016 PRX\",\"language\":\"en-US\",\"updateFrequency\":\"1\",\"updatePeriod\":\"hourly\",\"summary\":\"Transistor is a podcast of scientific curiosities and current events, featuring guest hosts, scientists, and story-driven reporters. Presented by radio and podcast powerhouse PRX, with support from the Sloan Foundation.\",\"link\":\"https://transistor.prx.org\",\"explicit\":\"clean\",\"newFeedUrl\":\"http://feeds.prx.org/transistor_stem\",\"enclosurePrefix\":\"https://dts.podtrac.com/redirect.mp3/media.blubrry.com/transistor/\",\"feedburnerUrl\":\"http://feeds.feedburner.com/transistor_stem\",\"url\":\"http://feeds.feedburner.com/transistor_stem\",\"author\":{\"name\":\"PRX\",\"email\":null},\"managingEditor\":{\"name\":\"PRX\",\"email\":\"prxwpadmin@prx.org\"},\"owner\":{\"name\":\"PRX\",\"email\":\"prxwpadmin@prx.org\"},\"itunesCategories\":[{\"name\":\"Science\",\"subcategories\":[\"Natural Sciences\"]}],\"categories\":[],\"complete\":false,\"keywords\":[],\"serialOrder\":false,\"locked\":true}",
+    with(:body => "{\"copyright\":\"Copyright 2016 PRX\",\"language\":\"en-US\",\"updateFrequency\":\"1\",\"updatePeriod\":\"hourly\",\"summary\":\"Transistor is a podcast of scientific curiosities and current events, featuring guest hosts, scientists, and story-driven reporters. Presented by radio and podcast powerhouse PRX, with support from the Sloan Foundation.\",\"link\":\"https://transistor.prx.org\",\"explicit\":\"false\",\"newFeedUrl\":\"http://feeds.prx.org/transistor_stem\",\"enclosurePrefix\":\"https://dts.podtrac.com/redirect.mp3/media.blubrry.com/transistor/\",\"feedburnerUrl\":\"http://feeds.feedburner.com/transistor_stem\",\"url\":\"http://feeds.feedburner.com/transistor_stem\",\"author\":{\"name\":\"PRX\",\"email\":null},\"managingEditor\":{\"name\":\"PRX\",\"email\":\"prxwpadmin@prx.org\"},\"owner\":{\"name\":\"PRX\",\"email\":\"prxwpadmin@prx.org\"},\"itunesCategories\":[{\"name\":\"Science\",\"subcategories\":[\"Natural Sciences\"]}],\"categories\":[],\"complete\":false,\"keywords\":[],\"serialOrder\":false,\"locked\":true}",
          :headers => {'Accept'=>'application/json', 'Authorization'=>'Bearer thisisnotatoken', 'Content-Type'=>'application/json', 'Host'=>'feeder.prx.org', 'User-Agent'=>'HyperResource 0.9.4'}).
   to_return(:status => 200, :body => '', :headers => {})
 


### PR DESCRIPTION
To deploy with PRX/feeder.prx.org#377.

Set podcast.explicit to `'true'/'false'` on import.

Set episode.explicit to `'true'/'false'/nil` on import.