### PR TITLE
Indicate if user has Feeder UI access

### DIFF
--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -16,6 +16,17 @@ class Authorization
     default_account.id
   end
 
+  def feeder_ui_access
+    if (token.resources(:feeder, :read_private) - token_auth_account_ids).any?
+      host = ENV["FEEDER_HOST"]
+      if host.present?
+        host.starts_with?("http") ? host : "https://#{host}"
+      else
+        "https://feeder.prx.org"
+      end
+    end
+  end
+
   def default_account
     User.find(token.user_id).default_account
   end

--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -17,7 +17,8 @@ class Authorization
   end
 
   def feeder_ui_access
-    if (token.resources(:feeder, :read_private) - token.resources(:cms, :read_private)).any?
+    # if the user has no CMS scope, but _does_ have Feeder - they get the new UI
+    if token.resources(:cms, :read_private).empty? && token.resources(:feeder, :read_private).any?
       host = ENV['FEEDER_HOST']
       if host.present?
         host.starts_with?('http') ? host : "https://#{host}"

--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -17,12 +17,12 @@ class Authorization
   end
 
   def feeder_ui_access
-    if (token.resources(:feeder, :read_private) - token_auth_account_ids).any?
-      host = ENV["FEEDER_HOST"]
+    if (token.resources(:feeder, :read_private) - token.resources(:cms, :read_private)).any?
+      host = ENV['FEEDER_HOST']
       if host.present?
-        host.starts_with?("http") ? host : "https://#{host}"
+        host.starts_with?('http') ? host : "https://#{host}"
       else
-        "https://feeder.prx.org"
+        'https://feeder.prx.org'
       end
     end
   end

--- a/app/representers/api/authorization_representer.rb
+++ b/app/representers/api/authorization_representer.rb
@@ -2,6 +2,7 @@
 
 class Api::AuthorizationRepresenter < Api::BaseRepresenter
   property :id, writeable: false
+  property :feeder_ui_access, writeable: false
 
   link :default_account do
     {

--- a/env-example
+++ b/env-example
@@ -12,6 +12,7 @@ DB_ENV_MYSQL_USER=root
 DB_PORT_3306_TCP_ADDR=db
 DB_PORT_3306_TCP_PORT=3306
 ELASTICSEARCH_URL=http://elasticsearch:9200
+FEEDER_HOST=feeder.prx.docker
 ID_HOST=id.prx.docker
 MEMCACHE_SERVERS=
 META_HOST=meta.prx.org


### PR DESCRIPTION
Related to PRX/id.prx.org#363.

Return an attribute on the Authorization so indicate if this user has account-access to new Feeder UI.  Publish can then use this to display/redirect the user over to Feeder.

Could honestly be deployed at any time.  Just has to precede Publish changes.