### PR TITLE
Remove episode url default

### DIFF
--- a/app/models/story_distributions/episode_distribution.rb
+++ b/app/models/story_distributions/episode_distribution.rb
@@ -95,8 +95,7 @@ class StoryDistributions::EpisodeDistribution < StoryDistribution
       categories: story.tags,
       published_at: story.published_at,
       released_at: story.released_at,
-      updated_at: story.updated_at,
-      url: self.class.default_story_url(story)
+      updated_at: story.updated_at
     }
   end
 


### PR DESCRIPTION
part of [Feeder migration to remove beta links](https://github.com/PRX/feeder.prx.org/issues/825)